### PR TITLE
docs: update version references from 0.16 to 0.18

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -114,7 +114,7 @@ curl "http://127.0.0.1:6066/api/v1/health/check"
 
 ```toml
 [dependencies]
-rmqtt = "0.16"
+rmqtt = "0.18"
 ```
 
 更多关于库模式的使用说明，请参考 [RMQTT 库使用文档](./rmqtt/README.md) 。

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ In addition to running as a standalone MQTT Broker/Server, rmqtt also provides a
 
 ```toml
 [dependencies]
-rmqtt = "0.16"
+rmqtt = "0.18"
 ```
 
 For more details about using rmqtt in library mode, please refer to the [RMQTT Library Documentation](./rmqtt/README.md).

--- a/rmqtt/README.md
+++ b/rmqtt/README.md
@@ -24,7 +24,7 @@ A basic MQTT server with RMQTT.
 
 ```toml
 [dependencies]
-rmqtt = "0.16"
+rmqtt = "0.18"
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"
@@ -58,7 +58,7 @@ Make sure you included the rmqtt crate with the required features in your Cargo.
 
 ```toml
 [dependencies]
-rmqtt = { version = "0.16", features = ["ws", "tls"] }
+rmqtt = { version = "0.18", features = ["ws", "tls"] }
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"
@@ -111,8 +111,8 @@ Make sure you included the rmqtt crate with the required features in your Cargo.
 
 ```toml
 [dependencies]
-rmqtt = { version = "0.16", features = ["plugin"] }
-rmqtt-plugins = { version = "0.16", features = ["full"] }
+rmqtt = { version = "0.18", features = ["plugin"] }
+rmqtt-plugins = { version = "0.18", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"
@@ -153,8 +153,8 @@ or
 
 ```toml
 [dependencies]
-rmqtt = { version = "0.16", features = ["plugin"] }
-rmqtt-plugins = { version = "0.16", features = ["full"] }
+rmqtt = { version = "0.18", features = ["plugin"] }
+rmqtt-plugins = { version = "0.18", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"
@@ -206,11 +206,11 @@ or
 
 ```toml
 [dependencies]
-rmqtt = { version = "0.16", features = ["plugin"] }
-rmqtt-acl = "0.16"
-rmqtt-retainer = "0.16"
-rmqtt-http-api = "0.16"
-rmqtt-web-hook = "0.16"
+rmqtt = { version = "0.18", features = ["plugin"] }
+rmqtt-acl = "0.18"
+rmqtt-retainer = "0.18"
+rmqtt-http-api = "0.18"
+rmqtt-web-hook = "0.18"
 tokio = { version = "1", features = ["full"] }
 simple_logger = "5"
 log = "0.4"


### PR DESCRIPTION
* Update version references in Chinese README from 0.16 to 0.18
* Update version references in English README from 0.16 to 0.18
* Update version references in rmqtt README examples from 0.16 to 0.18
* Update plugin dependency versions in examples to match current 0.18 release
* Maintain all documentation accuracy with current version information