### PR TITLE
feat(config): add environment variable support for MQTT bridge credentials #317

### DIFF
--- a/rmqtt-net/src/stream.rs
+++ b/rmqtt-net/src/stream.rs
@@ -147,6 +147,7 @@ pub mod v3 {
     ///     io: Framed::new(stream, MqttCodec::V3(Default::default())),
     ///     remote_addr: addr,
     ///     cfg: Arc::new(Builder::default()),
+    ///     cert_info: None,
     /// };
     ///
     /// // Send a PING request
@@ -364,6 +365,7 @@ pub mod v5 {
     ///     io: Framed::new(stream, MqttCodec::V5(Default::default())),
     ///     remote_addr: addr,
     ///     cfg: Arc::new(Builder::default()),
+    ///     cert_info: None
     /// };
     ///
     /// // Send authentication packet

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt.toml
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt.toml
@@ -24,8 +24,10 @@ server = "tcp://127.0.0.1:2883"
 #client_key = "./rmqtt-bin/client.key"
 
 # Username to connect to the remote MQTT broker
+#username = "${ENV:MQTT_USER}"
 username = "rmqtt_u"
 # Password to connect to the remote MQTT broker
+#password = "${ENV:MQTT_PASS}"
 password = "public"
 
 # Maximum limit of clients connected to the remote MQTT broker

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/config.rs
@@ -16,7 +16,7 @@ use serde_json::{self, Map, Value};
 
 use rmqtt::{
     codec::types::{Protocol, MQTT_LEVEL_31, MQTT_LEVEL_311, MQTT_LEVEL_5},
-    utils::{deserialize_duration, to_duration, Bytesize},
+    utils::{deserialize_duration, deserialize_expand_env_vars_option, to_duration, Bytesize},
     Result,
 };
 
@@ -44,9 +44,9 @@ pub struct Bridge {
     // #Client key file
     pub client_key: Option<String>,
 
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_expand_env_vars_option")]
     pub username: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_expand_env_vars_option")]
     pub password: Option<String>,
 
     #[serde(default = "Bridge::concurrent_client_limit_default")]

--- a/rmqtt-plugins/rmqtt-bridge-ingress-mqtt.toml
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-mqtt.toml
@@ -25,8 +25,10 @@ server = "tcp://127.0.0.1:2883"
 #client_key = "./rmqtt-bin/client.key"
 
 # Username to connect to the remote MQTT broker
+#username = "${ENV:MQTT_USER}"
 username = "rmqtt_u"
 # Password to connect to the remote MQTT broker
+#password = "${ENV:MQTT_PASS}"
 password = "public"
 
 # Maximum limit of clients connected to the remote MQTT broker

--- a/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/config.rs
@@ -18,7 +18,7 @@ use rmqtt::codec::types::{Protocol, MQTT_LEVEL_31, MQTT_LEVEL_311, MQTT_LEVEL_5}
 
 use rmqtt::{
     types::TopicName,
-    utils::{deserialize_duration, to_duration, Bytesize},
+    utils::{deserialize_duration, deserialize_expand_env_vars_option, to_duration, Bytesize},
     Result,
 };
 
@@ -44,9 +44,9 @@ pub struct Bridge {
     // #Client key file
     pub client_key: Option<String>,
 
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_expand_env_vars_option")]
     pub username: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_expand_env_vars_option")]
     pub password: Option<String>,
 
     #[serde(default = "Bridge::concurrent_client_limit_default")]

--- a/rmqtt-utils/Cargo.toml
+++ b/rmqtt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-utils"
-version = "0.1.3"
+version = "0.1.4"
 description = "Essential utilities for RMQTT system operations."
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-utils"
 edition.workspace = true
@@ -18,5 +18,6 @@ chrono = { workspace = true, features = ["clock"] }
 serde_json.workspace = true
 log.workspace = true
 bytestring = { workspace = true, features = ["serde"] }
-
+regex.workspace = true
+once_cell.workspace = true
 

--- a/rmqtt-utils/src/lib.rs
+++ b/rmqtt-utils/src/lib.rs
@@ -616,3 +616,64 @@ impl<'de> de::Deserialize<'de> for NodeAddr {
         NodeAddr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom)
     }
 }
+
+/// Expand all environment variable placeholders in the form `${ENV:VAR_NAME}`
+/// within a string.
+///
+/// Each occurrence of `${ENV:VAR_NAME}` will be replaced with the value of the
+/// corresponding environment variable `VAR_NAME`.  
+/// If an environment variable is not set, it will be replaced with an empty string
+/// and a warning will be logged.
+///
+/// # Example
+///
+/// ```
+/// use std::env;
+/// env::set_var("MQTT_USER", "user");
+/// env::set_var("MQTT_PASS", "pass");
+///
+/// let p = rmqtt_utils::expand_env_vars("${env:MQTT_PASS}");
+/// assert_eq!(p, "pass");
+///
+/// let s = rmqtt_utils::expand_env_vars("mqtt://${ENV:MQTT_USER}:${ENV:MQTT_PASS}@localhost");
+/// assert_eq!(s, "mqtt://user:pass@localhost");
+/// ```
+#[inline]
+pub fn expand_env_vars(value: &str) -> String {
+    static ENV_PATTERN: once_cell::sync::Lazy<regex::Regex> = once_cell::sync::Lazy::new(|| {
+        regex::Regex::new(r"(?i)\$\{ENV:([A-Z0-9_]+)\}").expect("Invalid regex pattern")
+    });
+
+    ENV_PATTERN
+        .replace_all(value, |caps: &regex::Captures| {
+            let env_name = &caps[1];
+            std::env::var(env_name).unwrap_or_else(|_| {
+                log::warn!("environment variable `{}` not set", env_name);
+                String::new()
+            })
+        })
+        .into_owned()
+}
+
+#[inline]
+pub fn deserialize_expand_env_vars<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let v = String::deserialize(deserializer)?;
+    Ok(expand_env_vars(&v))
+}
+
+#[inline]
+pub fn deserialize_expand_env_vars_option<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(|s| expand_env_vars(&s)).map(|s| {
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    })
+}


### PR DESCRIPTION
* Add environment variable expansion for username and password in MQTT bridge configurations
* Bump rmqtt-utils version to 0.1.4 with new expand_env_vars functionality
* Implement regex-based environment variable placeholder replacement (${ENV:VAR_NAME})
* Add deserialization helpers for automatic environment variable expansion
* Update configuration templates with commented environment variable examples
* Maintain backward compatibility with existing plaintext credentials