### PR TITLE
feat: add NATS ingress bridge support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ rmqtt-bridge-ingress-kafka = { path = "rmqtt-plugins/rmqtt-bridge-ingress-kafka"
 rmqtt-bridge-egress-kafka = { path = "rmqtt-plugins/rmqtt-bridge-egress-kafka" }
 rmqtt-bridge-ingress-pulsar = { path = "rmqtt-plugins/rmqtt-bridge-ingress-pulsar"}
 rmqtt-bridge-egress-pulsar = { path = "rmqtt-plugins/rmqtt-bridge-egress-pulsar"}
+rmqtt-bridge-ingress-nats = { path = "rmqtt-plugins/rmqtt-bridge-ingress-nats"}
 rmqtt-bridge-egress-nats = { path = "rmqtt-plugins/rmqtt-bridge-egress-nats"}
 rmqtt-bridge-egress-reductstore = { path = "rmqtt-plugins/rmqtt-bridge-egress-reductstore"}
 rmqtt-p2p-messaging = { path = "rmqtt-plugins/rmqtt-p2p-messaging"}
@@ -83,6 +84,7 @@ rmqtt-bridge-egress-mqtt = "0.17.0"
 rmqtt-bridge-ingress-mqtt = "0.17.0"
 rmqtt-bridge-ingress-pulsar = "0.17.0"
 rmqtt-bridge-egress-pulsar = "0.17.0"
+rmqtt-bridge-ingress-nats = "0.17.0"
 rmqtt-bridge-egress-nats = "0.17.0"
 rmqtt-bridge-egress-reductstore = "0.17.0"
 rmqtt-message-storage = "0.17.0"

--- a/README-CN.md
+++ b/README-CN.md
@@ -34,6 +34,7 @@
 - [Apache kafka桥接-出口模式](./docs/zh_CN/bridge-egress-kafka.md)
 - [Apache Pulsar桥接-入口模式](./docs/zh_CN/bridge-ingress-pulsar.md)
 - [Apache Pulsar桥接-出口模式](./docs/zh_CN/bridge-egress-pulsar.md)
+- [NATS桥接-入口模式](./docs/zh_CN/bridge-ingress-nats.md)
 - [NATS桥接-出口模式](./docs/zh_CN/bridge-egress-nats.md)
 - [Reductstore桥接-出口模式](./docs/zh_CN/bridge-egress-reductstore.md)
 - [主题重写](./docs/zh_CN/topic-rewrite.md)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ and mobile applications that can handle millions of concurrent clients on a sing
 - [Apache Kafka Bridging - Egress Mode](./docs/en_US/bridge-egress-kafka.md)
 - [Apache Pulsar Bridging - Ingress Mode](./docs/en_US/bridge-ingress-pulsar.md)
 - [Apache Pulsar Bridging - Egress Mode](./docs/en_US/bridge-egress-pulsar.md)
+- [NATS Bridging - Ingress Mode](./docs/en_US/bridge-ingress-nats.md)
 - [NATS Bridging - Egress Mode](./docs/en_US/bridge-egress-nats.md)
 - [Reductstore Bridging - Egress Mode](./docs/en_US/bridge-egress-reductstore.md)
 - [Topic Rewrite](./docs/en_US/topic-rewrite.md)

--- a/rmqtt-bin/Cargo.toml
+++ b/rmqtt-bin/Cargo.toml
@@ -49,6 +49,7 @@ rmqtt-bridge-egress-mqtt.workspace = true
 rmqtt-bridge-ingress-mqtt.workspace = true
 rmqtt-bridge-egress-pulsar.workspace = true
 rmqtt-bridge-ingress-pulsar.workspace = true
+rmqtt-bridge-ingress-nats.workspace = true
 rmqtt-bridge-egress-nats.workspace = true
 rmqtt-bridge-egress-reductstore.workspace = true
 rmqtt-message-storage = { workspace = true, features = ["ram", "redis", "redis-cluster"] }
@@ -75,6 +76,7 @@ rmqtt-bridge-egress-mqtt = { }
 rmqtt-bridge-ingress-mqtt = { }
 rmqtt-bridge-egress-pulsar = { }
 rmqtt-bridge-ingress-pulsar = { }
+rmqtt-bridge-ingress-nats = { }
 rmqtt-bridge-egress-nats = { }
 rmqtt-bridge-egress-reductstore = { }
 rmqtt-message-storage = { immutable = true }

--- a/rmqtt-plugins/Cargo.toml
+++ b/rmqtt-plugins/Cargo.toml
@@ -39,6 +39,7 @@ full = [
     "bridge-ingress-mqtt",
     "bridge-egress-pulsar",
     "bridge-ingress-pulsar",
+    "bridge-ingress-nats",
     "bridge-egress-nats",
     "bridge-egress-reductstore",
     "p2p-messaging",
@@ -82,6 +83,7 @@ bridge-egress-mqtt = ["rmqtt-bridge-egress-mqtt"]
 bridge-ingress-mqtt = ["rmqtt-bridge-ingress-mqtt"]
 bridge-egress-pulsar = ["rmqtt-bridge-egress-pulsar"]
 bridge-ingress-pulsar = ["rmqtt-bridge-ingress-pulsar"]
+bridge-ingress-nats = ["rmqtt-bridge-ingress-nats"]
 bridge-egress-nats = ["rmqtt-bridge-egress-nats"]
 bridge-egress-reductstore = ["rmqtt-bridge-egress-reductstore"]
 
@@ -109,6 +111,7 @@ rmqtt-bridge-egress-mqtt = { workspace = true, optional = true }
 rmqtt-bridge-ingress-mqtt = { workspace = true, optional = true }
 rmqtt-bridge-egress-pulsar = { workspace = true, optional = true }
 rmqtt-bridge-ingress-pulsar = { workspace = true, optional = true }
+rmqtt-bridge-ingress-nats = { workspace = true, optional = true }
 rmqtt-bridge-egress-nats = { workspace = true, optional = true }
 rmqtt-bridge-egress-reductstore = { workspace = true, optional = true }
 rmqtt-message-storage = { workspace = true, optional = true }

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -86,6 +86,7 @@ plugins.default_startups = [
     #"rmqtt-bridge-ingress-pulsar",
     #"rmqtt-auth-jwt",
     #"rmqtt-bridge-egress-nats",
+    #"rmqtt-bridge-ingress-nats",
     #"rmqtt-bridge-egress-reductstore",
     #"rmqtt-web-hook",
     #"rmqtt-p2p-messaging",


### PR DESCRIPTION
* Add new rmqtt-bridge-ingress-nats plugin to workspace dependencies
* Include NATS ingress bridge in plugin features and default startup configuration
* Update both Chinese and English documentation to include NATS ingress bridge
* Add NATS ingress to binary and plugin configuration files
* Maintain version consistency at 0.17.0 for all dependencies