### PR TITLE
Fix the issue where setting the configuration option `message_expiry_…

### DIFF
--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -166,7 +166,7 @@ listener.tcp.external.max_topic_levels = 0
 listener.tcp.external.session_expiry_interval = "2h"
 #QoS 1/2 message retry interval, 0 means no resend
 listener.tcp.external.message_retry_interval = "20s"
-#Message expiration time, 0 means no expiration
+#Message expiration time, 0 means no expiration, default value: 5 minutes
 listener.tcp.external.message_expiry_interval = "5m"
 #The maximum number of topics that a single client is allowed to subscribe to
 #0 means unlimited, default value: 0

--- a/rmqtt/src/settings/listener.rs
+++ b/rmqtt/src/settings/listener.rs
@@ -208,7 +208,7 @@ pub struct ListenerInner {
 
     #[serde(
         default = "ListenerInner::message_expiry_interval_default",
-        deserialize_with = "deserialize_duration"
+        deserialize_with = "ListenerInner::deserialize_message_expiry_interval"
     )]
     pub message_expiry_interval: Duration,
 
@@ -426,6 +426,20 @@ impl ListenerInner {
         };
         Ok(qos)
     }
+
+    #[inline]
+    fn deserialize_message_expiry_interval<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = String::deserialize(deserializer)?;
+        let mut d = to_duration(&v);
+        if d.is_zero() {
+            d = Duration::from_secs(u32::MAX as u64);
+        }
+        Ok(d)
+    }
+
     #[inline]
     fn cross_certificate_default() -> bool {
         false


### PR DESCRIPTION
…interval` to `0` in `rmqtt.toml` causes messages to expire immediately. The intended behavior should ensure messages never expire.