### PR TITLE
docs: add DeepWiki support badge to READMEs

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -2,6 +2,7 @@
 
 [![GitHub Release](https://img.shields.io/github/release/rmqtt/rmqtt?color=brightgreen)](https://github.com/rmqtt/rmqtt/releases)
 <a href="https://blog.rust-lang.org/2024/09/05/Rust-1.85.0.html"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.85.0%2B-blue" /></a>
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rmqtt/rmqtt)
 
 [English](./README.md)  | 简体中文
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub Release](https://img.shields.io/github/release/rmqtt/rmqtt?color=brightgreen)](https://github.com/rmqtt/rmqtt/releases)
 <a href="https://blog.rust-lang.org/2024/09/05/Rust-1.85.0.html"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.85.0%2B-blue" /></a>
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rmqtt/rmqtt)
 
 English | [简体中文](./README-CN.md)
 


### PR DESCRIPTION
- Added DeepWiki badge to both English and Chinese READMEs
- Badge links to RMQTT documentation on DeepWiki
- Helps users quickly access AI-powered documentation