### PR TITLE
Remove the `retain_available` configuration option. The retain messag…

### DIFF
--- a/docs/en_US/bridge-ingress-kafka.md
+++ b/docs/en_US/bridge-ingress-kafka.md
@@ -65,8 +65,6 @@ servers = "127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094"
 # Prefix for the client ID.
 client_id_prefix = "kafka_001"
 
-# Support retain messages, values: true/false, default: false
-retain_available = false
 # Message expiry interval, 0 means no expiry
 expiry_interval = "5m"
 

--- a/docs/en_US/bridge-ingress-mqtt.md
+++ b/docs/en_US/bridge-ingress-mqtt.md
@@ -97,8 +97,6 @@ connect_timeout = "20s"
 keepalive = "60s"
 # Auto-reconnect interval
 reconnect_interval = "5s"
-# Support retain messages, values: true/false, default: false
-retain_available = false
 # Message expiry interval, 0 means no expiry
 expiry_interval = "5m"
 # MQTT protocol version, values: v4, v5, corresponding to MQTT 3.1.1, 5.0

--- a/docs/en_US/bridge-ingress-pulsar.md
+++ b/docs/en_US/bridge-ingress-pulsar.md
@@ -100,12 +100,6 @@ consumer_name_prefix = "consumer_1"
 #auth.name = "oauth2"
 #auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
 
-## Whether to support retain message, true/false, default value: false
-##
-## Value: true | false
-## Default: false
-retain_available = false
-
 ## Message expiration time, 0 means no expiration
 ##
 ## Value: Duration

--- a/docs/en_US/http-api.md
+++ b/docs/en_US/http-api.md
@@ -40,8 +40,6 @@ http_request_log = false
 ## If set, will check request header Authorization value == Bearer $http_bearer_token, default value is undefined
 #http_bearer_token = bearer_token
 
-##Whether support retain message, true/false, default value: true
-message_retain_available = true
 ##Message expiration time, 0 means no expiration
 message_expiry_interval = "5m"
 ```

--- a/docs/en_US/sys-topic.md
+++ b/docs/en_US/sys-topic.md
@@ -34,8 +34,6 @@ publish_qos = 1
 #$SYS system message publish period
 publish_interval = "1m"
 
-##Whether support retain message, true/false, default value: false
-message_retain_available = false
 ##Message expiration time, 0 means no expiration
 message_expiry_interval = "5m"
 ```

--- a/docs/zh_CN/bridge-ingress-kafka.md
+++ b/docs/zh_CN/bridge-ingress-kafka.md
@@ -65,8 +65,6 @@ servers = "127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094"
 #客户端ID前缀
 client_id_prefix = "kafka_001"
 
-#是否支持保持消息, 值：true/false, 默认: false
-retain_available = false
 #消息过期时间, 0 表示不过期
 expiry_interval = "5m"
 

--- a/docs/zh_CN/bridge-ingress-mqtt.md
+++ b/docs/zh_CN/bridge-ingress-mqtt.md
@@ -90,8 +90,6 @@ connect_timeout = "20s"
 keepalive = "60s"
 #自动重连间隔
 reconnect_interval = "5s"
-#是否支持保持消息, 值：true/false, 默认: false
-retain_available = false
 #消息过期时间, 0 表示不过期
 expiry_interval = "5m"
 #使用的MQTT协议版本号，有：v4,v5, 分别对应MQTT 3.1.1, 5.0

--- a/docs/zh_CN/bridge-ingress-pulsar.md
+++ b/docs/zh_CN/bridge-ingress-pulsar.md
@@ -100,12 +100,6 @@ consumer_name_prefix = "consumer_1"
 #auth.name = "oauth2"
 #auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
 
-## Whether to support retain message, true/false, default value: false
-##
-## Value: true | false
-## Default: false
-retain_available = false
-
 ## Message expiration time, 0 means no expiration
 ##
 ## Value: Duration

--- a/docs/zh_CN/http-api.md
+++ b/docs/zh_CN/http-api.md
@@ -38,8 +38,6 @@ http_request_log = false
 ## If set, will check request header Authorization value == Bearer $http_bearer_token, default value is undefined
 #http_bearer_token = bearer_token
 
-##Whether support retain message, true/false, default value: true
-message_retain_available = true
 ##Message expiration time, 0 means no expiration
 message_expiry_interval = "5m"
 ```

--- a/docs/zh_CN/sys-topic.md
+++ b/docs/zh_CN/sys-topic.md
@@ -32,8 +32,6 @@ publish_qos = 1
 #$SYS system message publish period
 publish_interval = "1m"
 
-##Whether support retain message, true/false, default value: false
-message_retain_available = false
 ##Message expiration time, 0 means no expiration
 message_expiry_interval = "5m"
 ```

--- a/examples/cluster-raft-3/1/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,10 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
-## Whether to support storage messages, true/false, default value: false
-storage_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/examples/cluster-raft-3/1/plugins/rmqtt-sys-topic.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/examples/cluster-raft-3/2/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,10 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
-## Whether to support storage messages, true/false, default value: false
-storage_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/examples/cluster-raft-3/2/plugins/rmqtt-sys-topic.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/examples/cluster-raft-3/3/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,10 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
-## Whether to support storage messages, true/false, default value: false
-storage_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/examples/cluster-raft-3/3/plugins/rmqtt-sys-topic.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/examples/cluster-raft-5/1/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,10 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
-## Whether to support storage messages, true/false, default value: false
-storage_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/examples/cluster-raft-5/1/plugins/rmqtt-sys-topic.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/examples/cluster-raft-5/2/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,10 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
-## Whether to support storage messages, true/false, default value: false
-storage_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/examples/cluster-raft-5/2/plugins/rmqtt-sys-topic.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/examples/cluster-raft-5/3/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,10 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
-## Whether to support storage messages, true/false, default value: false
-storage_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/examples/cluster-raft-5/3/plugins/rmqtt-sys-topic.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/examples/cluster-raft-5/4/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,10 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
-## Whether to support storage messages, true/false, default value: false
-storage_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/examples/cluster-raft-5/4/plugins/rmqtt-sys-topic.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/examples/cluster-raft-5/5/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,10 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
-## Whether to support storage messages, true/false, default value: false
-storage_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/examples/cluster-raft-5/5/plugins/rmqtt-sys-topic.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/rmqtt-plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-kafka.toml
@@ -16,8 +16,6 @@ servers = "127.0.0.1:9092"
 # client.id
 client_id_prefix = "kafka_001"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/rmqtt-plugins/rmqtt-bridge-ingress-kafka/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-kafka/src/bridge.rs
@@ -26,10 +26,9 @@ use rmqtt::{
 
 use crate::config::{Bridge, Entry, PluginConfig, MESSAGE_KEY, PARTITION_UNASSIGNED};
 
-type RetainAvailable = bool;
 type ExpiryInterval = Duration;
 
-pub type MessageType = (From, Publish, RetainAvailable, ExpiryInterval);
+pub type MessageType = (From, Publish, ExpiryInterval);
 pub type OnMessageEvent = Arc<Event<MessageType, ()>>;
 
 #[derive(Debug)]
@@ -346,7 +345,7 @@ impl Consumer {
             create_time: timestamp_millis(),
         };
 
-        on_message.fire((from, p, cfg.retain_available, cfg.expiry_interval));
+        on_message.fire((from, p, cfg.expiry_interval));
     }
 }
 
@@ -396,9 +395,9 @@ impl BridgeManager {
 
     fn on_message(&self) -> OnMessageEvent {
         Arc::new(
-            Event::listen(|(f, p, retain_available, expiry_interval): MessageType, _next| {
+            Event::listen(|(f, p, expiry_interval): MessageType, _next| {
                 tokio::spawn(async move {
-                    send_publish(f, p, retain_available, expiry_interval).await;
+                    send_publish(f, p, expiry_interval).await;
                 });
             })
             .finish(),
@@ -427,7 +426,7 @@ impl BridgeManager {
     }
 }
 
-async fn send_publish(from: From, msg: Publish, retain_available: bool, expiry_interval: Duration) {
+async fn send_publish(from: From, msg: Publish, expiry_interval: Duration) {
     log::debug!("from {:?}, message: {:?}", from, msg);
 
     let expiry_interval = msg
@@ -447,9 +446,7 @@ async fn send_publish(from: From, msg: Publish, retain_available: bool, expiry_i
 
     let storage_available = Runtime::instance().extends.message_mgr().await.enable();
 
-    if let Err(e) =
-        SessionState::forwards(from, msg, retain_available, storage_available, Some(expiry_interval)).await
-    {
+    if let Err(e) = SessionState::forwards(from, msg, storage_available, Some(expiry_interval)).await {
         log::warn!("{:?}", e);
     }
 }

--- a/rmqtt-plugins/rmqtt-bridge-ingress-kafka/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-kafka/src/config.rs
@@ -34,19 +34,11 @@ pub struct Bridge {
     #[serde(default)]
     pub entries: Vec<Entry>,
 
-    #[serde(default = "Bridge::retain_available_default")]
-    pub retain_available: bool,
-
     #[serde(default = "Bridge::expiry_interval_default", deserialize_with = "deserialize_duration")]
     pub expiry_interval: Duration,
 }
 
 impl Bridge {
-    #[inline]
-    fn retain_available_default() -> bool {
-        false
-    }
-
     #[inline]
     fn expiry_interval_default() -> Duration {
         Duration::from_secs(300)

--- a/rmqtt-plugins/rmqtt-bridge-ingress-mqtt.toml
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-mqtt.toml
@@ -27,8 +27,6 @@ keepalive = "60s"
 # Automatic reconnection interval
 reconnect_interval = "5s"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 
@@ -83,8 +81,6 @@ keepalive = "60s"
 # Automatic reconnection interval
 reconnect_interval = "5s"
 
-## Whether to support retain message, true/false, default value: false
-retain_available = false
 ## Message expiration time, 0 means no expiration
 expiry_interval = "5m"
 

--- a/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/bridge.rs
@@ -260,10 +260,7 @@ async fn send_publish(
 
     let storage_available = Runtime::instance().extends.message_mgr().await.enable();
 
-    if let Err(e) =
-        SessionState::forwards(from, msg, cfg.retain_available, storage_available, Some(expiry_interval))
-            .await
-    {
+    if let Err(e) = SessionState::forwards(from, msg, storage_available, Some(expiry_interval)).await {
         log::warn!("{:?}", e);
     }
 }

--- a/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/config.rs
@@ -53,8 +53,6 @@ pub struct Bridge {
     #[serde(default = "Bridge::reconnect_interval_default", deserialize_with = "deserialize_duration")]
     pub reconnect_interval: Duration,
 
-    #[serde(default = "Bridge::retain_available_default")]
-    pub retain_available: bool,
     #[serde(default = "Bridge::expiry_interval_default", deserialize_with = "deserialize_duration")]
     pub expiry_interval: Duration,
 
@@ -88,10 +86,6 @@ impl Bridge {
 
     fn mqtt_ver_default() -> Protocol {
         Protocol::MQTT(MQTT_LEVEL_311)
-    }
-
-    fn retain_available_default() -> bool {
-        false
     }
 
     fn expiry_interval_default() -> Duration {

--- a/rmqtt-plugins/rmqtt-bridge-ingress-pulsar.toml
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-pulsar.toml
@@ -57,12 +57,6 @@ consumer_name_prefix = "consumer_1"
 #auth.name = "oauth2"
 #auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
 
-## Whether to support retain message, true/false, default value: false
-##
-## Value: true | false
-## Default: false
-retain_available = false
-
 ## Message expiration time, 0 means no expiration
 ##
 ## Value: Duration

--- a/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/config.rs
@@ -65,9 +65,6 @@ pub struct Bridge {
     #[serde(default)]
     pub entries: Vec<Entry>,
 
-    #[serde(default = "Bridge::retain_available_default")]
-    pub retain_available: bool,
-
     #[serde(default = "Bridge::expiry_interval_default", deserialize_with = "deserialize_duration")]
     pub expiry_interval: Duration,
 }
@@ -75,10 +72,6 @@ pub struct Bridge {
 impl Bridge {
     fn tls_hostname_verification_enabled_default() -> bool {
         true
-    }
-
-    fn retain_available_default() -> bool {
-        false
     }
 
     fn expiry_interval_default() -> Duration {

--- a/rmqtt-plugins/rmqtt-http-api.toml
+++ b/rmqtt-plugins/rmqtt-http-api.toml
@@ -13,8 +13,6 @@ http_laddr = "0.0.0.0:6060"
 ## Indicates whether to print HTTP request logs
 http_request_log = false
 
-##Whether support retain message, true/false, default value: false
-message_retain_available = false
 ##Message expiration time, 0 means no expiration
 message_expiry_interval = "5m"
 

--- a/rmqtt-plugins/rmqtt-http-api/src/config.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/config.rs
@@ -39,9 +39,6 @@ pub struct PluginConfig {
     #[serde(default = "PluginConfig::http_request_log_default")]
     pub http_request_log: bool,
 
-    #[serde(default = "PluginConfig::message_retain_available_default")]
-    pub message_retain_available: bool,
-
     #[serde(
         default = "PluginConfig::message_expiry_interval_default",
         deserialize_with = "deserialize_duration"
@@ -90,11 +87,6 @@ impl PluginConfig {
 
     #[inline]
     fn http_request_log_default() -> bool {
-        false
-    }
-
-    #[inline]
-    fn message_retain_available_default() -> bool {
         false
     }
 

--- a/rmqtt-plugins/rmqtt-retainer/src/ram.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/ram.rs
@@ -37,6 +37,11 @@ impl RamRetainer {
 
 #[async_trait]
 impl RetainStorage for &'static RamRetainer {
+    #[inline]
+    fn enable(&self) -> bool {
+        true
+    }
+
     ///topic - concrete topic
     async fn set(&self, topic: &TopicName, retain: Retain, expiry_interval: Option<Duration>) -> Result<()> {
         if !self.retain_enable.load(Ordering::SeqCst) {

--- a/rmqtt-plugins/rmqtt-retainer/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/storage.rs
@@ -373,6 +373,11 @@ impl RetainerInner {
 
 #[async_trait]
 impl RetainStorage for &'static Retainer {
+    #[inline]
+    fn enable(&self) -> bool {
+        true
+    }
+
     ///topic - concrete topic
     async fn set(&self, topic: &TopicName, retain: Retain, expiry_interval: Option<Duration>) -> Result<()> {
         if !self.retain_enable.load(Ordering::SeqCst) {

--- a/rmqtt-plugins/rmqtt-sys-topic.toml
+++ b/rmqtt-plugins/rmqtt-sys-topic.toml
@@ -8,7 +8,5 @@ publish_qos = 1
 ##$SYS system message publish period
 publish_interval = "1m"
 
-##Whether support retain message, true/false, default value: false
-message_retain_available = false
 ##Message expiration time, 0 means no expiration
 message_expiry_interval = "5m"

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -162,8 +162,6 @@ listener.tcp.external.max_qos_allowed = 2
 #The maximum level at which clients are allowed to subscribe to topics.
 #0 means unlimited. default value: 0
 listener.tcp.external.max_topic_levels = 0
-#Whether support retain message, true/false, default value: false
-listener.tcp.external.retain_available = false
 #Session timeout, default value: 2 hours
 listener.tcp.external.session_expiry_interval = "2h"
 #QoS 1/2 message retry interval, 0 means no resend
@@ -203,7 +201,6 @@ listener.tcp.internal.mqueue_rate_limit = "5000,1s"
 listener.tcp.internal.max_clientid_len = 65535
 listener.tcp.internal.max_qos_allowed = 2
 listener.tcp.internal.max_topic_levels = 0
-listener.tcp.internal.retain_available = false
 listener.tcp.internal.session_expiry_interval = "2h"
 listener.tcp.internal.message_retry_interval = "30s"
 listener.tcp.internal.message_expiry_interval = "5m"

--- a/rmqtt/src/broker/default.rs
+++ b/rmqtt/src/broker/default.rs
@@ -2129,7 +2129,6 @@ impl DefaultDelayedSender {
         if let Err(e) = SessionState::forwards(
             dp.from,
             dp.publish,
-            dp.retain_available,
             dp.message_storage_available,
             dp.message_expiry_interval,
         )
@@ -2166,19 +2165,12 @@ impl DelayedSender for &'static DefaultDelayedSender {
         &self,
         from: From,
         publish: Publish,
-        retain_available: bool,
         message_storage_available: bool,
         message_expiry_interval: Option<Duration>,
     ) -> Result<Option<(From, Publish)>> {
         let mut msgs = self.msgs.write().await;
         if msgs.len() < Runtime::instance().settings.mqtt.delayed_publish_max {
-            msgs.push(DelayedPublish::new(
-                from,
-                publish,
-                retain_available,
-                message_storage_available,
-                message_expiry_interval,
-            ));
+            msgs.push(DelayedPublish::new(from, publish, message_storage_available, message_expiry_interval));
             Runtime::instance().stats.delayed_publishs.max_max(msgs.len() as isize);
             Ok(None)
         } else {

--- a/rmqtt/src/broker/mod.rs
+++ b/rmqtt/src/broker/mod.rs
@@ -283,8 +283,8 @@ pub trait SharedSubscription: Sync + Send {
 pub trait RetainStorage: Sync + Send {
     ///Whether retain is supported
     #[inline]
-    fn is_supported(&self, listen_cfg: &Listener) -> bool {
-        listen_cfg.retain_available
+    fn enable(&self) -> bool {
+        false
     }
 
     ///topic - concrete topic
@@ -383,7 +383,6 @@ pub trait DelayedSender: Sync + Send {
         &self,
         from: From,
         publish: Publish,
-        retain_available: bool,
         message_storage_available: bool,
         message_expiry_interval: Option<Duration>,
     ) -> Result<Option<(From, Publish)>>;

--- a/rmqtt/src/broker/types.rs
+++ b/rmqtt/src/broker/types.rs
@@ -2624,7 +2624,6 @@ pub struct DelayedPublish {
     pub expired_time: TimestampMillis,
     pub from: From,
     pub publish: Publish,
-    pub retain_available: bool,
     pub message_storage_available: bool,
     pub message_expiry_interval: Option<Duration>,
 }
@@ -2634,7 +2633,6 @@ impl DelayedPublish {
     pub fn new(
         from: From,
         publish: Publish,
-        retain_available: bool,
         message_storage_available: bool,
         message_expiry_interval: Option<Duration>,
     ) -> Self {
@@ -2642,14 +2640,7 @@ impl DelayedPublish {
             .delay_interval
             .map(|di| timestamp_millis() + (di as TimestampMillis * 1000))
             .unwrap_or_else(timestamp_millis);
-        Self {
-            expired_time,
-            from,
-            publish,
-            retain_available,
-            message_storage_available,
-            message_expiry_interval,
-        }
+        Self { expired_time, from, publish, message_storage_available, message_expiry_interval }
     }
 
     #[inline]

--- a/rmqtt/src/broker/v5.rs
+++ b/rmqtt/src/broker/v5.rs
@@ -324,7 +324,7 @@ pub async fn _handshake<Io: 'static>(
     } else {
         Some(state.listen_cfg().max_qos_allowed)
     };
-    let retain_available = Runtime::instance().extends.retain().await.is_supported(state.listen_cfg());
+    let retain_available = Runtime::instance().extends.retain().await.enable();
     let max_server_packet_size = state.listen_cfg().max_packet_size.as_u32();
     let shared_subscription_available =
         Runtime::instance().extends.shared_subscription().await.is_supported(state.listen_cfg());

--- a/rmqtt/src/settings/listener.rs
+++ b/rmqtt/src/settings/listener.rs
@@ -194,9 +194,6 @@ pub struct ListenerInner {
     #[serde(default = "ListenerInner::max_topic_levels_default")]
     pub max_topic_levels: usize,
 
-    #[serde(default = "ListenerInner::retain_available_default")]
-    pub retain_available: bool,
-
     #[serde(
         default = "ListenerInner::session_expiry_interval_default",
         deserialize_with = "deserialize_duration"
@@ -260,7 +257,6 @@ impl Default for ListenerInner {
             max_clientid_len: ListenerInner::max_clientid_len_default(),
             max_qos_allowed: ListenerInner::max_qos_allowed_default(),
             max_topic_levels: ListenerInner::max_topic_levels_default(),
-            retain_available: ListenerInner::retain_available_default(),
             session_expiry_interval: ListenerInner::session_expiry_interval_default(),
             message_retry_interval: ListenerInner::message_retry_interval_default(),
             message_expiry_interval: ListenerInner::message_expiry_interval_default(),
@@ -363,10 +359,6 @@ impl ListenerInner {
     #[inline]
     fn max_topic_levels_default() -> usize {
         0
-    }
-    #[inline]
-    fn retain_available_default() -> bool {
-        false
     }
     #[inline]
     fn session_expiry_interval_default() -> Duration {


### PR DESCRIPTION
…e feature will now be enabled by default when the "rmqtt-retainer" plugin is activated.