### PR TITLE
docs: update version to 0.16.0 and add p2p-messaging documentation

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -38,6 +38,7 @@
 - [Reductstore桥接-出口模式](./docs/zh_CN/bridge-egress-reductstore.md)
 - [主题重写](./docs/zh_CN/topic-rewrite.md)
 - [自动订阅](./docs/zh_CN/auto-subscription.md)
+- [P2P 消息传递](./docs/zh_CN/p2p-messaging.md)
 - 共享订阅($share/{Group}/{TopicFilter});
 - 排它订阅($exclusive/{TopicFilter});
 - 限制订阅($limit/{LimitQuantity}/{TopicFilter});
@@ -111,7 +112,7 @@ curl "http://127.0.0.1:6066/api/v1/health/check"
 
 ```toml
 [dependencies]
-rmqtt = "0.15"
+rmqtt = "0.16"
 ```
 
 更多关于库模式的使用说明，请参考 [RMQTT 库使用文档](./rmqtt/README.md) 。

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ and mobile applications that can handle millions of concurrent clients on a sing
 - [Reductstore Bridging - Egress Mode](./docs/en_US/bridge-egress-reductstore.md)
 - [Topic Rewrite](./docs/en_US/topic-rewrite.md)
 - [Auto Subscription](./docs/en_US/auto-subscription.md)
+- [P2P Messaging](./docs/en_US/p2p-messaging.md)
 - Shared subscription($share/{Group}/{TopicFilter});
 - Exclusive subscription($exclusive/{TopicFilter});
 - Limit subscription($limit/{LimitQuantity}/{TopicFilter});
@@ -114,7 +115,7 @@ In addition to running as a standalone MQTT Broker/Server, rmqtt also provides a
 
 ```toml
 [dependencies]
-rmqtt = "0.15"
+rmqtt = "0.16"
 ```
 
 For more details about using rmqtt in library mode, please refer to the [RMQTT Library Documentation](./rmqtt/README.md).

--- a/docs/en_US/p2p-messaging.md
+++ b/docs/en_US/p2p-messaging.md
@@ -1,0 +1,87 @@
+English | [简体中文](../zh_CN/p2p-messaging.md)
+
+# P2P Messaging
+
+The *rmqtt-p2p-messaging* plugin provides point-to-point (P2P) messaging support.
+Clients can deliver messages directly to a target client using special topic rules, without requiring the target client to explicitly subscribe.
+
+The plugin automatically parses the `clientid` from the topic according to the configured rules and routes the message to the correct client.
+
+---
+
+#### Configure P2P Messaging Rules
+
+The topic format for P2P messaging is defined by the plugin configuration. Three modes are supported:
+
+* **prefix**: `p2p/{clientid}/{topic}` — the `p2p` identifier is at the start.
+* **suffix**: `{topic}/p2p/{clientid}` — the `p2p` identifier is at the end.
+* **both**: supports both prefix and suffix formats.
+
+Where:
+
+* `{clientid}` is the target client ID.
+* `{topic}` is the actual business topic.
+
+Examples:
+
+* `p2p/device001/sensor/temp` → sends to client `device001` with topic `sensor/temp`
+* `sensor/temp/p2p/device001` → sends to client `device001` with topic `sensor/temp`
+
+---
+
+#### Plugin:
+
+```bash
+rmqtt-p2p-messaging
+```
+
+---
+
+#### Plugin configuration file:
+
+```bash
+plugins/rmqtt-p2p-messaging.toml
+```
+
+---
+
+#### Plugin configuration options:
+
+```bash
+##--------------------------------------------------------------------
+## rmqtt-p2p-messaging
+##--------------------------------------------------------------------
+
+#"prefix": `p2p/{clientid}/{topic}` — the `p2p` identifier is at the start.
+#"suffix": `{topic}/p2p/{clientid}` — the `p2p` identifier is at the end.
+#"both": supports both prefix and suffix formats.
+mode = "prefix"
+```
+
+---
+
+#### Enable the plugin
+
+By default, this plugin is not enabled.
+To enable it, you must add `rmqtt-p2p-messaging` to the `plugins.default_startups` section in the main configuration file `rmqtt.toml`, for example:
+
+```bash
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+#Plug in configuration file directory
+plugins.dir = "rmqtt-plugins/"
+#Plug in started by default, when the mqtt server is started
+plugins.default_startups = [
+    #"rmqtt-retainer",
+    #"rmqtt-auth-http",
+    #"rmqtt-cluster-broadcast",
+    #"rmqtt-cluster-raft",
+    #"rmqtt-sys-topic",
+    #"rmqtt-message-storage",
+    #"rmqtt-session-storage",
+    "rmqtt-p2p-messaging",
+    "rmqtt-web-hook",
+    "rmqtt-http-api"
+]
+```

--- a/docs/zh_CN/p2p-messaging.md
+++ b/docs/zh_CN/p2p-messaging.md
@@ -1,0 +1,87 @@
+[English](../en_US/p2p-messaging.md)  | 简体中文
+
+# P2P 消息传递
+
+*rmqtt-p2p-messaging* 插件用于支持点对点（P2P）消息传递机制。
+客户端可以通过特定的主题规则直接向目标客户端发送消息，而无需目标客户端显式订阅。
+
+该插件会根据配置的规则自动解析主题中的 `clientid`，并将消息投递到对应客户端。
+
+---
+
+#### 配置 P2P 消息规则
+
+P2P 消息的主题格式由插件配置决定，支持三种模式：
+
+* **prefix 模式**：`p2p/{clientid}/{topic}`
+* **suffix 模式**：`{topic}/p2p/{clientid}`
+* **both 模式**：同时支持 `prefix` 和 `suffix` 两种格式
+
+其中：
+
+* `{clientid}` 表示目标客户端 ID。
+* `{topic}` 表示实际的业务主题。
+
+示例：
+
+* `p2p/device001/sensor/temp`  → 发送给 `device001` 的主题 `sensor/temp`
+* `sensor/temp/p2p/device001` → 发送给 `device001` 的主题 `sensor/temp`
+
+---
+
+#### 插件：
+
+```bash
+rmqtt-p2p-messaging
+```
+
+---
+
+#### 插件配置文件：
+
+```bash
+plugins/rmqtt-p2p-messaging.toml
+```
+
+---
+
+#### 插件配置项：
+
+```bash
+##--------------------------------------------------------------------
+## rmqtt-p2p-messaging
+##--------------------------------------------------------------------
+
+#"prefix": `p2p/{clientid}/{topic}` — the `p2p` identifier is at the start.
+#"suffix": `{topic}/p2p/{clientid}` — the `p2p` identifier is at the end.
+#"both": supports both prefix and suffix formats.
+mode = "prefix"
+```
+
+---
+
+#### 启用插件
+
+默认情况下此插件并不会启动，如果要开启此插件，必须在主配置文件 `rmqtt.toml` 中的 `plugins.default_startups` 配置中添加 `rmqtt-p2p-messaging` 项，如：
+
+```bash
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+#Plug in configuration file directory
+plugins.dir = "rmqtt-plugins/"
+#Plug in started by default, when the mqtt server is started
+plugins.default_startups = [
+    #"rmqtt-retainer",
+    #"rmqtt-auth-http",
+    #"rmqtt-cluster-broadcast",
+    #"rmqtt-cluster-raft",
+    #"rmqtt-sys-topic",
+    #"rmqtt-message-storage",
+    #"rmqtt-session-storage",
+    "rmqtt-p2p-messaging",
+    "rmqtt-web-hook",
+    "rmqtt-http-api"
+]
+```
+

--- a/rmqtt/README.md
+++ b/rmqtt/README.md
@@ -24,7 +24,7 @@ A basic MQTT server with RMQTT.
 
 ```toml
 [dependencies]
-rmqtt = "0.15"
+rmqtt = "0.16"
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"
@@ -58,7 +58,7 @@ Make sure you included the rmqtt crate with the required features in your Cargo.
 
 ```toml
 [dependencies]
-rmqtt = { version = "0.15", features = ["ws", "tls"] }
+rmqtt = { version = "0.16", features = ["ws", "tls"] }
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"
@@ -111,8 +111,8 @@ Make sure you included the rmqtt crate with the required features in your Cargo.
 
 ```toml
 [dependencies]
-rmqtt = { version = "0.15", features = ["plugin"] }
-rmqtt-plugins = { version = "0.15", features = ["full"] }
+rmqtt = { version = "0.16", features = ["plugin"] }
+rmqtt-plugins = { version = "0.16", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"
@@ -153,8 +153,8 @@ or
 
 ```toml
 [dependencies]
-rmqtt = { version = "0.15", features = ["plugin"] }
-rmqtt-plugins = { version = "0.15", features = ["full"] }
+rmqtt = { version = "0.16", features = ["plugin"] }
+rmqtt-plugins = { version = "0.16", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"
@@ -206,11 +206,11 @@ or
 
 ```toml
 [dependencies]
-rmqtt = { version = "0.15", features = ["plugin"] }
-rmqtt-acl = "0.15"
-rmqtt-retainer = "0.15"
-rmqtt-http-api = "0.15"
-rmqtt-web-hook = "0.15"
+rmqtt = { version = "0.16", features = ["plugin"] }
+rmqtt-acl = "0.16"
+rmqtt-retainer = "0.16"
+rmqtt-http-api = "0.16"
+rmqtt-web-hook = "0.16"
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"


### PR DESCRIPTION
**Changes Made:**

1. **Version Update:**
   - Updated all version references from 0.15.0 to 0.16.0 across documentation files
   - Affected files: README-CN.md, README.md, rmqtt/README.md

2. **New Feature Documentation:**
   - Added P2P Messaging plugin to feature lists in both Chinese and English READMEs
   - Added documentation links for P2P Messaging feature:
     * Chinese: `./docs/zh_CN/p2p-messaging.md`
     * English: `./docs/en_US/p2p-messaging.md`

3. **Documentation Structure:**
   - Maintained consistent formatting with existing plugin documentation
   - Added P2P Messaging to the plugin features list alongside other plugins

**Files Modified:**
* README-CN.md - Updated version and added Chinese P2P messaging docs
* README.md - Updated version and added English P2P messaging docs
* rmqtt/README.md - Updated version references in library usage examples

This update prepares for the 0.16.0 release and documents the new P2P messaging capability.