### PR TITLE
perf(shutdown): reduce shutdown delay and exit explicitly

### DIFF
--- a/rmqtt-bin/src/server.rs
+++ b/rmqtt-bin/src/server.rs
@@ -112,8 +112,8 @@ async fn main() -> Result<()> {
     shutdown_rx.await.expect("Failed to receive the shutdown command");
     //log::info!("Performing cleanup..."); @TODO ... Hook when exiting
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
-    Ok(())
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    std::process::exit(0);
 }
 
 fn config_builder(cfg: &Listener) -> Builder {


### PR DESCRIPTION
- Reduced shutdown delay from 1 second to 100 milliseconds
- Added explicit `std::process::exit(0)` for immediate termination
- Maintains cleanup opportunity while improving shutdown responsiveness

This change provides faster service termination while ensuring the process exits cleanly.