### PR TITLE
fix(queue): correct queue capacity check in push operation

### DIFF
--- a/rmqtt/src/queue.rs
+++ b/rmqtt/src/queue.rs
@@ -220,7 +220,7 @@ impl<T> Queue<T> {
     #[inline]
     pub fn push(&self, v: T) -> Result<(), T> {
         let mut inner = self.inner.lock();
-        if inner.len() > self.cap {
+        if inner.len() >= self.cap {
             return Err(v);
         }
         if let Some(f) = self.on_push_fn.as_ref() {


### PR DESCRIPTION
* Change capacity check from `>` to `>=` to properly handle full queue condition
* This prevents exceeding the intended queue capacity by one element
* Maintains existing error handling and callback functionality