### PR TITLE
feat(bridge): add topic level skipping for all egress bridges #318

### DIFF
--- a/rmqtt-plugins/rmqtt-bridge-egress-kafka.toml
+++ b/rmqtt-plugins/rmqtt-bridge-egress-kafka.toml
@@ -33,6 +33,11 @@ remote.queue_timeout = "0m"
 #Sets the destination partition of the record.
 #remote.partition = 0
 
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
 [[bridges.entries]]
 #Local topic filter: All messages matching this topic filter will be forwarded.
 local.topic_filter = "local/topic2/egress/#"

--- a/rmqtt-plugins/rmqtt-bridge-egress-kafka/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-kafka/src/config.rs
@@ -70,6 +70,8 @@ pub struct Remote {
     pub queue_timeout: Duration,
     #[serde(default)]
     pub partition: Option<i32>,
+    #[serde(default)]
+    pub skip_levels: usize,
 }
 
 impl Remote {

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt.toml
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt.toml
@@ -40,6 +40,7 @@ keepalive = "60s"
 reconnect_interval = "5s"
 # Specifies the maximum number of messages that the channel can hold simultaneously.
 message_channel_capacity = 100_000
+
 # MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
 mqtt_ver = "v5"
 
@@ -73,6 +74,11 @@ remote.qos = 1
 remote.retain = false
 # Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
 remote.topic = "remote/topic/egress/${local.topic}"
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
 
 [[bridges.entries]]
 #Local topic filter: All messages matching this topic filter will be forwarded.

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/config.rs
@@ -59,6 +59,7 @@ pub struct Bridge {
     pub reconnect_interval: Duration,
     #[serde(default = "Bridge::message_channel_capacity_default")]
     pub message_channel_capacity: usize,
+
     #[serde(default = "Bridge::mqtt_ver_default", deserialize_with = "Bridge::deserialize_mqtt_ver")]
     pub mqtt_ver: Protocol,
     #[serde(default)]
@@ -345,6 +346,8 @@ pub struct Remote {
     pub topic: (String, HasPattern),
     #[serde(default)]
     pub retain: Option<bool>,
+    #[serde(default)]
+    pub skip_levels: usize,
 }
 
 impl Remote {
@@ -359,9 +362,9 @@ impl Remote {
     }
 
     #[inline]
-    pub fn make_topic(&self, remote_topic: &str) -> ntex::util::ByteString {
+    pub fn make_topic(&self, topic: &str) -> ntex::util::ByteString {
         if self.topic_has_pattern() {
-            ntex::util::ByteString::from(self.topic().replace("${local.topic}", remote_topic))
+            ntex::util::ByteString::from(self.topic().replace("${local.topic}", topic))
         } else {
             ntex::util::ByteString::from(self.topic())
         }

--- a/rmqtt-plugins/rmqtt-bridge-egress-nats.toml
+++ b/rmqtt-plugins/rmqtt-bridge-egress-nats.toml
@@ -44,6 +44,11 @@ remote.topic = "test1"
 # forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
 #remote.forward_all_publish = true
 
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
 [[bridges.entries]]
 #Local topic filter: All messages matching this topic filter will be forwarded.
 local.topic_filter = "local/topic2/egress/#"

--- a/rmqtt-plugins/rmqtt-bridge-egress-nats/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-nats/src/config.rs
@@ -102,6 +102,8 @@ pub struct Remote {
     pub forward_all_from: bool,
     #[serde(default)]
     pub forward_all_publish: bool,
+    #[serde(default)]
+    pub skip_levels: usize,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]

--- a/rmqtt-plugins/rmqtt-bridge-egress-pulsar.toml
+++ b/rmqtt-plugins/rmqtt-bridge-egress-pulsar.toml
@@ -66,6 +66,11 @@ remote.topic = "non-persistent://public/default/test1"
 #producer access mode: shared = 0, exclusive = 1, waitforexclusive = 2, exclusivewithoutfencing = 3
 #remote.options.access_mode = 0
 
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
 [[bridges.entries]]
 #Local topic filter: All messages matching this topic filter will be forwarded.
 local.topic_filter = "local/topic2/egress/#"

--- a/rmqtt-plugins/rmqtt-bridge-egress-pulsar/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-pulsar/src/config.rs
@@ -124,6 +124,8 @@ pub struct Remote {
     pub schema_version: Option<Vec<u8>>,
     #[serde(default)]
     pub options: Opts,
+    #[serde(default)]
+    pub skip_levels: usize,
 }
 
 impl Remote {

--- a/rmqtt-plugins/rmqtt-bridge-egress-reductstore.toml
+++ b/rmqtt-plugins/rmqtt-bridge-egress-reductstore.toml
@@ -39,6 +39,11 @@ remote.forward_all_from = true
 # forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
 remote.forward_all_publish = true
 
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
 [[bridges.entries]]
 # Local topic filter: All messages matching this topic filter will be forwarded.
 local.topic_filter = "local/topic2/egress/#"

--- a/rmqtt-plugins/rmqtt-bridge-egress-reductstore/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-bridge-egress-reductstore/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 rmqtt = { workspace = true, features = ["plugin"] }
 tokio = { workspace = true, features = ["sync"] }
 serde = { workspace = true, features = ["derive"] }
-reduct-rs = "1.14.0"
+reduct-rs = "1.16.1"
 serde_json.workspace = true
 log.workspace = true
 async-trait.workspace = true

--- a/rmqtt-plugins/rmqtt-bridge-egress-reductstore/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-reductstore/src/bridge.rs
@@ -28,6 +28,7 @@ pub enum Command {
 
 pub struct Producer {
     pub(crate) name: String,
+    cfg_entry: Entry,
     tx: mpsc::Sender<Command>,
 }
 
@@ -60,11 +61,12 @@ impl Producer {
 
         let bucket = builder.send().await.map_err(|e| anyhow!(format!("Failed to create Bucket, {}", e)))?;
 
+        let cfg_entry1 = cfg_entry.clone();
         let (tx, rx) = mpsc::channel(100_000);
         tokio::spawn(async move {
-            Self::start(cfg_entry, bucket, rx).await;
+            Self::start(cfg_entry1, bucket, rx).await;
         });
-        Ok(Producer { name: producer_name, tx })
+        Ok(Producer { name: producer_name, cfg_entry, tx })
     }
 
     #[inline]
@@ -121,7 +123,6 @@ impl Producer {
 
                     //Must forward
                     sender = sender.add_label("topic", p.topic.clone());
-
                     if let Err(e) = sender.data(p.take_payload()).send().await {
                         log::warn!("{e}");
                     }
@@ -132,8 +133,16 @@ impl Producer {
     }
 
     #[inline]
-    pub(crate) async fn send(&self, f: &From, p: &Publish) -> Result<()> {
-        self.tx.send(Command::Message(f.clone(), p.clone())).await?;
+    pub(crate) async fn send(&self, f: &From, p: &Publish, topic: &Topic) -> Result<()> {
+        let p = if self.cfg_entry.remote.skip_levels > 0 {
+            let mut p = p.clone();
+            p.topic = ByteString::from(topic.to_string_skip(self.cfg_entry.remote.skip_levels));
+            p
+        } else {
+            p.clone()
+        };
+        log::debug!("new_local_topic: {}, skip_levels: {}", p.topic, self.cfg_entry.remote.skip_levels);
+        self.tx.send(Command::Message(f.clone(), p)).await?;
         Ok(())
     }
 }
@@ -214,7 +223,7 @@ impl BridgeManager {
             log::debug!("bridge_infos: {bridge_infos:?}");
             for (name, entry_idx) in bridge_infos {
                 if let Some(producer) = self.sinks.get(&(name.clone(), *entry_idx)) {
-                    if let Err(e) = producer.send(f, p).await {
+                    if let Err(e) = producer.send(f, p, &topic).await {
                         log::warn!("{e}");
                     }
                 }

--- a/rmqtt-plugins/rmqtt-bridge-egress-reductstore/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-reductstore/src/config.rs
@@ -52,6 +52,8 @@ pub struct Remote {
     pub forward_all_from: bool,
     #[serde(default)]
     pub forward_all_publish: bool,
+    #[serde(default)]
+    pub skip_levels: usize,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]

--- a/rmqtt/src/topic.rs
+++ b/rmqtt/src/topic.rs
@@ -222,6 +222,24 @@ impl Topic {
     pub fn matches_str<S: AsRef<str> + ?Sized>(&self, topic: &S) -> bool {
         matches!(self, topic.as_ref().split('/'))
     }
+
+    /// Convert the topic to a string, optionally ignoring the first `n` levels.
+    ///
+    /// # Example
+    /// ```
+    /// let topic: rmqtt::topic::Topic = "a/b/c/d".parse().unwrap();
+    /// assert_eq!(topic.to_string_skip(2), "c/d");
+    ///
+    /// let topic: rmqtt::topic::Topic = "sport/tennis/player1/stats".parse().unwrap();
+    /// assert_eq!(topic.to_string_skip(0), "sport/tennis/player1/stats");
+    /// assert_eq!(topic.to_string_skip(2), "player1/stats");
+    /// assert_eq!(topic.to_string_skip(4), "");
+    /// assert_eq!(topic.to_string_skip(6), "");
+    /// ```
+    #[inline]
+    pub fn to_string_skip(&self, skip: usize) -> String {
+        self.0.iter().skip(skip).map(|lvl| lvl.to_string()).collect::<Vec<_>>().join("/")
+    }
 }
 
 impl From<&[Level]> for Topic {


### PR DESCRIPTION
* Add skip_levels configuration to all egress bridges (Kafka, MQTT, NATS, Pulsar, ReductStore)
* Implement topic.to_string_skip() method to skip leading topic levels
* Update bridge send methods to use modified topics when skip_levels > 0
* Add debug logging for topic transformation
* Bump reduct-rs dependency to 1.16.1 for ReductStore bridge
* Maintain backward compatibility with existing configurations