### PR TITLE
chore(nats): add msgstore feature to ingress NATS bridge

### DIFF
--- a/rmqtt-plugins/rmqtt-bridge-ingress-nats/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-nats/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-rmqtt = { workspace = true, features = ["plugin"] }
+rmqtt = { workspace = true, features = ["plugin", "msgstore"] }
 tokio = { workspace = true, features = ["sync"] }
 serde = { workspace = true, features = ["derive"] }
 async-nats = "0.38"


### PR DESCRIPTION
* Enable msgstore feature for rmqtt dependency in NATS ingress bridge
* This allows the bridge to utilize message storage capabilities
* Maintains existing NATS bridge functionality with enhanced storage support