### PR TITLE
fix(http-api): add startup synchronization and improve reload handling

### DIFF
--- a/rmqtt-plugins/rmqtt-http-api/src/api.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/api.rs
@@ -148,6 +148,7 @@ pub(crate) async fn listen_and_serve(
     laddr: SocketAddr,
     cfg: PluginConfigType,
     rx: oneshot::Receiver<()>,
+    started_tx: oneshot::Sender<()>,
 ) -> Result<()> {
     let (reuseaddr, reuseport, http_bearer_token) = {
         let cfg = cfg.read().await;
@@ -164,6 +165,7 @@ pub(crate) async fn listen_and_serve(
         rx.await.ok();
         handler.stop_graceful(None);
     });
+    let _ = started_tx.send(());
     let monitor = prome::Monitor::new();
     server.try_serve(route(scx, cfg, http_bearer_token, monitor)).await?;
     Ok(())

--- a/rmqtt-plugins/rmqtt-http-api/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use tokio::{self, sync::oneshot, sync::RwLock};
 
@@ -45,20 +46,24 @@ impl HttpApiPlugin {
         log::info!("{name} HttpApiPlugin cfg: {cfg:?}");
         let cfg = Arc::new(RwLock::new(cfg?));
         let register = scx.extends.hook_mgr().register();
-        let shutdown_tx = Some(Self::start(scx.clone(), cfg.clone()).await);
+        let shutdown_tx = Some(Self::start(scx.clone(), cfg.clone()).await?);
         Ok(Self { scx, register, cfg, shutdown_tx })
     }
 
-    async fn start(scx: ServerContext, cfg: PluginConfigType) -> ShutdownTX {
-        let (shutdown_tx, shutdown_rx): (oneshot::Sender<()>, oneshot::Receiver<()>) = oneshot::channel();
+    async fn start(scx: ServerContext, cfg: PluginConfigType) -> Result<ShutdownTX> {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (started_tx, started_rx) = oneshot::channel();
         let http_laddr = cfg.read().await.http_laddr;
         tokio::spawn(async move {
-            if let Err(e) = api::listen_and_serve(scx, http_laddr, cfg, shutdown_rx).await {
+            if let Err(e) = api::listen_and_serve(scx, http_laddr, cfg, shutdown_rx, started_tx).await {
                 log::error!("{e:?}");
             }
             log::info!("Exit HTTP API Server, ..., http://{http_laddr:?}");
         });
-        shutdown_tx
+
+        started_rx.await.map_err(|_| anyhow!("HTTP API server failed to bind on {http_laddr}"))?;
+
+        Ok(shutdown_tx)
     }
 }
 
@@ -88,13 +93,18 @@ impl Plugin for HttpApiPlugin {
         let restart_enable = self.cfg.read().await.restart_enable(&new_cfg);
         if restart_enable {
             let new_cfg = Arc::new(RwLock::new(new_cfg));
-            if let Some(tx) = self.shutdown_tx.take() {
-                if let Err(e) = tx.send(()) {
-                    log::warn!("shutdown_tx send fail, {e:?}");
+            match Self::start(self.scx.clone(), new_cfg.clone()).await {
+                Ok(tx) => {
+                    if let Some(old_tx) = self.shutdown_tx.take() {
+                        let _ = old_tx.send(());
+                    }
+                    self.shutdown_tx = Some(tx);
+                    self.cfg = new_cfg;
+                }
+                Err(e) => {
+                    return Err(e);
                 }
             }
-            self.shutdown_tx = Some(Self::start(self.scx.clone(), new_cfg.clone()).await);
-            self.cfg = new_cfg;
         } else {
             *self.cfg.write().await = new_cfg;
         }


### PR DESCRIPTION
- Add `started_tx` channel to signal when HTTP server successfully binds to port
- Return `Result` from `start()` method to propagate bind failures during plugin init/reload
- Properly sequence shutdown/start during config reload: stop old server only after new server starts successfully
- Prevent plugin from running with unbound HTTP server on port conflicts