### PR TITLE
refactor(cluster-raft): remove global backoff strategy and clean up d…

### DIFF
--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -24,13 +24,11 @@ slog-term.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true
 bytes.workspace = true
-#regex.workspace = true
 bytestring.workspace = true
 futures.workspace = true
 rand.workspace = true
 dashmap.workspace = true
 ahash.workspace = true
-once_cell.workspace = true
 bincode.workspace = true
 
 

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/config.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/config.rs
@@ -1,9 +1,6 @@
-use anyhow::anyhow;
 use std::time::Duration;
 
-pub(crate) use backoff::future::retry;
-pub(crate) use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
-use once_cell::sync::Lazy;
+use anyhow::anyhow;
 use serde::de::{self, Deserializer};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
@@ -16,13 +13,6 @@ use rmqtt::{
     Result,
 };
 use rmqtt_raft::ReadOnlyOption;
-
-pub(crate) static BACKOFF_STRATEGY: Lazy<ExponentialBackoff> = Lazy::new(|| {
-    ExponentialBackoffBuilder::new()
-        .with_max_elapsed_time(Some(Duration::from_secs(60)))
-        .with_multiplier(2.5)
-        .build()
-});
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PluginConfig {


### PR DESCRIPTION
…ependencies

- Remove global BACKOFF_STRATEGY singleton
- Add instance-based ExponentialBackoff to components
- Pass backoff strategy through constructors (Router, Handler)
- Clean up unused dependencies (once_cell, regex)
- Initialize backoff strategy in ClusterPlugin
- Update all retry calls to use instance strategy
- Improve error handling with instance-specific backoff configuration