### PR TITLE
refactor(concurrency): streamline thread management and configuration

### DIFF
--- a/rmqtt-bin/src/server.rs
+++ b/rmqtt-bin/src/server.rs
@@ -62,13 +62,7 @@ async fn main() -> Result<()> {
         .await;
 
     //start gRPC server
-    scx.node.start_grpc_server(
-        scx.clone(),
-        conf.rpc.server_addr,
-        conf.rpc.server_workers,
-        conf.rpc.reuseaddr,
-        conf.rpc.reuseport,
-    );
+    scx.node.start_grpc_server(scx.clone(), conf.rpc.server_addr, conf.rpc.reuseaddr, conf.rpc.reuseport);
 
     //register plugin
     plugin::registers(&scx, conf.plugins.default_startups.clone()).await.expect("register plugin failed");

--- a/rmqtt-conf/src/lib.rs
+++ b/rmqtt-conf/src/lib.rs
@@ -248,18 +248,6 @@ pub struct Rpc {
 
     #[serde(default = "Rpc::reuseport_default")]
     pub reuseport: bool,
-
-    #[serde(default = "Rpc::server_workers_default")]
-    pub server_workers: usize,
-    // #[serde(default = "Rpc::client_concurrency_limit_default")]
-    // pub client_concurrency_limit: usize,
-    //
-    // #[serde(default = "Rpc::client_timeout_default", deserialize_with = "deserialize_duration")]
-    // pub client_timeout: Duration,
-    //
-    // //#Maximum number of messages sent in batch
-    // #[serde(default = "Rpc::batch_size_default")]
-    // pub batch_size: usize,
 }
 
 impl Default for Rpc {
@@ -268,11 +256,7 @@ impl Default for Rpc {
         Self {
             reuseaddr: Self::reuseaddr_default(),
             reuseport: Self::reuseport_default(),
-            // batch_size: Self::batch_size_default(),
             server_addr: Self::server_addr_default(),
-            server_workers: Self::server_workers_default(),
-            // client_concurrency_limit: Self::client_concurrency_limit_default(),
-            // client_timeout: Self::client_timeout_default(),
         }
     }
 }
@@ -286,9 +270,6 @@ impl Rpc {
     }
     fn server_addr_default() -> SocketAddr {
         ([0, 0, 0, 0], 5363).into()
-    }
-    fn server_workers_default() -> usize {
-        4
     }
 }
 

--- a/rmqtt-plugins/rmqtt-http-api.toml
+++ b/rmqtt-plugins/rmqtt-http-api.toml
@@ -4,8 +4,6 @@
 
 # See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
 
-##Number of worker threads
-workers = 1
 ## Max Row Limit
 max_row_limit = 10_000
 ## HTTP Listener address

--- a/rmqtt-plugins/rmqtt-http-api/src/config.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/config.rs
@@ -11,9 +11,6 @@ use rmqtt::{
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PluginConfig {
-    #[serde(default = "PluginConfig::workers_default")]
-    pub workers: usize,
-
     #[serde(default = "PluginConfig::max_row_limit_default")]
     pub max_row_limit: usize,
 
@@ -54,11 +51,6 @@ pub struct PluginConfig {
 }
 
 impl PluginConfig {
-    #[inline]
-    fn workers_default() -> usize {
-        1
-    }
-
     #[inline]
     fn max_row_limit_default() -> usize {
         10_000
@@ -111,15 +103,15 @@ impl PluginConfig {
 
     #[inline]
     pub fn changed(&self, other: &Self) -> bool {
-        self.workers != other.workers
-            || self.max_row_limit != other.max_row_limit
+        self.max_row_limit != other.max_row_limit
             || self.http_laddr != other.http_laddr
             || self.metrics_sample_interval != other.metrics_sample_interval
             || self.http_request_log != other.http_request_log
+            || self.prometheus_metrics_cache_interval != other.prometheus_metrics_cache_interval
     }
 
     #[inline]
     pub fn restart_enable(&self, other: &Self) -> bool {
-        self.workers != other.workers || self.http_laddr != other.http_laddr
+        self.http_laddr != other.http_laddr
     }
 }

--- a/rmqtt-plugins/rmqtt-web-hook.toml
+++ b/rmqtt-plugins/rmqtt-web-hook.toml
@@ -11,10 +11,17 @@
 
 # See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/web-hook.md
 
-## Hook general config
-worker_threads = 3
+##--------------------------------------------------------------------
+## Hook General Config
+##--------------------------------------------------------------------
+# Maximum number of tasks that can be queued before new tasks are rejected.
+# Changing this value requires restarting the service to take effect.
 queue_capacity = 300_000
+
+# Maximum number of tasks that can be executed concurrently.
+# Changing this value requires restarting the service to take effect.
 concurrency_limit = 128
+
 
 ## Default urls, supports http and file protocols
 #urls = ["file:///var/log/rmqtt/hook.log", "http://127.0.0.1:5656/mqtt/webhook"]

--- a/rmqtt-plugins/rmqtt-web-hook/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-web-hook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-web-hook"
-version = "0.1.3"
+version = "0.1.4"
 description = "This enables RMQTT to send hook event notifications to a web service."
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-web-hook"
 edition.workspace = true

--- a/rmqtt-plugins/rmqtt-web-hook/src/config.rs
+++ b/rmqtt-plugins/rmqtt-web-hook/src/config.rs
@@ -15,8 +15,6 @@ type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PluginConfig {
-    #[serde(default = "PluginConfig::worker_threads_default")]
-    pub worker_threads: usize,
     #[serde(default = "PluginConfig::queue_capacity_default")]
     pub queue_capacity: usize,
     #[serde(default = "PluginConfig::concurrency_limit_default")]
@@ -42,9 +40,6 @@ pub struct PluginConfig {
 }
 
 impl PluginConfig {
-    fn worker_threads_default() -> usize {
-        3
-    }
     fn queue_capacity_default() -> usize {
         1_000_000
     }

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -33,12 +33,22 @@ node.busy.cpuloadavg = 90.0
 node.busy.handshaking = 0
 
 ##--------------------------------------------------------------------
-## RPC
+## RPC (Remote Procedure Call) Configuration Section
 ##--------------------------------------------------------------------
-#gRPC listening address
+# gRPC server listening address
+# Format: "IP:PORT"
+# "0.0.0.0" means listen on all available network interfaces
+# 5363 is the default listening port
 rpc.server_addr = "0.0.0.0:5363"
-#Number of worker threads
-rpc.server_workers = 4
+
+# Enable SO_REUSEADDR socket option
+# true allows immediate reuse of addresses in TIME_WAIT state (useful for fast service restart)
+rpc.reuseaddr = true
+
+# Enable SO_REUSEPORT socket option
+# false prevents multiple sockets from binding to same IP+PORT combination
+# (Linux 3.9+ kernel feature, can be used for load balancing)
+rpc.reuseport = false
 
 ##--------------------------------------------------------------------
 ## Log

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -138,9 +138,7 @@ impl GrpcServer {
 
     async fn on_recv_message(&self, req: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let (typ, msg) = Message::decode(&req)?;
-        // self.scx.stats.grpc_server_actives.inc();
         let reply = self.grpc_message_received(typ, msg).await?;
-        // self.scx.stats.grpc_server_actives.dec();
         Ok(Some(reply.encode()?))
     }
 


### PR DESCRIPTION
Version Updates:
- Bumped rmqtt-web-hook from 0.1.3 to 0.1.4

Core Changes:
- Removed manual thread pool management in favor of Tokio runtime
- Eliminated worker_threads/server_workers configuration options
- Consolidated task execution using ServerContext's exec queue
- Simplified gRPC server startup using Tokio spawn

Configuration Improvements:
- Removed redundant worker_threads/server_workers settings
- Enhanced documentation for web-hook queue settings
- Streamlined RPC configuration section
- Added descriptive comments for socket options

Performance Monitoring:
- Cleaned up gRPC server active stats tracking
- Simplified client creation without ping thread

Code Quality:
- Removed unused init_task_exec_queue functions
- Reduced struct fields by removing redundant httpc client
- Improved configuration change detection logic