### PR TITLE
build: enable panic abort in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,4 @@ opt-level = 0
 lto = true
 opt-level = 's'
 codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
- Set `panic = "abort"` in release profile configuration
- Improves release binary size by removing panic unwinding infrastructure
- Maintains existing optimization settings (lto=true, opt-level='s')