### PR TITLE
add x509 cross cert

### DIFF
--- a/rmqtt-bin/gen_x509.sh
+++ b/rmqtt-bin/gen_x509.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+
+# Trusted server configuration (DNS and IP at least one configuration)
+# Priority first DNS then IP.
+# Trusted domain name, none can be empty, multiple separated by English spaces.
+DNS="rmqtt.com localhost"
+# Trusted IP, none can be empty, separate multiples with English spaces.
+IP="192.168.1.1 127.0.0.1"
+
+# root ca
+ROOT_KEY_FILE="root.key"
+ROOT_CERT_FILE="root.pem"
+ROOT_CERT_DAYS=3650
+ROOT_RSA_KEY_BIT="rsa:4096"
+
+# server ca
+SERVER_KEY_FILE="rmqtt.key"
+SERVER_CERT_FILE="rmqtt.pem"
+SERVER_CERT_FULL_CHAIN_FILE="rmqtt.fullchain.pem"
+SERVER_CERT_DAYS=3650
+SERVER_REQ_FILE="rmqtt.req"
+SERVER_RSA_KEY_BIT="rsa:2048"
+
+# client ca
+CLIENT_KEY_FILE="client.key"
+CLIENT_CERT_FILE="client.pem"
+CLIENT_CERT_DAYS=3650
+CLIENT_REQ_FILE="client.req"
+CLIENT_RSA_KEY_BIT="rsa:2048"
+
+# temp config file
+ROOT_CA_CONFIG_FILE="ca.conf"
+ROOT_CA_EXT_FILE="extfile.conf"
+
+gen_ca_conf(){
+    if [ -f ${ROOT_CA_CONFIG_FILE} ]; then rm ${ROOT_CA_CONFIG_FILE}; fi
+    cat > ${ROOT_CA_CONFIG_FILE} <<EOF
+[req]
+distinguished_name = req_distinguished_name
+prompt = no
+
+[req_distinguished_name]
+CN = Server certificate
+OU = RMQTT
+O = RMQTT
+C = CN
+EOF
+}
+
+gen_ext_file_conf(){
+    if [ -f ${ROOT_CA_EXT_FILE} ]; then rm ${ROOT_CA_EXT_FILE}; fi
+    cat > ${ROOT_CA_EXT_FILE} <<EOF
+[ v3_server ]
+basicConstraints = critical, CA:false
+keyUsage = nonRepudiation, digitalSignature
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:authorityKeyIdentifier,issuer:always
+subjectAltName = @alt_names
+extendedKeyUsage = critical, serverAuth
+
+[ v3_client ]
+basicConstraints = critical, CA:false
+keyUsage = nonRepudiation, digitalSignature
+extendedKeyUsage = critical, clientAuth
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:authorityKeyIdentifier,issuer:always
+
+[ alt_names ]
+EOF
+    index=1
+    for d in $DNS;
+    do
+        echo "DNS.${index} = ${d}" >> ${ROOT_CA_EXT_FILE}
+        index=$((index + 1))
+    done
+
+    index=1
+    for d in $IP;
+    do
+        echo "IP.${index} = ${d}" >> ${ROOT_CA_EXT_FILE}
+        index=$((index + 1))
+    done
+}
+
+gen_root(){
+    if [ ! -f ${ROOT_CA_CONFIG_FILE} ];
+    then
+        echo "${ROOT_CA_CONFIG_FILE} file not found, please use 'gen.sh conf' to generate";
+        exit 1;
+    fi
+
+    openssl req -nodes \
+        -x509 \
+        -days ${ROOT_CERT_DAYS} \
+        -newkey ${ROOT_RSA_KEY_BIT} \
+        -keyout ${ROOT_KEY_FILE} \
+        -out ${ROOT_CERT_FILE} \
+        -sha256 \
+        -batch \
+        -config ${ROOT_CA_CONFIG_FILE}
+
+    sed -i 's/BEGIN PRIVATE KEY/BEGIN RSA PRIVATE KEY/' ${ROOT_KEY_FILE}
+    sed -i 's/END PRIVATE KEY/END RSA PRIVATE KEY/' ${ROOT_KEY_FILE}
+}
+
+gen_server(){
+    if [ ! -f ${ROOT_CA_CONFIG_FILE} ];
+    then
+        echo "${ROOT_CA_CONFIG_FILE} file not found, please use 'gen.sh conf' to generate";
+        exit 1;
+    fi
+
+    if [ ! -f ${ROOT_CA_EXT_FILE} ];
+    then
+        echo "${ROOT_CA_EXT_FILE} file not found, please use 'gen.sh conf' to generate";
+        exit 1;
+    fi
+
+    if [ ! -f ${ROOT_CERT_FILE} ];
+    then
+        echo "${ROOT_CERT_FILE} file not found, please use 'gen.sh root' to generate";
+        exit 1;
+    fi
+
+    if [ ! -f ${ROOT_KEY_FILE} ];
+    then
+        echo "${ROOT_KEY_FILE} file not found, please use 'gen.sh root' to generate";
+        exit 1;
+    fi
+
+    openssl req -nodes \
+        -newkey ${SERVER_RSA_KEY_BIT} \
+        -keyout ${SERVER_KEY_FILE} \
+        -out ${SERVER_REQ_FILE} \
+        -sha256 \
+        -batch \
+        -config ${ROOT_CA_CONFIG_FILE}
+
+    openssl x509 -req \
+        -in ${SERVER_REQ_FILE} \
+        -out ${SERVER_CERT_FILE} \
+        -CA ${ROOT_CERT_FILE} \
+        -CAkey ${ROOT_KEY_FILE} \
+        -sha256 \
+        -days ${SERVER_CERT_DAYS} \
+        -set_serial 456 \
+        -extensions v3_server -extfile ${ROOT_CA_EXT_FILE}
+
+    sed -i 's/BEGIN PRIVATE KEY/BEGIN RSA PRIVATE KEY/' ${SERVER_KEY_FILE}
+    sed -i 's/END PRIVATE KEY/END RSA PRIVATE KEY/' ${SERVER_KEY_FILE}
+
+    # fullchain
+    cat ${SERVER_CERT_FILE} ${ROOT_CERT_FILE} > ${SERVER_CERT_FULL_CHAIN_FILE}
+
+    openssl verify -verbose -CAfile ${ROOT_CERT_FILE} ${SERVER_CERT_FILE}
+    openssl verify -verbose -CAfile ${ROOT_CERT_FILE} ${SERVER_CERT_FULL_CHAIN_FILE}
+}
+
+gen_client(){
+    if [ ! -f ${ROOT_CA_CONFIG_FILE} ];
+    then
+        echo "${ROOT_CA_CONFIG_FILE} file not found, please use 'gen.sh conf' to generate";
+        exit 1;
+    fi
+
+    if [ ! -f ${ROOT_CA_EXT_FILE} ];
+    then
+        echo "${ROOT_CA_EXT_FILE} file not found, please use 'gen.sh conf' to generate";
+        exit 1;
+    fi
+
+    if [ ! -f ${ROOT_CERT_FILE} ];
+    then
+        echo "${ROOT_CERT_FILE} file not found, please use 'gen.sh root' to generate";
+        exit 1;
+    fi
+
+    if [ ! -f ${ROOT_KEY_FILE} ];
+    then
+        echo "${ROOT_KEY_FILE} file not found, please use 'gen.sh root' to generate";
+        exit 1;
+    fi
+
+    openssl req -nodes \
+        -newkey ${CLIENT_RSA_KEY_BIT} \
+        -keyout ${CLIENT_KEY_FILE} \
+        -out ${CLIENT_REQ_FILE} \
+        -sha256 \
+        -batch \
+        -config ${ROOT_CA_CONFIG_FILE}
+
+    openssl x509 -req \
+        -in ${CLIENT_REQ_FILE} \
+        -out ${CLIENT_CERT_FILE} \
+        -CA ${ROOT_CERT_FILE} \
+        -CAkey ${ROOT_KEY_FILE} \
+        -sha256 \
+        -days ${CLIENT_CERT_DAYS} \
+        -set_serial 789 \
+        -extensions v3_client -extfile ${ROOT_CA_EXT_FILE}
+
+    sed -i 's/BEGIN PRIVATE KEY/BEGIN RSA PRIVATE KEY/' ${CLIENT_KEY_FILE}
+    sed -i 's/END PRIVATE KEY/END RSA PRIVATE KEY/' ${CLIENT_KEY_FILE}
+
+    openssl verify -verbose -CAfile ${ROOT_CERT_FILE} ${CLIENT_CERT_FILE}
+}
+
+case $1 in
+    conf)
+        echo "generate configuration file..."
+        gen_ca_conf
+        gen_ext_file_conf
+        echo "generate configuration file success"
+        ;;
+    root)
+        echo "generate root cert file..."
+        gen_root
+        echo "generate root cert file success"
+        ;;
+    client)
+        echo "generate client cert file..."
+        gen_client
+        echo "generate client cert file success"
+        ;;
+    server)
+        echo "generate server cert file..."
+        gen_server
+        echo "generate server cert file success"
+        ;;
+    all)
+        echo "generate all..."
+        gen_ca_conf
+        gen_ext_file_conf
+        gen_root
+        gen_client
+        gen_server
+        echo "generate all success"
+        ;;
+    *)
+        echo "Usage gen.sh {conf|root|client|server}" >&2
+        exit 1
+        ;;
+esac

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -153,6 +153,9 @@ listener.tcp.internal.max_topic_aliases = 0
 ##--------------------------------------------------------------------
 ## MQTT/TLS - External TLS Listener for MQTT Protocol
 listener.tls.external.addr = "0.0.0.0:8883"
+#listener.tls.external.cross_certificate = true
+#listener.tls.external.cert = "./rmqtt-bin/rmqtt.fullchain.pem"
+listener.tls.external.cross_certificate = false
 listener.tls.external.cert = "./rmqtt-bin/rmqtt.pem"
 listener.tls.external.key = "./rmqtt-bin/rmqtt.key"
 
@@ -163,5 +166,8 @@ listener.ws.external.addr = "0.0.0.0:8080"
 ##--------------------------------------------------------------------
 ## MQTT/TLS-WebSocket - External TLS-WebSocket Listener for MQTT Protocol
 listener.wss.external.addr = "0.0.0.0:8443"
+#listener.wss.external.cross_certificate = true
+#listener.wss.external.cert = "./rmqtt-bin/rmqtt.fullchain.pem"
+listener.wss.external.cross_certificate = false
 listener.wss.external.cert = "./rmqtt-bin/rmqtt.pem"
 listener.wss.external.key = "./rmqtt-bin/rmqtt.key"

--- a/rmqtt/src/settings/listener.rs
+++ b/rmqtt/src/settings/listener.rs
@@ -223,6 +223,8 @@ pub struct ListenerInner {
     #[serde(default)]
     pub max_topic_aliases: u16,
 
+    #[serde(default = "ListenerInner::cross_certificate_default")]
+    pub cross_certificate: bool,
     pub cert: Option<String>,
     pub key: Option<String>,
 }
@@ -259,6 +261,7 @@ impl Default for ListenerInner {
             max_subscriptions: ListenerInner::max_subscriptions_default(),
             shared_subscription: ListenerInner::shared_subscription_default(),
             max_topic_aliases: 0,
+            cross_certificate: ListenerInner::cross_certificate_default(),
             cert: None,
             key: None,
         }
@@ -423,5 +426,9 @@ impl ListenerInner {
             _ => return Err(de::Error::custom("QoS configuration error, only values (0,1,2) are supported")),
         };
         Ok(qos)
+    }
+    #[inline]
+    fn cross_certificate_default() -> bool {
+        false
     }
 }


### PR DESCRIPTION
* 在tls配置cross_cert 为true的时候支持x509证书双向认证
* gen_x509.sh脚本可以用于生成示例证书
使用脚本前需要配置脚本内的DNS和IP参数，授信客户端连接Broker的服务域名或IP。
