### PR TITLE
refactor(auth-http): remove global HTTP client and bump version to 0.1.3

### DIFF
--- a/rmqtt-plugins/rmqtt-auth-http/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-auth-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-auth-http"
-version = "0.1.2"
+version = "0.1.3"
 description = "HTTP authentication uses a custom HTTP API as the data source, enabling flexible and complex auth logic based on its responses."
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-auth-http"
 edition.workspace = true


### PR DESCRIPTION
- Bump version from 0.1.2 to 0.1.3
- Remove global HTTP_CLIENT singleton using once_cell
- Add instance-based reqwest::Client as plugin member
- Pass HTTP client through to AuthHandler
- Replace static client initialization with new_reqwest_client() function
- Update all HTTP request methods to use instance client
- Remove once_cell dependency
- Improve request handling with instance-specific client