### PR TITLE
feat: add new p2p-messaging plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ rmqtt-bridge-ingress-pulsar = { path = "rmqtt-plugins/rmqtt-bridge-ingress-pulsa
 rmqtt-bridge-egress-pulsar = { path = "rmqtt-plugins/rmqtt-bridge-egress-pulsar"}
 rmqtt-bridge-egress-nats = { path = "rmqtt-plugins/rmqtt-bridge-egress-nats"}
 rmqtt-bridge-egress-reductstore = { path = "rmqtt-plugins/rmqtt-bridge-egress-reductstore"}
+rmqtt-p2p-messaging = { path = "rmqtt-plugins/rmqtt-p2p-messaging"}
+
 
 [workspace.package]
 version = "0.16.0"
@@ -90,7 +92,7 @@ rmqtt-topic-rewrite = "0.16.0"
 rmqtt-web-hook = "0.16.0"
 rmqtt-cluster-raft = "0.16.0"
 rmqtt-cluster-broadcast = "0.16.0"
-
+rmqtt-p2p-messaging = "0.16.0"
 
 tokio = { version = "1.44",  default-features = false }
 reqwest = "0.12"

--- a/rmqtt-bin/Cargo.toml
+++ b/rmqtt-bin/Cargo.toml
@@ -58,6 +58,7 @@ rmqtt-topic-rewrite.workspace = true
 rmqtt-web-hook.workspace = true
 rmqtt-cluster-raft.workspace = true
 rmqtt-cluster-broadcast.workspace = true
+rmqtt-p2p-messaging.workspace = true
 #rmqtt-plugin-template = "0.1"
 
 [package.metadata.plugins]
@@ -83,6 +84,7 @@ rmqtt-topic-rewrite = { }
 rmqtt-web-hook = { }
 rmqtt-cluster-raft = { immutable = true }
 rmqtt-cluster-broadcast = { immutable = true }
+rmqtt-p2p-messaging = { }
 #rmqtt-plugin-template = { }
 
 [build-dependencies]

--- a/rmqtt-plugins/Cargo.toml
+++ b/rmqtt-plugins/Cargo.toml
@@ -41,6 +41,7 @@ full = [
     "bridge-ingress-pulsar",
     "bridge-egress-nats",
     "bridge-egress-reductstore",
+    "p2p-messaging",
 
     "sys-topic",
     "topic-rewrite",
@@ -88,6 +89,7 @@ bridge-egress-reductstore = ["rmqtt-bridge-egress-reductstore"]
 sys-topic = ["rmqtt-sys-topic"]
 topic-rewrite = ["rmqtt-topic-rewrite"]
 web-hook = ["rmqtt-web-hook"]
+p2p-messaging = ["rmqtt-p2p-messaging"]
 
 # ---- cluster plugins ----
 cluster-raft = ["rmqtt-cluster-raft"]
@@ -116,3 +118,4 @@ rmqtt-topic-rewrite = { workspace = true, optional = true }
 rmqtt-web-hook = { workspace = true, optional = true }
 rmqtt-cluster-raft = { workspace = true, optional = true }
 rmqtt-cluster-broadcast = { workspace = true, optional = true }
+rmqtt-p2p-messaging = { workspace = true, optional = true }

--- a/rmqtt-plugins/rmqtt-p2p-messaging.toml
+++ b/rmqtt-plugins/rmqtt-p2p-messaging.toml
@@ -1,0 +1,8 @@
+##--------------------------------------------------------------------
+## rmqtt-p2p-messaging
+##--------------------------------------------------------------------
+
+#"prefix": `p2p/{clientid}/{topic}` — the `p2p` identifier is at the start.
+#"suffix": `{topic}/p2p/{clientid}` — the `p2p` identifier is at the end.
+#"both": supports both prefix and suffix formats.
+mode = "prefix"

--- a/rmqtt-plugins/rmqtt-p2p-messaging/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-p2p-messaging/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rmqtt-p2p-messaging"
+version.workspace = true
+description = ""
+repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-p2p-messaging"
+edition.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+rmqtt = { workspace = true, features = ["plugin"] }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["sync"] }
+async-trait.workspace = true
+log.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+
+

--- a/rmqtt-plugins/rmqtt-p2p-messaging/src/config.rs
+++ b/rmqtt-plugins/rmqtt-p2p-messaging/src/config.rs
@@ -1,0 +1,82 @@
+use serde::de::{self, Deserializer};
+use serde::ser::{self};
+use serde::{Deserialize, Serialize};
+
+use rmqtt::Result;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PluginConfig {
+    /// P2P message routing mode.
+    ///
+    /// Determines where the `p2p` segment appears in the MQTT topic when sending
+    /// peer-to-peer messages.
+    ///
+    /// Modes:
+    /// - `"prefix"`: `p2p/{clientid}/{topic}` — the `p2p` identifier is at the start.
+    /// - `"suffix"`: `{topic}/p2p/{clientid}` — the `p2p` identifier is at the end.
+    /// - `"both"`: supports both prefix and suffix formats.
+    ///
+    /// Default: `"prefix"`.
+    #[serde(
+        default = "PluginConfig::mode_default",
+        serialize_with = "PluginConfig::serialize_mode",
+        deserialize_with = "PluginConfig::deserialize_mode"
+    )]
+    pub mode: Mode,
+}
+
+impl PluginConfig {
+    /// Returns the default P2P mode (`Prefix`).
+    #[inline]
+    fn mode_default() -> Mode {
+        Mode::Prefix
+    }
+
+    /// Serializes the `Mode` enum into a string for JSON.
+    #[inline]
+    fn serialize_mode<S>(enc: &Mode, s: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let enc_str = match enc {
+            Mode::Prefix => "prefix",
+            Mode::Suffix => "suffix",
+            Mode::Both => "both",
+        };
+        enc_str.serialize(s)
+    }
+
+    /// Deserializes a string into the `Mode` enum from JSON.
+    ///
+    /// Only `"prefix"`, `"suffix"`, or `"both"` are valid. Others will return an error.
+    #[inline]
+    fn deserialize_mode<'de, D>(deserializer: D) -> std::result::Result<Mode, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let enc: String = String::deserialize(deserializer)?;
+        match enc.as_str() {
+            "prefix" => Ok(Mode::Prefix),
+            "suffix" => Ok(Mode::Suffix),
+            "both" => Ok(Mode::Both),
+            _ => Err(de::Error::custom("Invalid mode, only 'prefix', 'suffix', or 'both' are supported.")),
+        }
+    }
+
+    /// Converts the configuration into a `serde_json::Value`.
+    #[inline]
+    pub fn to_json(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::to_value(self)?)
+    }
+}
+
+/// P2P message routing mode enum.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Mode {
+    /// `p2p` at the beginning of the topic.
+    Prefix,
+    /// `p2p` at the end of the topic.
+    Suffix,
+    /// Both prefix and suffix formats are supported.
+    Both,
+}

--- a/rmqtt-plugins/rmqtt-p2p-messaging/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-p2p-messaging/src/lib.rs
@@ -1,0 +1,158 @@
+#![deny(unsafe_code)]
+
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use rmqtt::{
+    context::ServerContext,
+    hook::{Handler, HookResult, Parameter, Register, ReturnType, Type},
+    macros::Plugin,
+    plugin::{PackageInfo, Plugin},
+    register,
+    types::TopicName,
+    Result,
+};
+
+use crate::config::Mode;
+use config::PluginConfig;
+use rmqtt::types::ClientId;
+
+mod config;
+
+register!(P2PMessagingPlugin::new);
+
+#[derive(Plugin)]
+struct P2PMessagingPlugin {
+    scx: ServerContext,
+    register: Box<dyn Register>,
+    cfg: Arc<RwLock<PluginConfig>>,
+}
+
+impl P2PMessagingPlugin {
+    #[inline]
+    async fn new<N: Into<String>>(scx: ServerContext, name: N) -> Result<Self> {
+        let name = name.into();
+        let cfg = scx.plugins.read_config_default::<PluginConfig>(&name)?;
+        let cfg = Arc::new(RwLock::new(cfg));
+        log::info!("{} P2PMessagingPlugin cfg: {:?}", name, cfg.read().await);
+        let register = scx.extends.hook_mgr().register();
+        Ok(Self { scx, register, cfg })
+    }
+}
+
+#[async_trait]
+impl Plugin for P2PMessagingPlugin {
+    #[inline]
+    async fn init(&mut self) -> Result<()> {
+        log::info!("{} init", self.name());
+        let cfg = &self.cfg;
+        self.register.add(Type::MessagePublish, Box::new(P2PMessagingHandler::new(cfg))).await;
+        Ok(())
+    }
+
+    #[inline]
+    async fn get_config(&self) -> Result<serde_json::Value> {
+        self.cfg.read().await.to_json()
+    }
+
+    #[inline]
+    async fn load_config(&mut self) -> Result<()> {
+        let new_cfg = self.scx.plugins.read_config::<PluginConfig>(self.name())?;
+        *self.cfg.write().await = new_cfg;
+        log::debug!("load_config ok,  {:?}", self.cfg);
+        Ok(())
+    }
+
+    #[inline]
+    async fn start(&mut self) -> Result<()> {
+        log::info!("{} start", self.name());
+        self.register.start().await;
+        Ok(())
+    }
+
+    #[inline]
+    async fn stop(&mut self) -> Result<bool> {
+        log::info!("{} stop", self.name());
+        self.register.stop().await;
+        Ok(false)
+    }
+}
+
+#[derive(Debug)]
+struct P2PMatch {
+    clientid: String,
+    topic: String,
+}
+
+struct P2PMessagingHandler {
+    cfg: Arc<RwLock<PluginConfig>>,
+}
+
+impl P2PMessagingHandler {
+    fn new(cfg: &Arc<RwLock<PluginConfig>>) -> Self {
+        Self { cfg: cfg.clone() }
+    }
+
+    #[inline]
+    async fn parse_p2p_topic(&self, topic: &str) -> Result<Option<P2PMatch>> {
+        let cfg = self.cfg.read().await;
+        let mode = cfg.mode;
+        let parts: Vec<&str> = topic.split('/').collect();
+
+        let p2p_match = match mode {
+            Mode::Prefix | Mode::Both if parts.len() >= 3 && parts[0] == "p2p" => {
+                Some(P2PMatch { clientid: parts[1].to_string(), topic: parts[2..].join("/") })
+            }
+            Mode::Suffix | Mode::Both if parts.len() >= 3 && parts[parts.len() - 2] == "p2p" => {
+                let clientid = parts
+                    .last()
+                    .ok_or_else(|| anyhow!("Invalid topic format, clientid not found: {topic:?}"))?;
+                Some(P2PMatch { clientid: clientid.to_string(), topic: parts[..parts.len() - 2].join("/") })
+            }
+            _ => None,
+        };
+
+        if let Some(ref m) = p2p_match {
+            if m.clientid.is_empty() {
+                return Err(anyhow!("Invalid topic format, clientid not found: {topic:?}"));
+            }
+            if m.topic.is_empty() {
+                return Err(anyhow!("Invalid topic format, sub topic not found: {topic:?}"));
+            }
+        }
+
+        Ok(p2p_match)
+    }
+}
+
+#[async_trait]
+impl Handler for P2PMessagingHandler {
+    async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
+        match param {
+            Parameter::MessagePublish(s, _f, p) => {
+                log::debug!("{:?} MessagePublish ..", s.map(|s| &s.id));
+
+                match self.parse_p2p_topic(&p.topic).await {
+                    Ok(Some(p2p_match)) => {
+                        log::debug!("{p2p_match:?}");
+                        let mut p1 = (*p).clone();
+                        p1.topic = TopicName::from(p2p_match.topic);
+                        p1.target_clientid = Some(ClientId::from(p2p_match.clientid));
+                        return (true, Some(HookResult::Publish(p1)));
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        log::warn!("{e:?}");
+                    }
+                }
+            }
+            _ => {
+                log::error!("parameter is: {param:?}");
+            }
+        }
+        (true, acc)
+    }
+}

--- a/rmqtt-plugins/src/lib.rs
+++ b/rmqtt-plugins/src/lib.rs
@@ -100,6 +100,9 @@ pub use rmqtt_topic_rewrite as topic_rewrite;
 #[cfg(feature = "web-hook")]
 pub use rmqtt_web_hook as web_hook;
 
+#[cfg(feature = "p2p-messaging")]
+pub use rmqtt_p2p_messaging as p2p_messaging;
+
 // ---- Cluster Plugins ----
 #[cfg(feature = "cluster-raft")]
 pub use rmqtt_cluster_raft as cluster_raft;

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -88,6 +88,7 @@ plugins.default_startups = [
     #"rmqtt-bridge-egress-nats",
     #"rmqtt-bridge-egress-reductstore",
     #"rmqtt-web-hook",
+    #"rmqtt-p2p-messaging",
     "rmqtt-http-api"
 ]
 

--- a/rmqtt/examples/plugins/src/main.rs
+++ b/rmqtt/examples/plugins/src/main.rs
@@ -10,6 +10,7 @@ async fn main() -> Result<()> {
     rmqtt_plugins::acl::register(&scx, true, false).await?;
     rmqtt_plugins::http_api::register(&scx, true, false).await?;
     rmqtt_plugins::retainer::register(&scx, true, false).await?;
+    rmqtt_plugins::p2p_messaging::register(&scx, true, false).await?;
     // rmqtt_plugins::sys_topic::register(&scx, true, false).await?;
     // rmqtt_plugins::message_storage::register(&scx, true, false).await?;
 


### PR DESCRIPTION
Introduces a new peer-to-peer messaging plugin to the RMQTT ecosystem.

**Changes Made:**
* Added new plugin dependency `rmqtt-p2p-messaging` in workspace Cargo.toml
* Updated plugin version to 0.16.0 in package metadata
* Included the plugin in rmqtt-bin executable dependencies
* Added plugin to plugins Cargo.toml features (full and p2p-messaging)
* Registered plugin in plugins library exports
* Added plugin to default startup configuration in rmqtt.toml
* Included plugin registration example in plugins example code

**Files Modified:**
* Cargo.toml - Added new plugin dependency
* rmqtt-bin/Cargo.toml - Added plugin to binary dependencies
* rmqtt-plugins/Cargo.toml - Added plugin feature flags
* rmqtt-plugins/src/lib.rs - Added plugin module export
* rmqtt.toml - Added plugin to default startup list
* rmqtt/examples/plugins/src/main.rs - Added plugin registration example

This new plugin enables peer-to-peer messaging capabilities within the RMQTT broker ecosystem.