### PR TITLE
feat(bridge): support modified messages from previous hooks in egressbridges #333

### DIFF
--- a/rmqtt-plugins/rmqtt-bridge-egress-kafka/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-kafka/src/lib.rs
@@ -149,9 +149,10 @@ impl HookHandler {
 impl Handler for HookHandler {
     async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
         match param {
-            Parameter::MessagePublish(s, f, publish) => {
-                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), publish);
-                if let Err(e) = self.bridge_mgr.send(f, publish).await {
+            Parameter::MessagePublish(s, f, p) => {
+                let p = if let Some(HookResult::Publish(publish)) = &acc { publish } else { p };
+                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), p);
+                if let Err(e) = self.bridge_mgr.send(f, p).await {
                     log::error!("{e}");
                 }
             }

--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/lib.rs
@@ -146,9 +146,10 @@ impl HookHandler {
 impl Handler for HookHandler {
     async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
         match param {
-            Parameter::MessagePublish(s, f, publish) => {
-                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), publish);
-                if let Err(e) = self.bridge_mgr.send(f, publish).await {
+            Parameter::MessagePublish(s, f, p) => {
+                let p = if let Some(HookResult::Publish(publish)) = &acc { publish } else { p };
+                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), p);
+                if let Err(e) = self.bridge_mgr.send(f, p).await {
                     log::error!("{e:?}");
                 }
             }

--- a/rmqtt-plugins/rmqtt-bridge-egress-nats/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-nats/src/lib.rs
@@ -144,9 +144,10 @@ impl HookHandler {
 impl Handler for HookHandler {
     async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
         match param {
-            Parameter::MessagePublish(s, f, publish) => {
-                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), publish);
-                if let Err(e) = self.bridge_mgr.send(f, publish).await {
+            Parameter::MessagePublish(s, f, p) => {
+                let p = if let Some(HookResult::Publish(publish)) = &acc { publish } else { p };
+                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), p);
+                if let Err(e) = self.bridge_mgr.send(f, p).await {
                     log::error!("{e:?}");
                 }
             }

--- a/rmqtt-plugins/rmqtt-bridge-egress-pulsar/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-pulsar/src/lib.rs
@@ -139,9 +139,10 @@ impl HookHandler {
 impl Handler for HookHandler {
     async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
         match param {
-            Parameter::MessagePublish(s, f, publish) => {
-                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), publish);
-                if let Err(e) = self.bridge_mgr.send(f, publish).await {
+            Parameter::MessagePublish(s, f, p) => {
+                let p = if let Some(HookResult::Publish(publish)) = &acc { publish } else { p };
+                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), p);
+                if let Err(e) = self.bridge_mgr.send(f, p).await {
                     log::error!("{e:?}");
                 }
             }

--- a/rmqtt-plugins/rmqtt-bridge-egress-reductstore/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-reductstore/src/lib.rs
@@ -145,9 +145,10 @@ impl HookHandler {
 impl Handler for HookHandler {
     async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
         match param {
-            Parameter::MessagePublish(s, f, publish) => {
-                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), publish);
-                if let Err(e) = self.bridge_mgr.send(f, publish).await {
+            Parameter::MessagePublish(s, f, p) => {
+                let p = if let Some(HookResult::Publish(publish)) = &acc { publish } else { p };
+                log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), p);
+                if let Err(e) = self.bridge_mgr.send(f, p).await {
                     log::error!("{e:?}");
                 }
             }

--- a/rmqtt-plugins/rmqtt-topic-rewrite/src/config.rs
+++ b/rmqtt-plugins/rmqtt-topic-rewrite/src/config.rs
@@ -12,6 +12,7 @@ use serde::{
 use tokio::sync::RwLock;
 
 use rmqtt::{
+    hook::Priority,
     trie::TopicTree,
     types::{Topic, TopicFilter, TopicName},
     Error, Result,
@@ -21,6 +22,8 @@ type Rules = Arc<RwLock<TopicTree<Rule>>>;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PluginConfig {
+    #[serde(default = "PluginConfig::default_priority")]
+    pub(crate) priority: Priority,
     #[serde(
         default,
         serialize_with = "PluginConfig::serialize_rules",
@@ -30,6 +33,10 @@ pub struct PluginConfig {
 }
 
 impl PluginConfig {
+    fn default_priority() -> Priority {
+        Priority::MAX
+    }
+
     #[inline]
     pub fn rules(&self) -> &Rules {
         let (_rules, _) = &self.rules;


### PR DESCRIPTION
* Update all egress bridge handlers (Kafka, MQTT, NATS, Pulsar, ReductStore) to use modified publish messages from previous hooks
* Add priority configuration support for topic-rewrite plugin with MAX priority by default
* Update topic-rewrite handler to process modified topic filters from previous hooks for subscribe/unsubscribe operations
* Maintain backward compatibility while enabling hook chain processing for message transformation
* Improve logging consistency across all bridge implementations