### PR TITLE
chore(docker): upgrade Alpine base images to latest stable

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.20.2
+FROM arm64v8/alpine:3.22.4
 LABEL maintainer="rmqtt <rmqttd@126.com>"
 
 RUN mkdir -p /app/rmqtt/rmqtt-bin

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM alpine:3.18.3
+FROM alpine:3.22.4
 LABEL maintainer="rmqtt <rmqttd@126.com>"
 
 RUN mkdir -p /app/rmqtt/rmqtt-bin


### PR DESCRIPTION
- Update aarch64 image from Alpine 3.20.2 to 3.22.4
- Update amd64 image from Alpine 3.18.3 to 3.22.4
- Includes latest security patches and package updates