### PR TITLE
feat(acl): add client-level ACL rule management

### DIFF
--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -1860,6 +1860,7 @@ pub struct _Session {
     pub id: Id,
     pub fitter: FitterType,
     pub auth_info: Option<AuthInfo>,
+    pub extra_attrs: Arc<RwLock<ExtraAttrs>>,
     pub scx: ServerContext,
 }
 
@@ -1982,7 +1983,8 @@ impl Session {
                 last_id,
             )
             .await?;
-        Ok(Self(Arc::new(_Session { inner: session_like, id, fitter, auth_info, scx })))
+        let extra_attrs = Arc::new(RwLock::new(ExtraAttrs::new()));
+        Ok(Self(Arc::new(_Session { inner: session_like, id, fitter, auth_info, extra_attrs, scx })))
     }
 
     #[inline]

--- a/rmqtt/src/types.rs
+++ b/rmqtt/src/types.rs
@@ -1,5 +1,6 @@
 //! Some commonly used type definitions
 
+use std::any::Any;
 use std::convert::From as _f;
 use std::fmt;
 use std::fmt::Display;
@@ -2197,70 +2198,70 @@ impl SessionSubs {
 //     }
 // }
 //
-// pub struct ExtraAttrs {
-//     attrs: HashMap<String, Box<dyn Any + Sync + Send>>,
-// }
-//
-// impl Default for ExtraAttrs {
-//     fn default() -> Self {
-//         Self::new()
-//     }
-// }
-//
-// impl ExtraAttrs {
-//     #[inline]
-//     pub fn new() -> Self {
-//         Self { attrs: HashMap::default() }
-//     }
-//
-//     #[inline]
-//     pub fn len(&self) -> usize {
-//         self.attrs.len()
-//     }
-//
-//     #[inline]
-//     pub fn is_empty(&self) -> bool {
-//         self.attrs.is_empty()
-//     }
-//
-//     #[inline]
-//     pub fn clear(&mut self) {
-//         self.attrs.clear()
-//     }
-//
-//     #[inline]
-//     pub fn insert<T: Any + Sync + Send>(&mut self, key: String, value: T) {
-//         self.attrs.insert(key, Box::new(value));
-//     }
-//
-//     #[inline]
-//     pub fn get<T: Any + Sync + Send>(&self, key: &str) -> Option<&T> {
-//         self.attrs.get(key).and_then(|v| v.downcast_ref::<T>())
-//     }
-//
-//     #[inline]
-//     pub fn get_mut<T: Any + Sync + Send>(&mut self, key: &str) -> Option<&mut T> {
-//         self.attrs.get_mut(key).and_then(|v| v.downcast_mut::<T>())
-//     }
-//
-//     #[inline]
-//     pub fn get_default_mut<T: Any + Sync + Send, F: Fn() -> T>(
-//         &mut self,
-//         key: String,
-//         def_fn: F,
-//     ) -> Option<&mut T> {
-//         self.attrs.entry(key).or_insert_with(|| Box::new(def_fn())).downcast_mut::<T>()
-//     }
-//
-//     #[inline]
-//     pub fn serialize_key<S, T>(&self, key: &str, serializer: S) -> Result<S::Ok, S::Error>
-//     where
-//         T: Any + Sync + Send + serde::ser::Serialize,
-//         S: Serializer,
-//     {
-//         self.get::<T>(key).serialize(serializer)
-//     }
-// }
+pub struct ExtraAttrs {
+    attrs: HashMap<String, Box<dyn Any + Sync + Send>>,
+}
+
+impl Default for ExtraAttrs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExtraAttrs {
+    #[inline]
+    pub fn new() -> Self {
+        Self { attrs: HashMap::default() }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.attrs.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.attrs.is_empty()
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.attrs.clear()
+    }
+
+    #[inline]
+    pub fn insert<T: Any + Sync + Send>(&mut self, key: String, value: T) {
+        self.attrs.insert(key, Box::new(value));
+    }
+
+    #[inline]
+    pub fn get<T: Any + Sync + Send>(&self, key: &str) -> Option<&T> {
+        self.attrs.get(key).and_then(|v| v.downcast_ref::<T>())
+    }
+
+    #[inline]
+    pub fn get_mut<T: Any + Sync + Send>(&mut self, key: &str) -> Option<&mut T> {
+        self.attrs.get_mut(key).and_then(|v| v.downcast_mut::<T>())
+    }
+
+    #[inline]
+    pub fn get_default_mut<T: Any + Sync + Send, F: Fn() -> T>(
+        &mut self,
+        key: String,
+        def_fn: F,
+    ) -> Option<&mut T> {
+        self.attrs.entry(key).or_insert_with(|| Box::new(def_fn())).downcast_mut::<T>()
+    }
+
+    #[inline]
+    pub fn serialize_key<S, T>(&self, key: &str, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        T: Any + Sync + Send + serde::ser::Serialize,
+        S: serde::ser::Serializer,
+    {
+        self.get::<T>(key).serialize(serializer)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct TimedValue<V>(V, Option<Instant>);


### PR DESCRIPTION
- Store client IDs in TopicTree for granular ACL control
- Add client-connected and client-disconnected hooks for rule lifecycle
- Implement client-specific topic filter addition and removal
- Extend session with extra_attrs for ACL caching
- Update ACL matching logic to consider client identity