### PR TITLE
chore(deps): update rmqtt-conf dependency to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rust-version = "1.85.0"
 rmqtt = "0.16.0"
 rmqtt-codec = "0.2"
 rmqtt-net = "0.2"
-rmqtt-conf = "0.1"
+rmqtt-conf = "0.2"
 rmqtt-macros = "0.1"
 rmqtt-utils = "0.1"
 


### PR DESCRIPTION
Updated the rmqtt-conf workspace dependency from 0.1 to 0.2 to match the recent version bump.