### PR TITLE
fix(net): fix conditional compilation and code organization

### DIFF
--- a/rmqtt-conf/Cargo.toml
+++ b/rmqtt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-conf"
-version = "0.3.0"
+version = "0.3.1"
 description = "Centralized configuration management system for RMQTT MQTT broker"
 edition.workspace = true
 license.workspace = true

--- a/rmqtt-net/Cargo.toml
+++ b/rmqtt-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-net"
-version = "0.3.0"
+version = "0.3.1"
 description = "Basic Implementation of MQTT Server"
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-net"
 edition.workspace = true

--- a/rmqtt-net/src/builder.rs
+++ b/rmqtt-net/src/builder.rs
@@ -66,7 +66,9 @@ use crate::quic::QuinnBiStream;
 use crate::stream::Dispatcher;
 #[cfg(feature = "ws")]
 use crate::ws::WsStream;
-use crate::{CertInfo, Error, Result, TlsCertExtractor};
+#[cfg(feature = "tls")]
+use crate::{CertInfo, TlsCertExtractor};
+use crate::{Error, Result};
 
 /// Configuration builder for MQTT server instances
 #[derive(Clone, Debug)]

--- a/rmqtt-net/src/cert.rs
+++ b/rmqtt-net/src/cert.rs
@@ -80,6 +80,7 @@ impl TlsCertExtractor for WsStream<tokio::net::TcpStream> {
 }
 
 #[cfg(feature = "ws")]
+#[cfg(feature = "tls")]
 impl TlsCertExtractor for WsStream<tokio_rustls::server::TlsStream<tokio::net::TcpStream>> {
     fn extract_cert_info(&self) -> Option<CertInfo> {
         self.get_inner().get_ref().extract_cert_info()

--- a/rmqtt-net/src/lib.rs
+++ b/rmqtt-net/src/lib.rs
@@ -27,6 +27,7 @@
 //! ```
 
 mod builder;
+mod cert;
 mod error;
 #[cfg(feature = "quic")]
 mod quic;
@@ -40,15 +41,14 @@ pub use quic::QuinnBiStream;
 /// Server configuration and listener management
 pub use builder::{Builder, Listener, ListenerType};
 
+pub use cert::{CertInfo, TlsCertExtractor};
+
 /// Error types for MQTT operations
 pub use error::MqttError;
 
 /// TLS implementation providers
 #[cfg(feature = "tls")]
 pub use rustls;
-
-pub mod cert;
-pub use cert::{CertInfo, TlsCertExtractor};
 
 /// AWS-LC based TLS provider (non-Windows platforms)
 #[cfg(not(target_os = "windows"))]

--- a/rmqtt-net/src/stream.rs
+++ b/rmqtt-net/src/stream.rs
@@ -274,6 +274,7 @@ pub mod v3 {
         #[inline]
         pub async fn recv_connect(&mut self, tm: Duration) -> Result<Box<Connect>> {
             let connect = match self.recv(tm).await {
+                #[allow(unused_mut)]
                 Ok(Some(Packet::Connect(mut connect))) => {
                     #[cfg(feature = "tls")]
                     {
@@ -333,7 +334,9 @@ pub mod v5 {
     use rmqtt_codec::{MqttCodec, MqttPacket};
 
     use crate::error::MqttError;
-    use crate::{Builder, CertInfo, Error, Result};
+    #[cfg(feature = "tls")]
+    use crate::CertInfo;
+    use crate::{Builder, Error, Result};
 
     /// MQTT v5.0 protocol stream implementation
     pub struct MqttStream<Io> {


### PR DESCRIPTION
* Bump rmqtt-net version to 0.3.1 and rmqtt-conf to 0.3.1
* Fix conditional compilation for TLS features in cert.rs and stream.rs
* Reorganize module exports to improve code structure
* Remove duplicate module declarations and fix import paths
* Add allow(unused_mut) attribute to suppress warnings
* Maintain all existing functionality with improved code quality