### PR TITLE
refactor(cluster-raft): remove global task queue and bump version to …

### DIFF
--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-cluster-raft"
-version = "0.1.4"
+version = "0.1.5"
 description = "The RMQTT cluster, powered by the `rmqtt-cluster-raft` plugin, uses RAFT for consistency and fault tolerance. Nodes share state to ensure reliable messaging and support scalable, resilient deployments."
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-cluster-raft"
 edition.workspace = true


### PR DESCRIPTION
…0.1.5

- Bump version from 0.1.4 to 0.1.5
- Remove global task_exec_queue singleton pattern
- Add TaskExecQueue as instance member in ClusterPlugin
- Pass TaskExecQueue through all components (Router, Shared, Handler)
- Remove once_cell dependency
- Improve task queue management by making it instance-specific
- Update all spawn calls to use instance queue
- Clean up imports and dependencies
- Add better task queue monitoring in status reporting