### PR TITLE
chore: remove once_cell dependency across multiple crates

### DIFF
--- a/rmqtt-net/Cargo.toml
+++ b/rmqtt-net/Cargo.toml
@@ -31,7 +31,6 @@ socket2.workspace = true
 serde = { workspace = true, features = ["derive"] }
 bytestring = { workspace = true, features = ["serde"] }
 nonzero_ext.workspace = true
-once_cell.workspace = true
 
 tokio-tungstenite = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
@@ -43,3 +42,4 @@ rustls = { workspace = true, features = ["ring", "logging", "std", "tls12"], opt
 [dev-dependencies]
 simple_logger = "5"
 tokio = { workspace = true,  features = ["full"] }
+once_cell.workspace = true

--- a/rmqtt-plugins/rmqtt-auth-http/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-auth-http/Cargo.toml
@@ -17,7 +17,6 @@ log.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "json"] }
 serde_json.workspace = true
 ahash.workspace = true
-once_cell.workspace = true
 anyhow.workspace = true
 bytestring.workspace = true
 itoa.workspace = true

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/Cargo.toml
@@ -21,4 +21,3 @@ bytestring.workspace = true
 futures.workspace = true
 ahash.workspace = true
 itertools.workspace = true
-once_cell.workspace = true

--- a/rmqtt-plugins/rmqtt-http-api/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-http-api/Cargo.toml
@@ -22,6 +22,5 @@ bytes.workspace = true
 futures.workspace = true
 socket2.workspace = true
 prometheus.workspace = true
-once_cell.workspace = true
 bincode.workspace = true
 

--- a/rmqtt-plugins/rmqtt-message-storage/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-message-storage/Cargo.toml
@@ -21,7 +21,6 @@ async-trait.workspace = true
 log.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
-once_cell.workspace = true
 get-size.workspace = true
 scc.workspace = true
 

--- a/rmqtt-plugins/rmqtt-session-storage/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-session-storage/Cargo.toml
@@ -21,4 +21,3 @@ log.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
 bytes.workspace = true
-once_cell.workspace = true

--- a/rmqtt-plugins/rmqtt-web-hook/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-web-hook/Cargo.toml
@@ -20,7 +20,6 @@ anyhow.workspace = true
 backoff = { workspace = true, features = ["futures", "tokio"] }
 base64.workspace = true
 bytestring.workspace = true
-once_cell.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 futures.workspace = true
 chrono.workspace = true

--- a/rmqtt/Cargo.toml
+++ b/rmqtt/Cargo.toml
@@ -49,7 +49,6 @@ thiserror.workspace = true
 async-trait.workspace = true
 bytes = { workspace = true, features = ["serde"] }
 bytestring = { workspace = true, features = ["serde"] }
-once_cell.workspace = true
 base64.workspace = true
 bitflags.workspace = true
 itertools.workspace = true


### PR DESCRIPTION
- Removed once_cell dependency from:
  - rmqtt-net (moved to dev-dependencies)
  - rmqtt-auth-http
  - rmqtt-cluster-broadcast
  - rmqtt-http-api
  - rmqtt-message-storage
  - rmqtt-session-storage
  - rmqtt-web-hook
  - rmqtt (main crate)

- Cleaned up Cargo.toml files by removing unused once_cell entries
- Moved once_cell to dev-dependencies where still needed for tests