### PR TITLE
feat(cluster-raft): bump version to 0.2.0 and update task executor usage

### DIFF
--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-cluster-raft"
-version = "0.1.6"
+version = "0.2.0"
 description = "The RMQTT cluster, powered by the `rmqtt-cluster-raft` plugin, uses RAFT for consistency and fault tolerance. Nodes share state to ensure reliable messaging and support scalable, resilient deployments."
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-cluster-raft"
 edition.workspace = true

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -424,7 +424,7 @@ impl Shared for ClusterShared {
                     }
                     scx.stats.forwards.dec();
                 };
-                let _reply = self.scx.global_exec.spawn(forwards_fut).await;
+                let _reply = self.scx.client_exec.spawn(forwards_fut).await;
             }
         }
 


### PR DESCRIPTION
- Bump version from 0.1.6 to 0.2.0 (minor version bump for backward-compatible changes)
- Update task executor usage to use client_exec instead of global_exec:
  * Forwards future now runs on client task executor
  * Better aligns with new task execution separation strategy
- Changes maintain all existing functionality while:
  * Improving task isolation
  * Better matching task types with appropriate executors
  * Following the new server/client executor pattern