### PR TITLE
chore: bump rmqtt-net to 0.3.5 and remove linger setting #386

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-net"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "bytestring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rust-version = "1.89.0"
 [workspace.dependencies]
 rmqtt = "0.21.0"
 rmqtt-codec = "0.2.2"
-rmqtt-net = "0.3.4"
+rmqtt-net = "0.3.5"
 rmqtt-conf = "0.3.3"
 rmqtt-macros = "0.1"
 rmqtt-utils = "0.1"

--- a/rmqtt-net/Cargo.toml
+++ b/rmqtt-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-net"
-version = "0.3.4"
+version = "0.3.5"
 description = "Basic Implementation of MQTT Server"
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-net"
 edition.workspace = true

--- a/rmqtt-net/src/builder.rs
+++ b/rmqtt-net/src/builder.rs
@@ -480,8 +480,6 @@ impl Builder {
             SocketAddr::V6(_) => Socket::new(Domain::IPV6, Type::STREAM, None)?,
         };
 
-        builder.set_linger(Some(Duration::from_secs(10)))?;
-
         builder.set_nonblocking(true)?;
 
         if let Some(reuseaddr) = self.reuseaddr {


### PR DESCRIPTION
- Update rmqtt-net version from 0.3.4 to 0.3.5
- Remove set_linger(Some(Duration::from_secs(10))) from socket builder