### PR TITLE
refactor(logging): replace slog with tracing ecosystem #343

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ target/
 # Exclusions:
 !.dockerignore
 !.github
+/CODEBUDDY.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,6 +2730,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +3214,15 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4950,7 +4968,6 @@ dependencies = [
  "rmqtt-utils",
  "serde",
  "serde_json",
- "slog",
  "structopt",
 ]
 
@@ -5263,15 +5280,14 @@ dependencies = [
  "rmqtt-sys-topic",
  "rmqtt-topic-rewrite",
  "rmqtt-web-hook",
- "slog",
- "slog-async",
- "slog-scope",
- "slog-stdlog",
- "slog-term",
  "structopt",
  "tikv-jemallocator",
+ "time",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5926,6 +5942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6112,18 +6137,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slog-async"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
-dependencies = [
- "crossbeam-channel",
- "slog",
- "take_mut",
- "thread_local",
-]
-
-[[package]]
 name = "slog-scope"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6301,6 +6314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6382,12 +6401,6 @@ dependencies = [
  "time",
  "winapi",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "task-exec-queue"
@@ -6977,6 +6990,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6994,6 +7020,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7146,6 +7202,12 @@ dependencies = [
  "rand 0.10.1",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,11 +120,9 @@ rand = "0.9.0"
 governor = "0.10"
 config = { version = "0.15.8", default-features = false}
 log = "0.4"
-slog = "2.7"
-slog-term = "2.9"
-slog-async = "2.8"
-slog-stdlog = "4.1"
-slog-scope = "4.4"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tracing-appender = "0.2"
 base64 = "0.22"
 bincode = "1.3"
 url = { version = "2.5.4", default-features = false }
@@ -153,6 +151,7 @@ parking_lot = "0.12.4"
 proxy-protocol = "0.5"
 jsonwebtoken = "9.3.1"
 quinn = "0.11.6"
+time = "0.3"
 
 [profile.dev]
 opt-level = 0

--- a/rmqtt-bin/Cargo.toml
+++ b/rmqtt-bin/Cargo.toml
@@ -27,13 +27,12 @@ rmqtt-conf.workspace = true
 rmqtt-net.workspace = true
 structopt.workspace = true
 log.workspace = true
-slog.workspace = true
-slog-stdlog.workspace = true
-slog-scope.workspace = true
-slog-term.workspace = true
-slog-async.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-appender.workspace = true
 anyhow.workspace = true
 chrono = { workspace = true, features = ["clock"] }
+time.workspace = true
 
 ##plugins
 rmqtt-acl.workspace = true

--- a/rmqtt-bin/src/logger.rs
+++ b/rmqtt-bin/src/logger.rs
@@ -1,19 +1,9 @@
 use std::path::Path;
 use std::sync::OnceLock;
 
-use time::{
-    format_description::FormatItem,
-    macros::format_description,
-    OffsetDateTime, UtcOffset,
-};
+use time::{format_description::FormatItem, macros::format_description, OffsetDateTime, UtcOffset};
 use tracing_appender::non_blocking::{self, WorkerGuard};
-use tracing_subscriber::{
-    fmt,
-    fmt::time::FormatTime,
-    layer::SubscriberExt,
-    prelude::*,
-    EnvFilter,
-};
+use tracing_subscriber::{fmt, fmt::time::FormatTime, layer::SubscriberExt, prelude::*, EnvFilter};
 
 use rmqtt_conf::logging::{Log, To};
 use rmqtt_net::Result;
@@ -40,10 +30,7 @@ impl LocalTimer {
 
 impl FormatTime for LocalTimer {
     #[inline]
-    fn format_time(
-        &self,
-        w: &mut tracing_subscriber::fmt::format::Writer<'_>,
-    ) -> std::fmt::Result {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
         let now = OffsetDateTime::now_utc().to_offset(self.offset);
 
         match now.format(TIME_FORMAT) {
@@ -55,14 +42,10 @@ impl FormatTime for LocalTimer {
 
 #[inline]
 fn build_env_filter(level: &str) -> EnvFilter {
-    EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(level))
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level))
 }
 
-fn build_non_blocking_writer(
-    dir: &str,
-    file: &str,
-) -> Result<non_blocking::NonBlocking> {
+fn build_non_blocking_writer(dir: &str, file: &str) -> Result<non_blocking::NonBlocking> {
     if !Path::new(dir).exists() {
         std::fs::create_dir_all(dir)?;
     }
@@ -82,11 +65,7 @@ fn build_non_blocking_writer(
 /// Shared layer configuration.
 macro_rules! common_layer {
     ($layer:expr) => {
-        $layer
-            .with_target(true)
-            .with_line_number(true)
-            .with_thread_ids(false)
-            .with_ansi(false)
+        $layer.with_target(true).with_line_number(true).with_thread_ids(false).with_ansi(false)
     };
 }
 
@@ -108,13 +87,11 @@ pub fn logger_init(cfg: &Log) -> Result<()> {
         To::Console => {
             tracing_subscriber::registry()
                 .with(
-                    common_layer!(
-                        fmt::layer()
-                            .with_writer(std::io::stderr)
-                            .with_timer(LocalTimer::new())
-                            .compact()
-                    )
-                        .with_filter(env_filter),
+                    common_layer!(fmt::layer()
+                        .with_writer(std::io::stderr)
+                        .with_timer(LocalTimer::new())
+                        .compact())
+                    .with_filter(env_filter),
                 )
                 .try_init()?;
         }
@@ -124,11 +101,7 @@ pub fn logger_init(cfg: &Log) -> Result<()> {
 
             tracing_subscriber::registry()
                 .with(
-                    common_layer!(
-                        fmt::layer()
-                            .with_writer(writer)
-                            .with_timer(LocalTimer::new())
-                    )
+                    common_layer!(fmt::layer().with_writer(writer).with_timer(LocalTimer::new()))
                         .with_filter(env_filter),
                 )
                 .try_init()?;
@@ -139,25 +112,16 @@ pub fn logger_init(cfg: &Log) -> Result<()> {
 
             let file_filter = env_filter.clone();
 
-            let file_layer = common_layer!(
-                fmt::layer()
-                    .with_writer(writer)
-                    .with_timer(LocalTimer::new())
-            )
+            let file_layer = common_layer!(fmt::layer().with_writer(writer).with_timer(LocalTimer::new()))
                 .with_filter(file_filter);
 
-            let console_layer = common_layer!(
-                fmt::layer()
-                    .with_writer(std::io::stderr)
-                    .with_timer(LocalTimer::new())
-                    .compact()
-            )
-                .with_filter(env_filter);
+            let console_layer = common_layer!(fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_timer(LocalTimer::new())
+                .compact())
+            .with_filter(env_filter);
 
-            tracing_subscriber::registry()
-                .with(file_layer)
-                .with(console_layer)
-                .try_init()?;
+            tracing_subscriber::registry().with(file_layer).with(console_layer).try_init()?;
         }
 
         _ => {}

--- a/rmqtt-bin/src/logger.rs
+++ b/rmqtt-bin/src/logger.rs
@@ -1,127 +1,167 @@
-use std::fs::{File, OpenOptions};
-use std::io::{self, Write};
+use std::path::Path;
+use std::sync::OnceLock;
 
-use anyhow::anyhow;
-use slog::{o, Drain, Record};
-use slog_scope::GlobalLoggerGuard;
-use slog_term::{CountingWriter, RecordDecorator, ThreadSafeTimestampFn};
+use time::{
+    format_description::FormatItem,
+    macros::format_description,
+    OffsetDateTime, UtcOffset,
+};
+use tracing_appender::non_blocking::{self, WorkerGuard};
+use tracing_subscriber::{
+    fmt,
+    fmt::time::FormatTime,
+    layer::SubscriberExt,
+    prelude::*,
+    EnvFilter,
+};
 
-use rmqtt_conf::logging::{Level, Log, To};
+use rmqtt_conf::logging::{Log, To};
 use rmqtt_net::Result;
 
-/// Initializes a logger using `slog` and `slog_scope`.
-///
-/// This function creates a `GlobalLoggerGuard` and sets the global logger to the `logger` passed
-/// in the `Runtime` instance. It also initializes `slog_stdlog` with the log level specified in
-/// the `Runtime` settings.
-pub fn logger_init(cfg: &Log) -> Result<(GlobalLoggerGuard, slog::Logger)> {
-    let logger = config_logger(cfg.filename(), cfg.to, cfg.level)?;
-    let level = slog_log_to_level(cfg.level.inner());
-    // Make sure to save the guard, see documentation for more information
-    let guard = slog_scope::set_global_logger(logger.clone());
-    // register slog_stdlog as the log handler with the log crate
-    slog_stdlog::init_with_level(level)?;
-    Ok((guard, logger))
+/// Prevent log loss on process exit.
+static LOG_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
+
+/// Example:
+/// 2026-05-16 19:00:07.487
+static TIME_FORMAT: &[FormatItem<'static>] =
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]");
+
+struct LocalTimer {
+    offset: UtcOffset,
 }
 
-fn slog_log_to_level(level: slog::Level) -> log::Level {
-    match level {
-        slog::Level::Trace => log::Level::Trace,
-        slog::Level::Debug => log::Level::Debug,
-        slog::Level::Info => log::Level::Info,
-        slog::Level::Warning => log::Level::Warn,
-        slog::Level::Error => log::Level::Error,
-        slog::Level::Critical => log::Level::Error,
+impl LocalTimer {
+    #[inline]
+    fn new() -> Self {
+        let offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);
+        Self { offset }
     }
 }
 
-/// Creates a new `slog::Logger` with two `Drain`s: one for printing to the console and another for
-/// printing to a file.
-///
-/// This function takes three arguments: `filename`, which specifies the name of the file to print
-/// to; `to`, which specifies where to print the logs (either the console or a file); and `level`,
-/// which specifies the minimum log level to print. The function sets the format for the logs and
-/// creates the two `Drain`s using the provided parameters. It then combines the two `Drain`s using a
-/// `Tee` and returns the resulting `Logger`.
-pub fn config_logger(filename: String, to: To, level: Level) -> Result<slog::Logger> {
-    let custom_timestamp =
-        |io: &mut dyn io::Write| write!(io, "{}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f"));
+impl FormatTime for LocalTimer {
+    #[inline]
+    fn format_time(
+        &self,
+        w: &mut tracing_subscriber::fmt::format::Writer<'_>,
+    ) -> std::fmt::Result {
+        let now = OffsetDateTime::now_utc().to_offset(self.offset);
 
-    let print_msg_header = |fn_timestamp: &dyn ThreadSafeTimestampFn<Output = io::Result<()>>,
-                            mut rd: &mut dyn RecordDecorator,
-                            record: &Record,
-                            _use_file_location: bool|
-     -> io::Result<bool> {
-        rd.start_timestamp()?;
-        fn_timestamp(&mut rd)?;
-
-        rd.start_whitespace()?;
-        write!(rd, " ")?;
-
-        rd.start_level()?;
-        write!(rd, "{}", record.level().as_short_str())?;
-
-        rd.start_location()?;
-        if record.function().is_empty() {
-            write!(rd, " {}.{} | ", record.module(), record.line())?;
-        } else {
-            write!(rd, " {}::{}.{} | ", record.module(), record.function(), record.line())?;
+        match now.format(TIME_FORMAT) {
+            Ok(s) => w.write_str(&s),
+            Err(_) => w.write_str("0000-00-00 00:00:00.000"),
         }
-
-        rd.start_msg()?;
-        let mut count_rd = CountingWriter::new(&mut rd);
-        write!(count_rd, "{}", record.msg())?;
-        Ok(count_rd.count() != 0)
-    };
-
-    //Console
-    let stdout_drain = if to.console() {
-        let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        let stdout_drain = slog_term::FullFormat::new(plain)
-            .use_custom_timestamp(custom_timestamp)
-            .use_custom_header_print(print_msg_header)
-            .build()
-            .fuse();
-        Some(stdout_drain.filter_level(level.inner()).fuse())
-    } else {
-        None
-    };
-
-    //File
-    let file_drain = if to.file() {
-        let decorator = slog_term::PlainSyncDecorator::new(open_file(&filename)?);
-        let file_drain = slog_term::FullFormat::new(decorator)
-            .use_custom_timestamp(custom_timestamp)
-            .use_custom_header_print(print_msg_header)
-            .build()
-            .fuse();
-
-        //@TODO config ...
-        let file_drain = slog_async::Async::new(file_drain)
-            .chan_size(100_000)
-            .overflow_strategy(slog_async::OverflowStrategy::DropAndReport)
-            .build()
-            .fuse();
-
-        Some(file_drain.filter_level(level.inner()).fuse())
-    } else {
-        None
-    };
-
-    Ok(match (stdout_drain, file_drain) {
-        (Some(stdout_drain), None) => slog::Logger::root(stdout_drain, o!()),
-        (None, Some(file_drain)) => slog::Logger::root(file_drain, o!()),
-        (Some(stdout_drain), Some(file_drain)) => {
-            slog::Logger::root(slog::Duplicate::new(stdout_drain, file_drain).fuse(), o!())
-        }
-        (None, None) => slog::Logger::root(slog::Discard, o!()),
-    })
+    }
 }
 
-fn open_file(filename: &str) -> Result<File> {
-    OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(filename)
-        .map_err(|e| anyhow!(format!("logger file config error, filename: {}, {:?}", filename, e)))
+#[inline]
+fn build_env_filter(level: &str) -> EnvFilter {
+    EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(level))
+}
+
+fn build_non_blocking_writer(
+    dir: &str,
+    file: &str,
+) -> Result<non_blocking::NonBlocking> {
+    if !Path::new(dir).exists() {
+        std::fs::create_dir_all(dir)?;
+    }
+
+    let file_appender = tracing_appender::rolling::never(dir, file);
+
+    let (writer, guard) = non_blocking::NonBlockingBuilder::default()
+        .lossy(false)
+        .buffered_lines_limit(1024 * 1024)
+        .finish(file_appender);
+
+    let _ = LOG_GUARD.set(guard);
+
+    Ok(writer)
+}
+
+/// Shared layer configuration.
+macro_rules! common_layer {
+    ($layer:expr) => {
+        $layer
+            .with_target(true)
+            .with_line_number(true)
+            .with_thread_ids(false)
+            .with_ansi(false)
+    };
+}
+
+/// Initializes tracing logger.
+///
+/// Supported config:
+/// - log.to: off | console | file | both
+/// - log.level: trace | debug | info | warn | error
+/// - log.dir
+/// - log.file
+pub fn logger_init(cfg: &Log) -> Result<()> {
+    if cfg.to.off() {
+        return Ok(());
+    }
+
+    let env_filter = build_env_filter(cfg.level.as_str());
+
+    match cfg.to {
+        To::Console => {
+            tracing_subscriber::registry()
+                .with(
+                    common_layer!(
+                        fmt::layer()
+                            .with_writer(std::io::stderr)
+                            .with_timer(LocalTimer::new())
+                            .compact()
+                    )
+                        .with_filter(env_filter),
+                )
+                .try_init()?;
+        }
+
+        To::File => {
+            let writer = build_non_blocking_writer(&cfg.dir, &cfg.file)?;
+
+            tracing_subscriber::registry()
+                .with(
+                    common_layer!(
+                        fmt::layer()
+                            .with_writer(writer)
+                            .with_timer(LocalTimer::new())
+                    )
+                        .with_filter(env_filter),
+                )
+                .try_init()?;
+        }
+
+        To::Both => {
+            let writer = build_non_blocking_writer(&cfg.dir, &cfg.file)?;
+
+            let file_filter = env_filter.clone();
+
+            let file_layer = common_layer!(
+                fmt::layer()
+                    .with_writer(writer)
+                    .with_timer(LocalTimer::new())
+            )
+                .with_filter(file_filter);
+
+            let console_layer = common_layer!(
+                fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_timer(LocalTimer::new())
+                    .compact()
+            )
+                .with_filter(env_filter);
+
+            tracing_subscriber::registry()
+                .with(file_layer)
+                .with(console_layer)
+                .try_init()?;
+        }
+
+        _ => {}
+    }
+
+    Ok(())
 }

--- a/rmqtt-bin/src/server.rs
+++ b/rmqtt-bin/src/server.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
         .expect("Failed to install the default Rustls crypto backend because it is already installed.");
 
     //init log
-    let (_guard, _logger) = logger::logger_init(&conf.log).expect("logger init failed");
+    logger::logger_init(&conf.log).expect("logger init failed");
 
     //node info
     let node = Node::new(
@@ -80,27 +80,63 @@ async fn main() -> Result<()> {
 
     //tcp
     for (_, listen_cfg) in Settings::instance().listeners.tcps.iter() {
-        builder = builder.listener(config_builder(listen_cfg).bind()?.tcp()?);
+        let listener = match config_builder(listen_cfg).bind() {
+            Ok(l) => l.tcp()?,
+            Err(e) => {
+                log::error!("Failed to bind TCP listener on {}: {}", listen_cfg.addr, e);
+                return Err(e);
+            }
+        };
+        builder = builder.listener(listener);
     }
 
     //tls
     for (_, listen_cfg) in Settings::instance().listeners.tlss.iter() {
-        builder = builder.listener(config_builder(listen_cfg).bind()?.tls()?);
+        let listener = match config_builder(listen_cfg).bind() {
+            Ok(l) => l.tls()?,
+            Err(e) => {
+                log::error!("Failed to bind TLS listener on {}: {}", listen_cfg.addr, e);
+                return Err(e);
+            }
+        };
+        builder = builder.listener(listener);
     }
 
     //websocket
     for (_, listen_cfg) in Settings::instance().listeners.wss.iter() {
-        builder = builder.listener(config_builder(listen_cfg).bind()?.ws()?);
+        let listener = match config_builder(listen_cfg).bind() {
+            Ok(l) => l.ws()?,
+            Err(e) => {
+                log::error!("Failed to bind WebSocket listener on {}: {}", listen_cfg.addr, e);
+                return Err(e);
+            }
+        };
+        builder = builder.listener(listener);
     }
 
     //tls-websocket
     for (_, listen_cfg) in Settings::instance().listeners.wsss.iter() {
-        builder = builder.listener(config_builder(listen_cfg).bind()?.wss()?);
+        let listener = match config_builder(listen_cfg).bind() {
+            Ok(l) => l.wss()?,
+            Err(e) => {
+                log::error!("Failed to bind WSS listener on {}: {}", listen_cfg.addr, e);
+                return Err(e);
+            }
+        };
+        builder = builder.listener(listener);
     }
 
     //MQTT over QUIC
     for (_, listen_cfg) in Settings::instance().listeners.quics.iter() {
-        builder = builder.listener(config_builder(listen_cfg).bind_quic()?);
+        let listener = match config_builder(listen_cfg).bind_quic() {
+            Ok(l) => l,
+            Err(e) => {
+                log::error!("Failed to bind QUIC listener on {}: {}", listen_cfg.addr, e);
+
+                return Err(e);
+            }
+        };
+        builder = builder.listener(listener);
     }
 
     builder.build().start();

--- a/rmqtt-conf/Cargo.toml
+++ b/rmqtt-conf/Cargo.toml
@@ -23,7 +23,6 @@ serde.workspace = true
 log.workspace = true
 serde_json.workspace = true
 ahash.workspace = true
-slog.workspace = true
 structopt.workspace = true
 bytestring.workspace = true
 

--- a/rmqtt-conf/src/logging.rs
+++ b/rmqtt-conf/src/logging.rs
@@ -4,7 +4,6 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Log {
     #[serde(default = "Log::to_default")]
-
     pub to: To,
     #[serde(default = "Log::level_default")]
     pub level: Level,

--- a/rmqtt-conf/src/logging.rs
+++ b/rmqtt-conf/src/logging.rs
@@ -1,11 +1,10 @@
 use serde::de::{self, Deserializer};
 use serde::Deserialize;
-use std::ops::{Deref, DerefMut};
-use std::str::FromStr;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Log {
     #[serde(default = "Log::to_default")]
+
     pub to: To,
     #[serde(default = "Log::level_default")]
     pub level: Level,
@@ -34,11 +33,11 @@ impl Log {
     }
     #[inline]
     fn level_default() -> Level {
-        Level { inner: slog::Level::Info }
+        Level::Info
     }
     #[inline]
     fn dir_default() -> String {
-        "/etc/log/rmqtt".into()
+        "/var/log/rmqtt".into()
     }
     #[inline]
     fn file_default() -> String {
@@ -100,29 +99,30 @@ impl<'de> Deserialize<'de> for To {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct Level {
-    inner: slog::Level,
+pub enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
 }
 
 impl Level {
     #[inline]
-    pub fn inner(&self) -> slog::Level {
-        self.inner
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Level::Trace => "trace",
+            Level::Debug => "debug",
+            Level::Info => "info",
+            Level::Warn => "warn",
+            Level::Error => "error",
+        }
     }
 }
 
-impl Deref for Level {
-    type Target = slog::Level;
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl DerefMut for Level {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+impl std::fmt::Display for Level {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -133,7 +133,14 @@ impl<'de> Deserialize<'de> for Level {
         D: Deserializer<'de>,
     {
         let level = String::deserialize(deserializer)?;
-        let level = slog::Level::from_str(&level).map_err(|_e| de::Error::missing_field("level"))?;
-        Ok(Level { inner: level })
+        let level = match level.to_ascii_lowercase().as_str() {
+            "trace" => Level::Trace,
+            "debug" => Level::Debug,
+            "info" => Level::Info,
+            "warn" => Level::Warn,
+            "error" => Level::Error,
+            _ => return Err(de::Error::missing_field("level")),
+        };
+        Ok(level)
     }
 }

--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -18,9 +18,6 @@ backoff = { workspace = true, features = ["futures", "tokio"] }
 rust-box = { workspace = true, features = ["task-exec-queue"] }
 serde_json.workspace = true
 log.workspace = true
-slog-stdlog.workspace = true
-slog.workspace = true
-slog-term.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true
 bytes.workspace = true
@@ -32,6 +29,9 @@ ahash.workspace = true
 bincode.workspace = true
 rayon.workspace = true
 
+slog = "2.7"
+slog-term = "2.9"
+slog-stdlog = "4.1"
 
 lz4_flex = { version = "0.11" }
 lz4 = "1.27.0"

--- a/rmqtt/src/server.rs
+++ b/rmqtt/src/server.rs
@@ -181,7 +181,7 @@ impl MqttServer {
     pub fn start(self) {
         tokio::spawn(async move {
             if let Err(e) = self.run().await {
-                log::error!("Failed to start the MQTT server! {e}");
+                eprintln!("Failed to start the MQTT server! {e}");
                 std::process::exit(1);
             }
         });


### PR DESCRIPTION
- Replace slog logging framework with tracing (tracing, tracing-subscriber, tracing-appender)
- Add non-blocking async file writer support with configurable buffer limits
- Implement local timezone-aware timestamp formatting
- Add env_filter support for dynamic log level control
- Update logger config structure with new Level enum (Trace, Debug, Info, Warn, Error)
- Change default log directory from /etc/log/rmqtt to /var/log/rmqtt
- Improve error handling for listener binding failures with detailed error messages
- Remove slog dependencies from workspace and individual crates
- Keep slog only in cluster-raft plugin (external dependency)

Benefits:
- Better structured logging with span support
- Async non-blocking file I/O prevents logging bottlenecks
- Environment variable based filter control (RUST_LOG)
- Modern Rust logging ecosystem integration