### PR TITLE
feat(webhook): add user_properties support to client_connected events

### DIFF
--- a/docs/en_US/web-hook.md
+++ b/docs/en_US/web-hook.md
@@ -246,20 +246,32 @@ opts include
 
 **client_connected**
 
-| Key             | Type    | Description                                        |
-|-----------------|---------|--------------------------------------------------- |
-| action          | string  | Event name<br>Default: "client_connected"           |
-| node            | integer | Node ID                                            |
-| ipaddress       | string  | Source IP address and port of the client               |
-| clientid        | string  | Client ID                                          |
-| username        | string  | Client Username; "undefined" if it doesn't exist     |
-| keepalive       | integer | Requested keep-alive time by the client               |
-| proto_ver       | integer | Protocol version number                             |
-| clean_session   | bool    | Session persistence flag (MQTT 3.1, 3.1.1)          |
-| clean_start     | bool    | Session clean start flag (MQTT 5.0)                 |
+| Key             | Type    | Description                                                   |
+|-----------------|---------|---------------------------------------------------------------|
+| action          | string  | Event name<br>Default: "client_connected"                     |
+| node            | integer | Node ID                                                       |
+| ipaddress       | string  | Source IP address and port of the client                      |
+| clientid        | string  | Client ID                                                     |
+| username        | string  | Client Username; "undefined" if it doesn't exist              |
+| keepalive       | integer | Requested keep-alive time by the client                       |
+| proto_ver       | integer | Protocol version number                                       |
+| clean_session   | bool    | Session persistence flag (MQTT 3.1, 3.1.1)                    |
+| clean_start     | bool    | Session clean start flag (MQTT 5.0)                           |
 | connected_at    | integer | Timestamp in milliseconds when the connection was established |
-| session_present | bool    | Indicates whether a persistent session is present     |
-| time            | string  | Hook Information Creation Time, Format: %Y-%m-%d %H:%M:%S%.3f  |
+| session_present | bool    | Indicates whether a persistent session is present             |
+| user_properties | json    | Attach additional contextual information                      |
+| time            | string  | Hook Information Creation Time, Format: %Y-%m-%d %H:%M:%S%.3f |
+
+user_properties contains
+
+| Key  | Type | Description                          |
+|------|--------------------|------------------------|
+| name | string or [string] | The property name serves as the key, and its value may be a single string or a string array |
+
+Such as:
+```
+{"age": "23", "interests": ["reading", "gaming", "running"], "name": "Alice"}
+```
 
 **client_disconnected**
 

--- a/docs/zh_CN/web-hook.md
+++ b/docs/zh_CN/web-hook.md
@@ -249,20 +249,32 @@ opts 包含
 
 **client_connected**
 
-| Key             | 类型      | 说明                               |
-|-----------------|---------|----------------------------------|
-| action          | string  | 事件名称<br>默认为："client_connected"   |
-| node            | integer | 节点ID                             |
-| ipaddress       | string  | 客户端源 IP 地址和端口                    |
-| clientid        | string  | 客户端 ClientId                     |
-| username        | string  | 客户端 Username，不存在时该值为 "undefined" |
-| keepalive       | integer | 客户端申请的心跳保活时间                     |
-| proto_ver       | integer | 协议版本号                            |
-| clean_session   | bool    | 保持会话标记(MQTT 3.1, 3.1.1)          |
-| clean_start     | bool    | 连接时清除会话标记(MQTT 5.0)              |
-| connected_at    | integer | 时间戳(毫秒)                          |
-| session_present | bool    | 是否持久会话                           |
+| Key             | 类型      | 说明                                  |
+|-----------------|---------|-------------------------------------|
+| action          | string  | 事件名称<br>默认为："client_connected"      |
+| node            | integer | 节点ID                                |
+| ipaddress       | string  | 客户端源 IP 地址和端口                       |
+| clientid        | string  | 客户端 ClientId                        |
+| username        | string  | 客户端 Username，不存在时该值为 "undefined"    |
+| keepalive       | integer | 客户端申请的心跳保活时间                        |
+| proto_ver       | integer | 协议版本号                               |
+| clean_session   | bool    | 保持会话标记(MQTT 3.1, 3.1.1)             |
+| clean_start     | bool    | 连接时清除会话标记(MQTT 5.0)                 |
+| connected_at    | integer | 时间戳(毫秒)                             |
+| session_present | bool    | 是否持久会话                              |
+| user_properties | json    | 用户自定义属性                             |
 | time            | string  | Hook信息创建时间，格式：%Y-%m-%d %H:%M:%S%.3f |
+
+user_properties 包含
+
+| Key  | 类型                | 说明                     |
+|------|-------------------|------------------------|
+| name | string 或 [string] | name为属性名，值：单值为串，多值为串数组 |
+
+如：
+```
+{"age": "23", "interests": ["reading", "gaming", "running"], "name": "Alice"}
+```
 
 **client_disconnected**
 
@@ -279,15 +291,15 @@ opts 包含
 
 **client_subscribe**
 
-| Key         |  类型   | 说明  |
-|-------------| ------- | ----- |
-| action      | string  | 事件名称<br>默认为："client_subscribe" |
-| node        | integer | 节点ID |
-| ipaddress   | string  | 客户端源 IP 地址和端口 |
-| clientid    | string  | 客户端 ClientId |
-| username    | string  | 客户端 Username，不存在时该值为 "undefined" |
-| topic       | string  | 订阅的主题 |
-| opts        | json    | 订阅参数 |
+| Key         |  类型   | 说明                                  |
+|-------------| ------- |-------------------------------------|
+| action      | string  | 事件名称<br>默认为："client_subscribe"      |
+| node        | integer | 节点ID                                |
+| ipaddress   | string  | 客户端源 IP 地址和端口                       |
+| clientid    | string  | 客户端 ClientId                        |
+| username    | string  | 客户端 Username，不存在时该值为 "undefined"    |
+| topic       | string  | 订阅的主题                               |
+| opts        | json    | 订阅参数                         |
 | time        | string  | Hook信息创建时间，格式：%Y-%m-%d %H:%M:%S%.3f |
 
 opts 包含

--- a/rmqtt-plugins/rmqtt-sys-topic/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-sys-topic/src/lib.rs
@@ -185,7 +185,7 @@ impl Handler for SystemTopicHandler {
                 let mut body = session
                     .connect_info()
                     .await
-                    .map(|connect_info| connect_info.to_hook_body())
+                    .map(|connect_info| connect_info.to_hook_body(true))
                     .unwrap_or_default();
                 if let Some(obj) = body.as_object_mut() {
                     obj.insert(

--- a/rmqtt-plugins/rmqtt-web-hook/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-web-hook/src/lib.rs
@@ -515,14 +515,14 @@ impl Handler for WebHookHandler {
         let now_time = format_timestamp_millis(now);
         let bodys = match param {
             Parameter::ClientConnect(conn_info) => {
-                let mut body = conn_info.to_hook_body();
+                let mut body = conn_info.to_hook_body(false);
                 if let Some(obj) = body.as_object_mut() {
                     obj.insert("time".into(), serde_json::Value::String(now_time));
                 }
                 Some((None, body))
             }
             Parameter::ClientConnack(conn_info, conn_ack) => {
-                let mut body = conn_info.to_hook_body();
+                let mut body = conn_info.to_hook_body(false);
                 if let Some(obj) = body.as_object_mut() {
                     obj.insert("conn_ack".into(), serde_json::Value::String(conn_ack.reason().to_string()));
                     obj.insert("time".into(), serde_json::Value::String(now_time));
@@ -531,7 +531,7 @@ impl Handler for WebHookHandler {
             }
 
             Parameter::ClientConnected(session) => {
-                let mut body = session.connect_info().await.map(|c| c.to_hook_body()).unwrap_or_default();
+                let mut body = session.connect_info().await.map(|c| c.to_hook_body(true)).unwrap_or_default();
                 if let Some(obj) = body.as_object_mut() {
                     obj.insert(
                         "connected_at".into(),


### PR DESCRIPTION
* Add user_properties field to webhook client_connected events for MQTT v5
* Update both Chinese and English documentation to include user_properties description
* Implement serialize_user_properties helper function to convert UserProperties to JSON
* Add user_properties parameter to ConnectInfo::to_hook_body method
* Update web-hook and sys-topic plugins to pass user_properties flag appropriately
* Support both single string values and string arrays for user properties in webhook payloads