### PR TITLE
fix: num-bigint-dig future-incompatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,11 +3241,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",


### PR DESCRIPTION
The following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.4 help: update to a newer version to see if the issue has been fixed
        - num-bigint-dig v0.8.4 has the following newer
	  versions available: 0.8.6, 0.9.0, 0.9.1
help: ensure the maintainers know of this problem (e.g. creating a
      bug report if needed)
      or even helping with a fix (e.g. by creating a pull request)
        - num-bigint-dig@0.8.4
        - repository: https://github.com/dignifiedquire/num-bigint - detailed warning command: `cargo report future-incompatibilities --id 1 --package num-bigint-dig@0.8.4`