### PR TITLE
docs(p2p-messaging): add comprehensive plugin description

### DIFF
--- a/rmqtt-plugins/rmqtt-p2p-messaging/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-p2p-messaging/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rmqtt-p2p-messaging"
 version.workspace = true
-description = ""
+description = "An rmqtt plugin that provides point-to-point (P2P) messaging support, enabling direct message delivery between clients using configurable topic patterns."
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-p2p-messaging"
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Added detailed description for the P2P messaging plugin to clearly communicate its functionality: "An rmqtt plugin that provides point-to-point (P2P) messaging support, enabling direct message delivery between clients using configurable topic patterns."