### PR TITLE
chore(conf): bump version from 0.1.1 to 0.2.0

### DIFF
--- a/rmqtt-conf/Cargo.toml
+++ b/rmqtt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-conf"
-version = "0.1.1"
+version = "0.2.0"
 description = "Centralized configuration management system for RMQTT MQTT broker"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Updated rmqtt-conf crate version to 0.2.0 to reflect configuration management system improvements.