### PR TITLE
chore(deps): update rmqtt-net dependency to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 rmqtt = "0.16.0"
 rmqtt-codec = "0.2"
-rmqtt-net = "0.1"
+rmqtt-net = "0.2"
 rmqtt-conf = "0.1"
 rmqtt-macros = "0.1"
 rmqtt-utils = "0.1"


### PR DESCRIPTION
Updated the rmqtt-net workspace dependency from 0.1 to 0.2 to match the recent version bump.