### PR TITLE
fix(connection): improve connection closing and error handling

### DIFF
--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -197,6 +197,10 @@ impl SessionState {
         }
         self.scx.connections.dec();
 
+        if let Err(e) = sink.close().await {
+            log::info!("{} close io error, {e:?}", self.id);
+        }
+
         let disconnect = self.disconnect().await.unwrap_or(None);
         let clean_session = self.clean_session(disconnect.as_ref()).await;
 
@@ -257,8 +261,6 @@ impl SessionState {
             };
             let _ = s.send_disconnect(d).await;
         }
-
-        let _ = sink.close().await;
 
         self.hook.client_disconnected(reason).await;
 

--- a/rmqtt/src/v3.rs
+++ b/rmqtt/src/v3.rs
@@ -68,6 +68,9 @@ where
             Ok(c) => c,
             Err((ack_code, e)) => {
                 refused_ack_v3(&scx, &mut sink, None, ack_code, e.to_string()).await?;
+                if let Err(e) = sink.close().await {
+                    log::info!("{lid} close io error, {e:?}");
+                }
                 return Err(e);
             }
         };

--- a/rmqtt/src/v5.rs
+++ b/rmqtt/src/v5.rs
@@ -83,6 +83,9 @@ where
             Ok(c) => c,
             Err((ack_code, e)) => {
                 refused_ack(&scx, &mut sink, None, ack_code, e.to_string()).await?;
+                if let Err(e) = sink.close().await {
+                    log::info!("{lid} close io error, {e:?}");
+                }
                 return Err(e);
             }
         };


### PR DESCRIPTION
* Move sink.close() earlier in session termination process with proper error logging
* Add connection close with error logging when MQTT connection is refused in v3 and v5 protocols
* Maintain existing disconnect logic while ensuring proper resource cleanup
* Improve error visibility by logging IO close errors in connection refusal scenarios