### PR TITLE
disable reqwest default feature

### DIFF
--- a/rmqtt/Cargo.toml
+++ b/rmqtt/Cargo.toml
@@ -60,7 +60,7 @@ bincode = "1.3"
 url = { version = "2.2", default-features = false }
 systemstat = "0.1"
 itertools = "0.10"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 rust-box = { version = "0.7.1", features = ["task-exec-queue", "task-exec-queue-rate", "std-ext", "dequemap"] }
 structopt = "0.3"
 tokio-tungstenite = "0.18"


### PR DESCRIPTION
reqwest default depends on openssl,
rmqtt based on rustls,
disable the default feature will refine the tree of dependencies