### PR TITLE
fix: improve MQTT protocol validation and WebSocket subprotocol support #340

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ rust-version = "1.85.0"
 
 [workspace.dependencies]
 rmqtt = "0.18.0"
-rmqtt-codec = "0.2"
-rmqtt-net = "0.3"
+rmqtt-codec = "0.2.1"
+rmqtt-net = "0.3.2"
 rmqtt-conf = "0.3"
 rmqtt-macros = "0.1"
 rmqtt-utils = "0.1"

--- a/rmqtt-codec/Cargo.toml
+++ b/rmqtt-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-codec"
-version = "0.2.0"
+version = "0.2.1"
 description = "MQTT protocol codec implementation with multi-version support and version negotiation"
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-codec"
 edition.workspace = true

--- a/rmqtt-net/Cargo.toml
+++ b/rmqtt-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-net"
-version = "0.3.1"
+version = "0.3.2"
 description = "Basic Implementation of MQTT Server"
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-net"
 edition.workspace = true


### PR DESCRIPTION
* Bump rmqtt-codec to 0.2.1 and rmqtt-net to 0.3.2
* Fix MQTT 3.1 protocol validation with proper length checking for MQISDP
* Add support for "mqttv3.1" WebSocket subprotocol in addition to "mqtt"
* Improve protocol name validation with better error handling and bounds checking
* Maintain backward compatibility with existing MQTT 3.1.1 and 5.0 protocols