### PR TITLE
deps(kafka): upgrade rdkafka to 0.38 and pin rdkafka-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
+checksum = "5f1856d72dbbbea0d2a5b2eaf6af7fb3847ef2746e883b11781446a51dbc85c0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -4372,9 +4372,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.10.0+2.12.1"
+version = "4.9.0+2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
+checksum = "5230dca48bc354d718269f3e4353280e188b610f7af7e2fcf54b7a79d5802872"
 dependencies = [
  "cmake",
  "libc",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-acl"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-auth-http"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-auth-jwt"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-auto-subscription"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-egress-kafka"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4705,6 +4705,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "rdkafka",
+ "rdkafka-sys",
  "rmqtt",
  "rust-box",
  "serde",
@@ -4714,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-egress-mqtt"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4737,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-egress-nats"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4754,7 +4755,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-egress-pulsar"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4771,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-egress-reductstore"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4788,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-ingress-kafka"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4797,6 +4798,7 @@ dependencies = [
  "event-notify",
  "log",
  "rdkafka",
+ "rdkafka-sys",
  "rmqtt",
  "serde",
  "serde_json",
@@ -4805,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-ingress-mqtt"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4827,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-ingress-nats"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4846,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-bridge-ingress-pulsar"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4866,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-cluster-broadcast"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4885,7 +4887,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-cluster-raft"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4954,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-counter"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "log",
@@ -4963,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-http-api"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4992,7 +4994,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-message-storage"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5037,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-p2p-messaging"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5050,7 +5052,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-plugins"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "rmqtt-acl",
  "rmqtt-auth-http",
@@ -5110,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-retainer"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5126,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-session-storage"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5164,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-sys-topic"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5179,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-topic-rewrite"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5207,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-web-hook"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5229,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "rmqttd"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rmqtt-plugins/rmqtt-bridge-egress-kafka/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-bridge-egress-kafka/Cargo.toml
@@ -20,4 +20,5 @@ bytestring.workspace = true
 itoa.workspace = true
 rand.workspace = true
 rust-box = { workspace = true, features = ["task-exec-queue"] }
-rdkafka = { version = "0.37", features = ["cmake-build"] }
+rdkafka = { version = "0.38", features = ["cmake-build"] }
+rdkafka-sys = "=4.9.0"

--- a/rmqtt-plugins/rmqtt-bridge-egress-kafka/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-kafka/src/bridge.rs
@@ -121,8 +121,8 @@ impl Producer {
 
             let delivery_status = producer.send(frecord, queue_timeout).await;
             match delivery_status {
-                Ok((partition, offset)) => {
-                    log::debug!("{name} delivery ok, partition: {partition}, offset: {offset}");
+                Ok(delivery) => {
+                    log::debug!("{name} delivery ok, delivery: {delivery:?}");
                 }
                 Err((e, msg)) => {
                     log::error!("{name} delivery error: {e:?}, message: {msg:?}");

--- a/rmqtt-plugins/rmqtt-bridge-ingress-kafka/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-kafka/Cargo.toml
@@ -19,4 +19,5 @@ anyhow.workspace = true
 bytestring.workspace = true
 bytes.workspace = true
 event-notify = "0.1.1"
-rdkafka = { version = "0.37", features = ["cmake-build"] }
+rdkafka = { version = "0.38", features = ["cmake-build"] }
+rdkafka-sys = "=4.9.0"


### PR DESCRIPTION
- Bump rdkafka dependency from 0.37 to 0.38 for both ingress and egress bridges
- Add explicit rdkafka-sys version pin to 4.9.0 for compatibility