### PR TITLE
docs: add library mode integration and crate badges to README

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -3,6 +3,8 @@
 [![GitHub Release](https://img.shields.io/github/release/rmqtt/rmqtt?color=brightgreen)](https://github.com/rmqtt/rmqtt/releases)
 <a href="https://blog.rust-lang.org/2025/03/18/Rust-1.85.1/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.85.0%2B-blue" /></a>
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rmqtt/rmqtt)
+[![crates.io page](https://img.shields.io/crates/v/rmqtt.svg)](https://crates.io/crates/rmqtt)
+[![docs.rs page](https://docs.rs/rmqtt/badge.svg)](https://docs.rs/rmqtt/latest/rmqtt/)
 
 [English](./README.md)  | 简体中文
 
@@ -101,6 +103,18 @@ curl "http://127.0.0.1:6066/api/v1/health/check"
 - [单节点安装配置文档](./docs/zh_CN/install.md)
 
 - [集群安装配置文档](./docs/zh_CN/install.md)
+
+
+##  通过库方式集成
+
+除了作为独立的 MQTT Broker/Server 使用外，rmqtt 还提供 **库模式（Library Mode）**，可以将 rmqtt 作为 Rust 的依赖直接嵌入到你的应用或服务中。只需在 `Cargo.toml` 中添加如下依赖，即可在代码中像使用普通库一样调用 rmqtt 的 API：
+
+```toml
+[dependencies]
+rmqtt = "0.15"
+```
+
+更多关于库模式的使用说明，请参考 [RMQTT 库使用文档](./rmqtt/README.md) 。
 
 ## 体验
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![GitHub Release](https://img.shields.io/github/release/rmqtt/rmqtt?color=brightgreen)](https://github.com/rmqtt/rmqtt/releases)
 <a href="https://blog.rust-lang.org/2025/03/18/Rust-1.85.1/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.85.0%2B-blue" /></a>
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rmqtt/rmqtt)
+[![crates.io page](https://img.shields.io/crates/v/rmqtt.svg)](https://crates.io/crates/rmqtt)
+[![docs.rs page](https://docs.rs/rmqtt/badge.svg)](https://docs.rs/rmqtt/latest/rmqtt/)
+
 
 English | [简体中文](./README-CN.md)
 
@@ -103,6 +106,18 @@ Get the binary package of the corresponding OS from [RMQTT Download](https://git
 - [Single Node Install](./docs/en_US/install.md)
 
 - [Multi Node Install](./docs/en_US/install.md)
+
+
+## Library Mode Integration
+
+In addition to running as a standalone MQTT Broker/Server, rmqtt also provides a **Library Mode**, which allows you to embed rmqtt directly into your Rust applications or services. Simply add the following dependency to your `Cargo.toml`, and you can use rmqtt's APIs just like a regular Rust library:
+
+```toml
+[dependencies]
+rmqtt = "0.15"
+```
+
+For more details about using rmqtt in library mode, please refer to the [RMQTT Library Documentation](./rmqtt/README.md).
 
 ## Experience
 


### PR DESCRIPTION
Documentation Enhancements:

1. **Added Crate Badges**:
   - Added crates.io version badge for visibility
   - Added docs.rs documentation badge pointing to latest version
   - Added to both English and Chinese READMEs

2. **Library Mode Documentation**:
   - Added new "Library Mode Integration" section in both languages
   - Provides clear instructions for embedding rmqtt as a Rust dependency
   - Includes example Cargo.toml dependency configuration
   - Links to detailed library documentation in rmqtt/README.md

3. **Bilingual Support**:
   - English version: "Library Mode Integration"
   - Chinese version: "通过库方式集成" (Library Mode Integration)
   - Consistent structure and information across both languages

Benefits:
- **Better Discoverability**: Developers can easily find the crate on crates.io
- **Improved Documentation Access**: Direct link to latest API documentation
- **Enhanced Integration Options**: Clear guidance for using rmqtt as a library
- **Multilingual Support**: Consistent information for both English and Chinese users

The changes make it easier for developers to discover, integrate, and use rmqtt in various deployment scenarios.