### PR TITLE
perf(session): optimize offline message handling with VecDeque

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rmqtt-bridge-egress-nats = { path = "rmqtt-plugins/rmqtt-bridge-egress-nats"}
 rmqtt-bridge-egress-reductstore = { path = "rmqtt-plugins/rmqtt-bridge-egress-reductstore"}
 
 [workspace.package]
-version = "0.13.3"
+version = "0.13.4"
 edition = "2021"
 authors = ["rmqtt <rmqttd@126.com>"]
 description = "MQTT Server for v3.1, v3.1.1 and v5.0 protocols"

--- a/rmqtt-plugins/rmqtt-bridge-egress-kafka/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-kafka/src/bridge.rs
@@ -226,7 +226,7 @@ impl BridgeManager {
     pub(crate) async fn send(&self, f: &From, p: &Publish) -> Result<()> {
         let topic = Topic::from_str(&p.topic)?;
         let rnd = rand::random::<u64>() as usize;
-        for (topic_filter, bridge_infos) in { self.topics.read().await.matches(&topic) }.iter() {
+        for (topic_filter, bridge_infos) in self.topics.read().await.matches(&topic).iter() {
             let topic_filter = topic_filter.to_topic_filter();
             log::debug!("topic_filter: {topic_filter:?}");
             log::debug!("bridge_infos: {bridge_infos:?}");

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/bridge.rs
@@ -166,7 +166,7 @@ impl BridgeManager {
     pub(crate) async fn send(&self, _f: &From, p: &Publish) -> Result<()> {
         let topic = Topic::from_str(&p.topic)?;
         let rnd = rand::random::<u64>() as usize;
-        for (topic_filter, bridge_infos) in { self.topics.read().await.matches(&topic) }.iter() {
+        for (topic_filter, bridge_infos) in self.topics.read().await.matches(&topic).iter() {
             let topic_filter = topic_filter.to_topic_filter();
             log::debug!("topic_filter: {topic_filter:?}");
             log::debug!("bridge_infos: {bridge_infos:?}");

--- a/rmqtt-plugins/rmqtt-bridge-egress-nats/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-nats/src/bridge.rs
@@ -261,7 +261,7 @@ impl BridgeManager {
     #[inline]
     pub(crate) async fn send(&self, f: &From, p: &Publish) -> Result<()> {
         let topic = Topic::from_str(&p.topic)?;
-        for (topic_filter, bridge_infos) in { self.topics.read().await.matches(&topic) }.iter() {
+        for (topic_filter, bridge_infos) in self.topics.read().await.matches(&topic).iter() {
             let topic_filter = topic_filter.to_topic_filter();
             log::debug!("topic_filter: {topic_filter:?}");
             log::debug!("bridge_infos: {bridge_infos:?}");

--- a/rmqtt-plugins/rmqtt-bridge-egress-pulsar/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-pulsar/src/bridge.rs
@@ -312,7 +312,7 @@ impl BridgeManager {
     #[inline]
     pub(crate) async fn send(&self, f: &From, p: &Publish) -> Result<()> {
         let topic = Topic::from_str(&p.topic)?;
-        for (topic_filter, bridge_infos) in { self.topics.read().await.matches(&topic) }.iter() {
+        for (topic_filter, bridge_infos) in self.topics.read().await.matches(&topic).iter() {
             let topic_filter = topic_filter.to_topic_filter();
             log::debug!("topic_filter: {topic_filter:?}");
             log::debug!("bridge_infos: {bridge_infos:?}");

--- a/rmqtt-plugins/rmqtt-bridge-egress-reductstore/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-reductstore/src/bridge.rs
@@ -206,7 +206,7 @@ impl BridgeManager {
     #[inline]
     pub(crate) async fn send(&self, f: &From, p: &Publish) -> Result<()> {
         let topic = Topic::from_str(&p.topic)?;
-        for (topic_filter, bridge_infos) in { self.topics.read().await.matches(&topic) }.iter() {
+        for (topic_filter, bridge_infos) in self.topics.read().await.matches(&topic).iter() {
             let topic_filter = topic_filter.to_topic_filter();
             log::debug!("topic_filter: {topic_filter:?}");
             log::debug!("bridge_infos: {bridge_infos:?}");

--- a/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/config.rs
@@ -414,10 +414,10 @@ impl Local {
     pub(crate) fn prepare_topic(&mut self) {
         if let Some(item) = self.topic.as_ref() {
             match &item.pattern {
-                Some(LocalTopicPattern::RemoteProperties(name, ref placeholder)) => {
+                Some(LocalTopicPattern::RemoteProperties(name, placeholder)) => {
                     self.props_topic_names.insert(name.into(), placeholder.as_str().into());
                 }
-                Some(LocalTopicPattern::RemotePayload(path, ref placeholder)) => {
+                Some(LocalTopicPattern::RemotePayload(path, placeholder)) => {
                     self.payload_topic_names.insert(["/", path].concat(), placeholder.as_str().into());
                 }
                 _ => {}
@@ -426,10 +426,10 @@ impl Local {
 
         for item in self.topics.iter() {
             match &item.pattern {
-                Some(LocalTopicPattern::RemoteProperties(name, ref placeholder)) => {
+                Some(LocalTopicPattern::RemoteProperties(name, placeholder)) => {
                     self.props_topic_names.insert(name.into(), placeholder.as_str().into());
                 }
-                Some(LocalTopicPattern::RemotePayload(path, ref placeholder)) => {
+                Some(LocalTopicPattern::RemotePayload(path, placeholder)) => {
                     self.payload_topic_names.insert(["/", path].concat(), placeholder.as_str().into());
                 }
                 _ => {}
@@ -452,7 +452,7 @@ impl Local {
             (LocalTopicPattern::RemoteTopic, false) => {
                 topics.push(TopicName::from(topic.replace(REMOTE_TOPIC_NAME, remote_topic)))
             }
-            (LocalTopicPattern::RemoteProperties(ref name, ref placeholder), true) => {
+            (LocalTopicPattern::RemoteProperties(name, placeholder), true) => {
                 if let Some(t) = props_topics.get(placeholder.as_str()).map(|t| TopicName::from(*t)) {
                     topics.push(t);
                 } else {
@@ -461,7 +461,7 @@ impl Local {
                     );
                 }
             }
-            (LocalTopicPattern::RemoteProperties(ref name, ref placeholder), false) => {
+            (LocalTopicPattern::RemoteProperties(name, placeholder), false) => {
                 if let Some(t) = props_topics
                     .get(placeholder.as_str())
                     .map(|t| TopicName::from(topic.replace(placeholder, t)))
@@ -473,7 +473,7 @@ impl Local {
                     );
                 }
             }
-            (LocalTopicPattern::RemotePayload(ref path, ref placeholder), true) => {
+            (LocalTopicPattern::RemotePayload(path, placeholder), true) => {
                 if let Some(ts) = payload_topics.as_ref().and_then(|payload_topics| {
                     payload_topics
                         .get(placeholder.as_str())
@@ -486,7 +486,7 @@ impl Local {
                     );
                 }
             }
-            (LocalTopicPattern::RemotePayload(ref path, ref placeholder), false) => {
+            (LocalTopicPattern::RemotePayload(path, placeholder), false) => {
                 if let Some(ts) = payload_topics.as_ref().and_then(|payload_topics| {
                     payload_topics.get(placeholder.as_str()).map(|ts| {
                         ts.iter().map(|t| TopicName::from(topic.replace(placeholder, t))).collect_vec()

--- a/rmqtt-plugins/rmqtt-http-api/src/types.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/types.rs
@@ -35,7 +35,7 @@ impl Message<'_> {
         Ok(bincode::serialize(self).map_err(anyhow::Error::new)?)
     }
     #[inline]
-    pub fn decode(data: &[u8]) -> Result<Message> {
+    pub fn decode(data: &[u8]) -> Result<Message<'_>> {
         Ok(bincode::deserialize::<Message>(data).map_err(anyhow::Error::new)?)
     }
 }

--- a/rmqtt-plugins/rmqtt-session-storage/src/session.rs
+++ b/rmqtt-plugins/rmqtt-session-storage/src/session.rs
@@ -516,6 +516,7 @@ pub trait AtomicFlags {
     fn empty() -> Self;
     #[allow(dead_code)]
     fn all() -> Self;
+    #[allow(dead_code)]
     fn get(&self) -> Self::T;
     #[allow(dead_code)]
     fn insert(&self, other: Self::T);
@@ -525,6 +526,7 @@ pub trait AtomicFlags {
     fn remove(&self, other: Self::T);
     #[allow(dead_code)]
     fn equal_exchange(&self, current: Self::T, new: Self::T, mask: Self::T) -> Result<Self::T, Self::T>;
+    #[allow(dead_code)]
     fn difference(&self, other: Self::T) -> Self::T;
 }
 

--- a/rmqtt/src/broker/types.rs
+++ b/rmqtt/src/broker/types.rs
@@ -235,7 +235,7 @@ impl ConnectInfo {
     }
 
     #[inline]
-    pub fn last_will(&self) -> Option<LastWill> {
+    pub fn last_will(&self) -> Option<LastWill<'_>> {
         match self {
             ConnectInfo::V3(_, conn_info) => conn_info.last_will.as_ref().map(LastWill::V3),
             ConnectInfo::V5(_, conn_info) => conn_info.last_will.as_ref().map(LastWill::V5),

--- a/rmqtt/src/plugin.rs
+++ b/rmqtt/src/plugin.rs
@@ -340,12 +340,12 @@ impl Manager {
     }
 
     ///Get a Plugin
-    pub fn get(&self, name: &str) -> Option<EntryRef> {
+    pub fn get(&self, name: &str) -> Option<EntryRef<'_>> {
         self.plugins.get(name)
     }
 
     ///Get a mut Plugin
-    pub fn get_mut(&self, name: &str) -> Result<Option<EntryRefMut>> {
+    pub fn get_mut(&self, name: &str) -> Result<Option<EntryRefMut<'_>>> {
         if let Some(entry) = self.plugins.get_mut(name) {
             if entry.immutable {
                 Err(MqttError::from("the plug-in is immutable"))
@@ -367,7 +367,7 @@ impl Manager {
     }
 
     ///List Plugins
-    pub fn iter(&self) -> EntryIter {
+    pub fn iter(&self) -> EntryIter<'_> {
         self.plugins.iter()
     }
 }


### PR DESCRIPTION
Version & Core:
- Bumped workspace version from 0.13.3 to 0.13.4

Performance Improvements:
- Changed offline_messages from Vec to VecDeque for efficient FIFO operations
- Replaced pop() with pop_front() for proper queue behavior
- Used push_back() instead of push() for correct queue ordering

Key Benefits:
1. **Efficiency**: VecDeque provides O(1) amortized time for both ends
2. **Correctness**: Ensures proper first-in-first-out delivery of offline messages
3. **Memory**: Better memory utilization for queue operations
4. **Behavior**: Maintains message ordering during offline storage and retrieval

The changes ensure that offline messages are processed in the correct order while improving performance for queue operations.