### PR TITLE
feat(bridge): improve string handling and bump version to 0.13.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rmqtt-bridge-egress-nats = { path = "rmqtt-plugins/rmqtt-bridge-egress-nats"}
 rmqtt-bridge-egress-reductstore = { path = "rmqtt-plugins/rmqtt-bridge-egress-reductstore"}
 
 [workspace.package]
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 authors = ["rmqtt <rmqttd@126.com>"]
 description = "MQTT Server for v3.1, v3.1.1 and v5.0 protocols"

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/bridge.rs
@@ -242,16 +242,21 @@ fn to_properties(props: &PublishProperties) -> ntex_mqtt::v5::codec::PublishProp
     let user_properties: ntex_mqtt::v5::codec::UserProperties = props
         .user_properties
         .iter()
-        .map(|(k, v)| (ntex::util::ByteString::from(k.as_ref()), ntex::util::ByteString::from(v.as_ref())))
+        .map(|(k, v)| {
+            (ntex::util::ByteString::from(k.to_string()), ntex::util::ByteString::from(v.to_string()))
+        })
         .collect();
     ntex_mqtt::v5::codec::PublishProperties {
         topic_alias: props.topic_alias,
         correlation_data: props.correlation_data.as_ref().map(|data| ntex::util::Bytes::from(data.to_vec())),
         message_expiry_interval: props.message_expiry_interval,
-        content_type: props.content_type.as_ref().map(|data| ntex::util::ByteString::from(data.as_ref())),
+        content_type: props.content_type.as_ref().map(|data| ntex::util::ByteString::from(data.to_string())),
         user_properties,
         is_utf8_payload: props.is_utf8_payload.unwrap_or_default(),
-        response_topic: props.response_topic.as_ref().map(|data| ntex::util::ByteString::from(data.as_ref())),
+        response_topic: props
+            .response_topic
+            .as_ref()
+            .map(|data| ntex::util::ByteString::from(data.to_string())),
         subscription_ids: props.subscription_ids.clone().unwrap_or_default(),
     }
 }

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/v4.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/v4.rs
@@ -78,7 +78,7 @@ impl Client {
         };
 
         let mut builder = v3::client::MqttConnector::new(client.cfg.server.addr.clone())
-            .client_id(ByteString::from(client.client_id.as_ref()))
+            .client_id(ByteString::from(client.client_id.to_string()))
             .keep_alive(Seconds(client.cfg.keepalive.as_secs() as u16))
             .handshake_timeout(Seconds(client.cfg.connect_timeout.as_secs() as u16));
 

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/v5.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/v5.rs
@@ -77,7 +77,7 @@ impl Client {
         };
 
         let mut builder = v5::client::MqttConnector::new(client.cfg.server.addr.clone())
-            .client_id(ByteString::from(client.client_id.as_ref()))
+            .client_id(ByteString::from(client.client_id.to_string()))
             .keep_alive(Seconds(client.cfg.keepalive.as_secs() as u16))
             .handshake_timeout(Seconds(client.cfg.connect_timeout.as_secs() as u16));
 

--- a/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/v4.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/v4.rs
@@ -103,7 +103,7 @@ impl Client {
         );
 
         let mut builder = v3::client::MqttConnector::new(client.cfg.server.addr.clone())
-            .client_id(ByteString::from(client.client_id.as_ref()))
+            .client_id(ByteString::from(client.client_id.to_string()))
             .keep_alive(Seconds(client.cfg.keepalive.as_secs() as u16))
             .handshake_timeout(Seconds(client.cfg.connect_timeout.as_secs() as u16));
 
@@ -172,7 +172,7 @@ impl Client {
                             sink.clone(),
                             topic_filter,
                             qos,
-                            ByteString::from(client.client_id.as_ref()),
+                            ByteString::from(client.client_id.to_string()),
                         ));
                     }
 

--- a/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/v5.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/v5.rs
@@ -96,7 +96,7 @@ impl Client {
         };
 
         let mut builder = v5::client::MqttConnector::new(client.cfg.server.addr.clone())
-            .client_id(ByteString::from(client.client_id.as_ref()))
+            .client_id(ByteString::from(client.client_id.to_string()))
             .keep_alive(Seconds(client.cfg.keepalive.as_secs() as u16))
             .handshake_timeout(Seconds(client.cfg.connect_timeout.as_secs() as u16));
 
@@ -171,7 +171,7 @@ impl Client {
                             sink.clone(),
                             topic_filter,
                             qos,
-                            ByteString::from(client.client_id.as_ref()),
+                            ByteString::from(client.client_id.to_string()),
                         ));
                     }
 


### PR DESCRIPTION
Version & Core:
- Bumped workspace version from 0.13.2 to 0.13.3
- Standardized string conversion patterns across bridge components

String Handling Improvements:
- Replaced `.as_ref()` with explicit `.to_string()` for:
  * MQTT client IDs in both ingress/egress bridges
  * User properties in publish messages
  * Content type and response topic fields
- Ensured consistent string conversion in v3/v5 protocol handlers

Bridge Components:
- Updated both ingress and egress MQTT bridges
- Applied changes to both v4 and v5 protocol implementations
- Maintained all existing timeout and keepalive functionality