### PR TITLE
chore(cluster-raft): update rmqtt-raft dependency to 0.5.3

### DIFF
--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 rmqtt = { workspace = true, features = ["plugin", "grpc", "stats", "msgstore"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["sync"] }
-rmqtt-raft = { version = "0.5.2", features = ["reuse"] }
+rmqtt-raft = { version = "0.5.3", features = ["reuse"] }
 #rmqtt-raft = { path = "../../../rmqtt-raft", features = ["reuse"] }
 backoff = { workspace = true, features = ["futures", "tokio"] }
 rust-box = { workspace = true, features = ["task-exec-queue"] }


### PR DESCRIPTION
- Update rmqtt-raft version from 0.5.2 to 0.5.3
- Maintain all existing features ("reuse" feature still enabled)
- Keep commented local path reference for development purposes