### PR TITLE
chore(net): bump version from 0.1.5 to 0.2.0

### DIFF
--- a/rmqtt-net/Cargo.toml
+++ b/rmqtt-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-net"
-version = "0.1.5"
+version = "0.2.0"
 description = "Basic Implementation of MQTT Server"
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-net"
 edition.workspace = true


### PR DESCRIPTION
Updated the version of rmqtt-net crate to 0.2.0 to reflect API changes and new functionality.