### PR TITLE
feat(handshake): add timeout checks and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rmqtt-bridge-egress-nats = { path = "rmqtt-plugins/rmqtt-bridge-egress-nats"}
 rmqtt-bridge-egress-reductstore = { path = "rmqtt-plugins/rmqtt-bridge-egress-reductstore"}
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 authors = ["rmqtt <rmqttd@126.com>"]
 description = "MQTT Server for v3.1, v3.1.1 and v5.0 protocols"

--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 rmqtt.workspace = true
 rmqtt-macros.workspace = true
 serde = { workspace = true, features = ["derive"] }
-rmqtt-raft = { version = "0.4.5", features = ["reuse"] }
+rmqtt-raft = { version = "0.5.3", features = ["reuse"] }
 #rmqtt-raft = { path = "../../../rmqtt-raft", features = ["reuse"] }
 backoff = { version = "0.4", features = ["futures", "tokio"] }
 lz4_flex = { version = "0.11" }


### PR DESCRIPTION
Core Changes:
- Bump workspace version from 0.13.1 to 0.13.2
- Add handshake timeout checks for both MQTT v3 and v5 protocols
- Track handshake start time and enforce listener.handshake_timeout
- Return ServiceUnavailable/ServerUnavailable when timeout exceeded

Dependency Updates:
- Update rmqtt-raft dependency from 0.4.5 to 0.5.3
- Maintain reuse feature flag for raft implementation

Protocol Improvements:
- v3: Added timeout check before client ID validation
- v5: Added timeout check before client ID validation
- Both protocols now properly handle handshake timeouts