### PR TITLE
chore: update rmqtt-raft to 0.6.0 with new lead method signature #331

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5053,9 +5053,9 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-raft"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb082fbfbfce5f9ccd9088c5e8355a3f064c05208c1d18443fa33dae6d913205"
+checksum = "e3e248ddccabfb596f3425466bafd7a03275d0e391d409371e0f4fe6417271fc"
 dependencies = [
  "ahash",
  "anyhow",

--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 rmqtt = { workspace = true, features = ["plugin", "grpc", "stats", "msgstore"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["sync"] }
-rmqtt-raft = { version = "0.5.3", features = ["reuse"] }
+rmqtt-raft = { version = "0.6.0", features = ["reuse"] }
 #rmqtt-raft = { path = "../../../rmqtt-raft", features = ["reuse"] }
 backoff = { workspace = true, features = ["futures", "tokio"] }
 rust-box = { workspace = true, features = ["task-exec-queue"] }

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
@@ -210,7 +210,7 @@ impl ClusterPlugin {
                     }
                     None => {
                         log::info!("running in leader mode");
-                        tokio::spawn(raft.lead(id)).await
+                        tokio::spawn(raft.lead(id, raft_node_addr)).await
                     }
                 };
 


### PR DESCRIPTION
* Update rmqtt-raft dependency from 0.6.0 to 0.6.0 (version bump)
* Update cluster-raft plugin to use new raft.lead() method signature with raft_node_addr parameter
* Maintain all existing raft cluster functionality with updated dependency