### PR TITLE
docs: add detailed documentation links for MQTT protocol features

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -14,8 +14,8 @@
 
 - 100% Rust安全编码;
 - 基于 [tokio](https://crates.io/crates/tokio) 开发;
-- 支持MQTT v3.1,v3.1.1 及 v5.0协议;
-    - QoS0, QoS1, QoS2 消息支持;
+- [支持MQTT v3.1,v3.1.1 及 v5.0协议](./docs/zh_CN/mqtt-protocol.md);
+    - [QoS0, QoS1, QoS2 消息支持](./docs/zh_CN/mqtt-protocol.md#41-qos-说明);
     - [离线消息支持](./docs/zh_CN/offline-message.md);
     - [Retained 消息支持](./docs/zh_CN/retainer.md);
     - Last Will 消息支持;

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ and mobile applications that can handle millions of concurrent clients on a sing
 
 - 100% Rust safe code;
 - Based on [tokio](https://crates.io/crates/tokio);
-- MQTT v3.1, v3.1.1 and v5.0 protocols support;
-    - QoS0, QoS1, QoS2 message support;
+- [MQTT v3.1, v3.1.1 and v5.0 protocols support](./docs/en_US/mqtt-protocol.md);
+    - [QoS0, QoS1, QoS2 message support](./docs/en_US/mqtt-protocol.md#41-qos-levels);
     - [Offline message support](./docs/en_US/offline-message.md);
     - [Retained message support](./docs/en_US/retainer.md);
     - Last Will message support;

--- a/docs/en_US/mqtt-protocol.md
+++ b/docs/en_US/mqtt-protocol.md
@@ -1,0 +1,160 @@
+English | [简体中文](../zh_CN/mqtt-protocol.md)
+
+# MQTT Protocol Documentation
+
+## 1. Protocol Versions and Official Documentation
+
+RMQTT supports the following MQTT protocol versions and strictly follows the official specifications to ensure standardized message exchange between clients and the server while maintaining cross-version compatibility:
+
+| Version    | Official English Documentation                                                                                | Chinese Documentation                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| MQTT 3.1   | [MQTT V3.1 Protocol Specification](https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html) | [MQTT 3.1 中文版](https://mqtt.p2hp.com/mqtt311)   |
+| MQTT 3.1.1 | [MQTT Version 3.1.1](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html)                     | [MQTT 3.1.1 中文版](https://mqtt.p2hp.com/mqtt311) |
+| MQTT 5.0   | [MQTT Version 5.0](https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html)                                 | [MQTT 5.0 中文版](https://mqtt.p2hp.com/mqtt-5-0)  |
+
+---
+
+## 2. Connect Packet (CONNECT)
+
+* Clients initiate a connection with the server using the **CONNECT** packet.
+* Key fields include:
+
+    * `Client Identifier`: unique client ID
+    * `Username` / `Password` (optional)
+    * `Keep Alive`: heartbeat interval used by the server to check client activity
+    * `Clean Session` / `Clean Start` (MQTT 5.0)
+    * `Will Message` (optional last will message)
+    * MQTT 5.0 optional fields: `Authentication Method`, `Authentication Data`
+
+The server responds with a **CONNACK** packet, indicating the connection result, session status, and optional protocol-level error codes (Reason Codes).
+
+---
+
+## 3. Subscribe and Unsubscribe
+
+### 3.1 Subscribe (SUBSCRIBE)
+
+* Clients subscribe to topics to receive messages.
+
+* Packet fields include:
+
+    * List of topic filters
+    * QoS level (0, 1, 2)
+    * MQTT 5.0 may include User Properties
+
+* The server responds with **SUBACK**, confirming the subscription result and return codes for each topic.
+
+* Supports **Shared Subscriptions**, allowing multiple clients to consume messages from the same topic collaboratively.
+
+### 3.2 Unsubscribe (UNSUBSCRIBE)
+
+* Clients can unsubscribe from one or more topics.
+* The server responds with **UNSUBACK**, confirming the unsubscription.
+
+---
+
+## 4. Publish Messages (PUBLISH)
+
+* Clients or the server send messages to a topic.
+* Key fields:
+
+    * Topic Name
+    * Payload
+    * QoS (0 / 1 / 2)
+    * Retain flag (whether the message should be retained)
+    * MQTT 5.0 optional fields: `Message Expiry Interval`, `Content Type`, `User Properties`, `Response Topic`
+
+### 4.1 QoS Levels
+
+| QoS | Description   |
+| --- | ------------- |
+| 0   | At most once  |
+| 1   | At least once |
+| 2   | Exactly once  |
+
+* QoS 1 and 2 involve acknowledgment flows (PUBACK, PUBREC / PUBREL / PUBCOMP).
+* Retained messages: the server stores the last message with the Retain flag; new subscribers receive it immediately.
+
+### 4.2 Offline Messages and Expiry
+
+* RMQTT supports **offline message queues**: QoS 1/2 messages are stored when clients are offline.
+* `Message Expiry Interval` controls the message lifetime in the queue.
+* Session queue length is configurable; when exceeded, **old messages are discarded** to prevent unbounded accumulation.
+
+---
+
+## 5. Session and State
+
+* **Clean Session / Clean Start** determines session persistence.
+* **Persistent Session**: subscription info and undelivered QoS 1/2 messages are retained.
+* **Non-Persistent Session**: the server does not retain any messages after client disconnect.
+* **Will Message**: published by the server if the client disconnects unexpectedly.
+* **Session Reconnection**: persistent session state, including offline messages, can be restored when the client reconnects.
+
+---
+
+## 6. Retained and Will Messages
+
+* **Retained Messages**: the server stores the last message of a topic; new subscribers receive it immediately.
+* **Will Messages**: sent by the server when a client disconnects unexpectedly.
+* Note: only the most recent retained message is stored; older ones are overwritten.
+
+---
+
+## 7. Topics and Wildcards
+
+* Topic levels are separated by `/`, e.g., `home/kitchen/temperature`.
+
+* Wildcards:
+
+    * `+`: single-level wildcard, matches one topic level
+    * `#`: multi-level wildcard, matches the current and all sub-levels
+
+* Shared subscription topic format: `$share/<group>/<topic>`
+
+---
+
+## 8. MQTT 5.0 New Features
+
+* **User Properties**: custom metadata
+* **Topic Alias**: reduce packet size
+* **Message Expiry Interval**
+* **Response Information**
+* **Server Reference**
+* **Maximum Packet Size**
+* **Request/Response Pattern**
+* **Shared Subscription**
+* **Enhanced Reason Codes**: finer-grained operation feedback
+
+---
+
+## 9. Packet Overview
+
+| Packet Type | Description                                     |
+| ----------- | ----------------------------------------------- |
+| CONNECT     | Establish a connection                          |
+| CONNACK     | Connection acknowledgment                       |
+| PUBLISH     | Publish message                                 |
+| PUBACK      | QoS 1 message acknowledgment                    |
+| PUBREC      | QoS 2 message received                          |
+| PUBREL      | QoS 2 message release                           |
+| PUBCOMP     | QoS 2 message complete                          |
+| SUBSCRIBE   | Subscribe to topics                             |
+| SUBACK      | Subscription acknowledgment                     |
+| UNSUBSCRIBE | Unsubscribe from topics                         |
+| UNSUBACK    | Unsubscription acknowledgment                   |
+| PINGREQ     | Heartbeat request                               |
+| PINGRESP    | Heartbeat response                              |
+| DISCONNECT  | Client disconnect                               |
+| AUTH        | MQTT 5.0 Authentication/Authorization extension |
+
+---
+
+## 10. Error Handling and Reconnection Strategy
+
+* RMQTT provides detailed **error codes** for connection exceptions.
+* Clients can use returned codes to **reconnect or adjust parameters**.
+* Supports **automatic reconnection**, with configurable retry intervals and maximum attempts.
+* Subscription or publish failures return corresponding **Reason Codes**.
+
+---

--- a/docs/zh_CN/mqtt-protocol.md
+++ b/docs/zh_CN/mqtt-protocol.md
@@ -1,0 +1,161 @@
+[English](../en_US/mqtt-protocol.md)  | 简体中文
+
+# MQTT 协议文档
+
+## 1. 协议版本与官方文档
+
+RMQTT 支持以下 MQTT 协议版本，并严格遵循官方规范，确保客户端与服务器之间的消息交换符合标准，同时保证跨版本兼容性：
+
+| 版本         | 官方英文版                                                                                                         | 中文版                                             |
+| ---------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| MQTT 3.1   | [MQTT V3.1 Protocol Specification](https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html) | [MQTT 3.1 中文版](https://mqtt.p2hp.com/mqtt311)   |
+| MQTT 3.1.1 | [MQTT Version 3.1.1](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html)                     | [MQTT 3.1.1 中文版](https://mqtt.p2hp.com/mqtt311) |
+| MQTT 5.0   | [MQTT Version 5.0](https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html)                                 | [MQTT 5.0 中文版](https://mqtt.p2hp.com/mqtt-5-0)  |
+
+---
+
+## 2. 连接报文（CONNECT）
+
+* 客户端通过 **CONNECT** 报文向服务器发起连接请求。
+* 报文包含以下关键字段：
+
+    * `Client Identifier`：客户端唯一标识
+    * `Username` / `Password`（可选）
+    * `Keep Alive`：心跳间隔，服务器根据此间隔检查客户端活跃状态
+    * `Clean Session` / `Clean Start`（MQTT 5.0）
+    * `Will Message`（可选遗嘱消息）
+    * MQTT 5.0 可选字段：`Authentication Method`、`Authentication Data`
+
+服务器响应 **CONNACK** 报文，返回连接结果、会话状态以及可选的协议级错误码（Reason Code）。
+
+---
+
+## 3. 订阅与取消订阅
+
+### 3.1 订阅（SUBSCRIBE）
+
+* 客户端订阅主题以接收消息。
+
+* 报文包含：
+
+    * 主题列表（Topic Filter）
+    * QoS 等级（0、1、2）
+    * MQTT 5.0 可包含用户属性（User Properties）
+
+* 服务器返回 **SUBACK** 报文，确认订阅结果，包括每个主题的订阅状态码。
+
+* 支持 **共享订阅（Shared Subscription）**，多个客户端可共同消费同一主题消息。
+
+### 3.2 取消订阅（UNSUBSCRIBE）
+
+* 客户端可取消对一个或多个主题的订阅。
+* 服务器返回 **UNSUBACK** 报文确认操作结果。
+
+---
+
+## 4. 发布消息（PUBLISH）
+
+* 客户端或服务器发送消息到主题。
+* 关键字段：
+
+    * 主题（Topic Name）
+    * 消息负载（Payload）
+    * QoS（0 / 1 / 2）
+    * Retain 标志（是否保留消息）
+    * MQTT 5.0 可包含消息过期时间（Message Expiry Interval）、内容类型（Content Type）、用户属性（User Properties）、响应主题（Response Topic）
+
+### 4.1 QoS 说明
+
+| QoS | 描述                  |
+| --- | ------------------- |
+| 0   | 最多一次（At most once）  |
+| 1   | 至少一次（At least once） |
+| 2   | 仅一次（Exactly once）   |
+
+* QoS 1 和 2 会有相应的确认流程（PUBACK、PUBREC / PUBREL / PUBCOMP）
+* 保留消息（Retained Message）：服务器保存最后一条带 Retain 标志的消息，新订阅者可立即接收
+
+### 4.2 离线消息与过期
+
+* RMQTT 支持 **离线消息队列**：当客户端离线时，服务器可保存 QoS 1/2 消息
+* 消息过期时间（Message Expiry Interval）控制消息在队列中的存活时长
+* 会话队列长度可配置，超过长度时，旧消息将被丢弃以防无限积压
+
+---
+
+## 5. 会话与状态
+
+* **Clean Session / Clean Start** 控制会话持久化与否
+* **持久会话**：保存订阅信息与未发送的 QoS 1/2 消息
+* **非持久会话**：客户端断开后，服务器不保存任何消息
+* **遗嘱消息（Will Message）**：客户端异常断开时，由服务器发布指定消息
+* **会话重连**：客户端重连时，可恢复持久会话状态，包括未收到的离线消息
+
+---
+
+## 6. 保留消息与遗嘱消息
+
+* **保留消息（Retained Messages）**：服务器保存最后一条消息，新订阅者可立即收到
+* **遗嘱消息（Will Message）**：客户端异常断开时，服务器发布指定消息
+* **注意**：保留消息仅保存最后一条，旧消息会被覆盖
+
+---
+
+## 7. 主题与通配符
+
+* 主题层级以 `/` 分隔，如 `home/kitchen/temperature`
+
+* 通配符：
+
+    * `+`：单层通配符，匹配一层主题
+    * `#`：多层通配符，匹配该层及子层主题
+
+* 支持共享订阅主题格式 `$share/<group>/<topic>`
+
+---
+
+## 8. MQTT 5.0 新特性
+
+* **用户属性（User Properties）**：自定义元数据
+* **主题别名（Topic Alias）**：减少报文大小
+* **消息过期时间（Message Expiry Interval）**
+* **响应信息（Response Information）**
+* **服务器参考（Server Reference）**
+* **最大消息大小（Maximum Packet Size）**
+* **请求响应模式（Request/Response Pattern）**
+* **共享订阅（Shared Subscription）**
+* **增强错误码与原因码（Reason Codes）**：更精细的操作反馈
+
+---
+
+## 9. 报文格式概览
+
+| 报文类型        | 描述               |
+| ----------- | ---------------- |
+| CONNECT     | 建立客户端与服务器连接      |
+| CONNACK     | 连接确认             |
+| PUBLISH     | 发布消息             |
+| PUBACK      | QoS 1 消息确认       |
+| PUBREC      | QoS 2 消息接收确认     |
+| PUBREL      | QoS 2 消息释放       |
+| PUBCOMP     | QoS 2 消息完成确认     |
+| SUBSCRIBE   | 订阅主题             |
+| SUBACK      | 订阅确认             |
+| UNSUBSCRIBE | 取消订阅             |
+| UNSUBACK    | 取消订阅确认           |
+| PINGREQ     | 心跳请求             |
+| PINGRESP    | 心跳响应             |
+| DISCONNECT  | 客户端断开连接          |
+| AUTH        | MQTT 5.0 授权/认证扩展 |
+
+---
+
+## 10. 错误处理与重连策略
+
+* RMQTT 对连接异常提供详细 **错误码**
+* 客户端可根据返回码选择 **重连或调整参数**
+* 支持 **自动重连机制**，可配置重试间隔和最大次数
+* 订阅或发布失败可返回相应 **Reason Code**
+
+---
+


### PR DESCRIPTION
* Add documentation links for MQTT protocol support in both Chinese and English README
* Add specific anchor links for QoS levels explanation in protocol documentation
* Maintain consistent formatting with previous documentation improvements