### PR TITLE
feat(handshake): add handshake timeout checks and update raft dependency

### DIFF
--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 rmqtt = { workspace = true, features = ["plugin", "grpc", "stats", "msgstore"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["sync"] }
-rmqtt-raft = { version = "0.4.5", features = ["reuse"] }
+rmqtt-raft = { version = "0.4.6", features = ["reuse"] }
 #rmqtt-raft = { path = "../../../rmqtt-raft", features = ["reuse"] }
 backoff = { workspace = true, features = ["futures", "tokio"] }
 rust-box = { workspace = true, features = ["task-exec-queue"] }


### PR DESCRIPTION
- Bump rmqtt-raft dependency from 0.4.5 to 0.4.6
- Add handshake timeout checks for both MQTT v3 and v5:
  * Track handshake start time using Instant
  * Return ServiceUnavailable/ServerUnavailable if timeout exceeded
  * Use listener's configured handshake_timeout threshold
- Changes ensure:
  * Better protection against stalled connections
  * More predictable handshake behavior
  * Alignment with configured timeout thresholds
- Maintains backward compatibility while adding safety checks