### PR TITLE
chore(logging): change default log level from Debug to Info

### DIFF
--- a/rmqtt-conf/src/logging.rs
+++ b/rmqtt-conf/src/logging.rs
@@ -34,7 +34,7 @@ impl Log {
     }
     #[inline]
     fn level_default() -> Level {
-        Level { inner: slog::Level::Debug }
+        Level { inner: slog::Level::Info }
     }
     #[inline]
     fn dir_default() -> String {


### PR DESCRIPTION
- Changed default logging level from `slog::Level::Debug` to `slog::Level::Info`
- Reduces verbosity for production environments
- Maintains useful operational logging while minimizing noise
- Better out-of-the-box experience for new deployments