### PR TITLE
refactor(queue): migrate from SegQueue to Mutex<VecDeque>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,6 @@ serde_json = "1.0"
 chrono = { version = "0.4", default-features = false }
 uuid = "=1.11.0"
 rand = "0.9.0"
-crossbeam = "0.8"
 governor = "0.10"
 config = { version = "0.15.8", default-features = false}
 log = "0.4"

--- a/rmqtt/Cargo.toml
+++ b/rmqtt/Cargo.toml
@@ -58,7 +58,6 @@ ahash.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 get-size = { workspace = true, features = ["derive"] }
 leaky-bucket.workspace = true
-crossbeam.workspace = true
 governor.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 systemstat.workspace = true
@@ -69,6 +68,7 @@ prometheus.workspace = true
 url.workspace = true
 config = { workspace = true, features = ["toml"] }
 scopeguard.workspace = true
+parking_lot.workspace = true
 
 [build-dependencies]
 chrono = { workspace = true, features = ["clock"] }


### PR DESCRIPTION
- Replace crossbeam::SegQueue with parking_lot::Mutex<VecDeque>
- Implement thread-safe queue with mutex lock
- Update push/pop operations to use VecDeque
- Maintain same API interface but with different locking strategy