### PR TITLE
fix(bridge-egress-mqtt): anti-loop guard for bidirectional mesh

### DIFF
--- a/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-egress-mqtt/src/lib.rs
@@ -147,6 +147,44 @@ impl Handler for HookHandler {
     async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
         match param {
             Parameter::MessagePublish(s, f, p) => {
+                // ── Anti-loop guard for bidirectional bridge mesh ──
+                //
+                // In a mesh of brokers where every pair has a bidirectional
+                // egress-mqtt bridge, a single PUBLISH amplifies infinitely
+                // without this filter. Empirically: ~75K deliveries per second
+                // across a 2-broker A↔B mesh from one client publish.
+                //
+                // Two cases:
+                //
+                // 1) `s.is_none()` — publish injected by an internal source
+                //    (rmqtt-bridge-ingress-mqtt and similar plugins call
+                //    `hook_mgr().message_publish(None, ...)` to inject what
+                //    they received from the remote). Forwarding it back over
+                //    egress echoes the message we just imported.
+                //
+                // 2) The publish has a session, but the session's client_id
+                //    is one of this plugin's egress clients (or the ingress
+                //    plugin's clients). Both build their client_id as
+                //    `<prefix>:<bridge_name>:{egress|ingress}:<node_id>:
+                //    <entry_idx>:<client_no>`. Re-forwarding such publishes
+                //    is what bounces messages A.egress→B→B.egress→A→...
+                //    indefinitely. Filtering on the ":egress:" / ":ingress:"
+                //    substring catches them regardless of operator-configured
+                //    `client_id_prefix`.
+                //
+                // Operators who want a fully-symmetric mesh should *also*
+                // disable the ingress plugin on every node — otherwise the
+                // egress + remote ingress combination doubles every delivery
+                // (no loop, but each message lands twice on every subscriber).
+                if s.is_none() {
+                    return (true, acc);
+                }
+                if let Some(sess) = s {
+                    let cid: &str = sess.id.client_id.as_ref();
+                    if cid.contains(":egress:") || cid.contains(":ingress:") {
+                        return (true, acc);
+                    }
+                }
                 let p = if let Some(HookResult::Publish(publish)) = &acc { publish } else { p };
                 log::debug!("{:?} message publish, {:?}", s.map(|s| &s.id), p);
                 if let Err(e) = self.bridge_mgr.send(f, p).await {


### PR DESCRIPTION
## Problem

In a mesh where every pair of brokers has a bidirectional `rmqtt-bridge-egress-mqtt` bridge, a single PUBLISH amplifies infinitely. Measured: **~75 000 deliveries per second across a 2-broker A↔B mesh from one client publish** (CPU saturated, count growing).

Two distinct loop paths exist:

1. **Session-less republish loop**: `rmqtt-bridge-ingress-mqtt` injects messages it pulled from the remote by calling `hook_mgr().message_publish(None, ...)`. The egress hook then re-forwards them back to the remote.

2. **Bridge-to-bridge client loop**: messages that arrive on the local broker over a real MQTT session whose client is another node's egress (or this node's ingress) get re-forwarded over our own egress, bouncing forever between brokers.

## Fix

Filter both cases in the `MessagePublish` hook of `rmqtt-bridge-egress-mqtt`:

- Skip if `s.is_none()` — covers case 1.
- Skip if the session's `client_id` contains `:egress:` or `:ingress:` — those substrings are baked into the auto-generated client_id of both plugins (`<prefix>:<bridge_name>:{egress|ingress}:<node_id>:<entry_idx>:<client_no>`), so the check is robust to any operator-configured `client_id_prefix`.

Conservative by design: never re-forwards a message that arrived through a bridge. Original client publishes (arbitrary client_id, with a session) are unaffected.

## Validation

| Configuration | Subscriber A received | Subscriber B received |
|---|---|---|
| 2 brokers, bidirectional egress+ingress, **stock** | 276 491 / 5s (growing, CPU saturated) | 276 007 / 5s |
| 2 brokers, bidirectional egress+ingress, **with this fix** | 1 | 1 |
| 2 brokers, bidirectional egress only, **with this fix** | 1 publish in A → 1 in B + 1 local | symmetric |

## Operator note (worth documenting alongside)

Even with this fix, a fully-symmetric mesh works best with **egress only** on each node. The combination of egress on broker A and ingress on broker B for the same topic still delivers each message twice on every subscriber (no loop, but a duplicate). Disable `rmqtt-bridge-ingress-mqtt` where the same topics are already covered by the peers' egress.

## Compatibility

- No public API or config schema changes.
- A deployment that relies on the looping behaviour (none expected — it's silently broken) would need to be reviewed. None of the docs document this case.