### PR TITLE
chore(gitignore): add publish script files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ target/
 /Cargo.lock
 /readme.txt
 !.github
+/publishs-dry-run.bat
+/publishs.bat


### PR DESCRIPTION
- Added `/publishs-dry-run.bat` to gitignore
- Added `/publishs.bat` to gitignore

These files are likely local/automated publish scripts that should not be tracked in version control.