### PR TITLE
feat(bridge-origin): add bridge-origin plugin for identifying bridge …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4883,6 +4883,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmqtt-bridge-origin"
+version = "0.21.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "log",
+ "rmqtt",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "rmqtt-cluster-broadcast"
 version = "0.21.0"
 dependencies = [
@@ -5288,6 +5301,7 @@ dependencies = [
  "rmqtt-bridge-ingress-mqtt",
  "rmqtt-bridge-ingress-nats",
  "rmqtt-bridge-ingress-pulsar",
+ "rmqtt-bridge-origin",
  "rmqtt-cluster-broadcast",
  "rmqtt-cluster-raft",
  "rmqtt-conf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rmqtt-bridge-egress-pulsar = { path = "rmqtt-plugins/rmqtt-bridge-egress-pulsar"
 rmqtt-bridge-ingress-nats = { path = "rmqtt-plugins/rmqtt-bridge-ingress-nats"}
 rmqtt-bridge-egress-nats = { path = "rmqtt-plugins/rmqtt-bridge-egress-nats"}
 rmqtt-bridge-egress-reductstore = { path = "rmqtt-plugins/rmqtt-bridge-egress-reductstore"}
+rmqtt-bridge-origin = { path = "rmqtt-plugins/rmqtt-bridge-origin"}
 rmqtt-p2p-messaging = { path = "rmqtt-plugins/rmqtt-p2p-messaging"}
 
 
@@ -88,6 +89,7 @@ rmqtt-bridge-egress-pulsar = "0.21.0"
 rmqtt-bridge-ingress-nats = "0.21.0"
 rmqtt-bridge-egress-nats = "0.21.0"
 rmqtt-bridge-egress-reductstore = "0.21.0"
+rmqtt-bridge-origin = "0.21.0"
 rmqtt-message-storage = "0.21.0"
 rmqtt-session-storage = "0.21.0"
 rmqtt-sys-topic = "0.21.0"

--- a/docs/en_US/bridge-origin.md
+++ b/docs/en_US/bridge-origin.md
@@ -1,0 +1,143 @@
+English | [简体中文](../zh_CN/bridge-origin.md)
+
+# Bridge Origin
+
+The `rmqtt-bridge-origin` plugin is responsible for identifying whether an MQTT client originates from a bridge-ingress-mqtt or bridge-egress-mqtt connection.
+
+When bridge plugins (such as `rmqtt-bridge-ingress-mqtt` or `rmqtt-bridge-egress-mqtt`) connect to remote MQTT brokers, they generate client IDs with identifiable markers. For example:
+
+```bash
+# Ingress bridge client ID example
+node-a:ingress:node-b
+
+# Egress bridge client ID example
+node-a:egress:node-b
+```
+
+The `rmqtt-bridge-origin` plugin listens for the `ClientConnected` hook event after a client successfully connects, checks the `client_id` against configurable markers, and writes the bridge origin information into `session.extra_attrs`. This metadata can then be consumed by other plugins for purposes such as anti-loop or routing decisions.
+
+**Note:** This plugin is only responsible for identification and metadata storage — it does not perform anti-loop, message filtering, message dropping, routing control, or bridge forwarding logic. These responsibilities belong to other bridge plugins.
+
+#### Plugin:
+
+```bash
+rmqtt-bridge-origin
+```
+
+#### Plugin Configuration File:
+
+```bash
+plugins/rmqtt-bridge-origin.toml
+```
+
+#### Plugin Configuration Options:
+
+```bash
+##--------------------------------------------------------------------
+## rmqtt-bridge-origin
+##--------------------------------------------------------------------
+
+# Marker string to identify ingress bridge clients.
+# If a client_id contains this substring, it is treated as an ingress bridge client.
+# Default: ":ingress:"
+#ingress_marker = ":ingress:"
+
+# Marker string to identify egress bridge clients.
+# If a client_id contains this substring, it is treated as an egress bridge client.
+# Default: ":egress:"
+#egress_marker = ":egress:"
+
+# Key used to store BridgeOrigin in session.extra_attrs.
+# Default: "bridge_origin"
+#attr_key = "bridge_origin"
+```
+
+#### Data Model:
+
+The bridge origin information is stored as typed data in `session.extra_attrs` under the configurable `attr_key` (defaults to `"bridge_origin"`):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeDirection {
+    Ingress,
+    Egress,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BridgeOrigin {
+    pub direction: BridgeDirection,
+}
+
+impl BridgeOrigin {
+    pub fn is_ingress(&self) -> bool { ... }
+    pub fn is_egress(&self) -> bool { ... }
+}
+```
+
+#### Usage in Other Plugins:
+
+Other plugins can read the stored bridge origin data from the client session.
+The attribute key used to read the data must match the `attr_key` configured in `rmqtt-bridge-origin` (defaults to `"bridge_origin"`):
+
+```rust
+if let Some(origin) = session
+    .extra_attrs
+    .read()
+    .await
+    .get::<BridgeOrigin>("bridge_origin")
+{
+    if origin.is_ingress() {
+        log::info!("message from ingress bridge, skip forwarding");
+        return (true, acc);
+    }
+}
+```
+
+This pattern is particularly useful in bridge egress plugins to avoid forwarding loops:
+messages that arrived via an ingress bridge should not be forwarded back to a remote broker by an egress bridge.
+
+#### Client ID Pattern Recognition:
+
+The plugin recognizes bridge clients by matching substrings in the `client_id`. The markers are configurable, with the following defaults:
+
+| Bridge Type | Default Marker | Example client_id |
+|-------------|----------------|-------------------|
+| Ingress     | `:ingress:`    | `prefix:bridge_a:ingress:node1:0:1` |
+| Egress      | `:egress:`     | `prefix:bridge_b:egress:node2:0:1` |
+
+These markers align with the auto-generated client ID patterns used by `rmqtt-bridge-ingress-mqtt` and `rmqtt-bridge-egress-mqtt` plugins.
+
+#### Conflict Detection:
+
+If a `client_id` contains both ingress and egress markers simultaneously (which should not occur under normal operation), the plugin logs a warning and ignores the connection to avoid ambiguity:
+
+```bash
+WARN bridge-origin: client_id contains both ingress and egress markers, client_id=...
+```
+
+By default, this plugin is not enabled. To activate it, you must add the `rmqtt-bridge-origin` entry to the
+`plugins.default_startups` configuration in the main configuration file `rmqtt.toml`, as shown below:
+```bash
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+#Plug in configuration file directory
+plugins.dir = "rmqtt-plugins/"
+#Plug in started by default, when the mqtt server is started
+plugins.default_startups = [
+    #"rmqtt-plugin-template",
+    #"rmqtt-retainer",
+    #"rmqtt-auth-http",
+    #"rmqtt-cluster-broadcast",
+    #"rmqtt-cluster-raft",
+    #"rmqtt-sys-topic",
+    #"rmqtt-message-storage",
+    #"rmqtt-session-storage",
+    #"rmqtt-bridge-ingress-mqtt",
+    #"rmqtt-bridge-egress-mqtt",
+    "rmqtt-bridge-origin",
+    "rmqtt-web-hook",
+    "rmqtt-http-api"
+]
+```
+

--- a/docs/zh_CN/bridge-origin.md
+++ b/docs/zh_CN/bridge-origin.md
@@ -1,0 +1,142 @@
+[English](../en_US/bridge-origin.md) | 简体中文
+
+# 桥接来源识别
+
+`rmqtt-bridge-origin` 插件负责识别 MQTT 客户端是否来自 `rmqtt-bridge-ingress-mqtt` 或 `rmqtt-bridge-egress-mqtt` 插件建立的桥接连接。
+
+当桥接插件（如 `rmqtt-bridge-ingress-mqtt` 或 `rmqtt-bridge-egress-mqtt`）连接到远程 MQTT 代理时，它们会生成带有可识别标记的客户端ID。例如：
+
+```bash
+# 入口桥接客户端 ID 示例
+node-a:ingress:node-b
+
+# 出口桥接客户端 ID 示例
+node-a:egress:node-b
+```
+
+`rmqtt-bridge-origin` 插件监听客户端连接成功后的 `ClientConnected` 事件，检查 `client_id` 中是否包含可配置的标记，并将桥接来源信息写入 `session.extra_attrs`。其他插件可以读取这些元数据，用于防环或路由决策等场景。
+
+**注意：** 此插件仅负责识别和元数据存储——它不执行防环、消息过滤、消息丢弃、路由控制或桥接转发逻辑。这些职责属于其他桥接插件。
+
+#### 插件：
+
+```bash
+rmqtt-bridge-origin
+```
+
+#### 插件配置文件：
+
+```bash
+plugins/rmqtt-bridge-origin.toml
+```
+
+#### 插件配置项：
+
+```bash
+##--------------------------------------------------------------------
+## rmqtt-bridge-origin
+##--------------------------------------------------------------------
+
+# 识别入口桥接客户端的标记字符串。
+# 如果 client_id 包含此子字符串，则视为入口桥接客户端。
+# 默认值: ":ingress:"
+#ingress_marker = ":ingress:"
+
+# 识别出口桥接客户端的标记字符串。
+# 如果 client_id 包含此子字符串，则视为出口桥接客户端。
+# 默认值: ":egress:"
+#egress_marker = ":egress:"
+
+# 用于在 session.extra_attrs 中存储 BridgeOrigin 的键名。
+# 默认值: "bridge_origin"
+#attr_key = "bridge_origin"
+```
+
+#### 数据模型：
+
+桥接来源信息以类型化数据存储在 `session.extra_attrs` 中，键名由 `attr_key` 配置项决定（默认为 `"bridge_origin"`）：
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeDirection {
+    Ingress,  // 入口桥接
+    Egress,   // 出口桥接
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BridgeOrigin {
+    pub direction: BridgeDirection,
+}
+
+impl BridgeOrigin {
+    pub fn is_ingress(&self) -> bool { ... }
+    pub fn is_egress(&self) -> bool { ... }
+}
+```
+
+#### 在其他插件中使用：
+
+其他插件可以从客户端会话中读取存储的桥接来源数据。
+读取时使用的键名必须与 `rmqtt-bridge-origin` 中配置的 `attr_key` 一致（默认为 `"bridge_origin"`）：
+
+```rust
+if let Some(origin) = session
+    .extra_attrs
+    .read()
+    .await
+    .get::<BridgeOrigin>("bridge_origin")
+{
+    if origin.is_ingress() {
+        log::info!("消息来自入口桥接，跳过转发");
+        return (true, acc);
+    }
+}
+```
+
+此模式在桥接出口插件中特别有用，用于避免转发循环：
+通过入口桥接到达的消息不应再由出口桥接转发回远程代理。
+
+#### 客户端 ID 模式识别：
+
+插件通过匹配 `client_id` 中的子字符串来识别桥接客户端。标记可通过配置自定义，默认值如下：
+
+| 桥接类型 | 默认标记 | client_id 示例 |
+|---------|---------|----------------|
+| Ingress (入口) | `:ingress:` | `prefix:bridge_a:ingress:node1:0:1` |
+| Egress (出口) | `:egress:`  | `prefix:bridge_b:egress:node2:0:1` |
+
+这些标记与 `rmqtt-bridge-ingress-mqtt` 和 `rmqtt-bridge-egress-mqtt` 插件使用的自动生成客户端 ID 模式保持一致。
+
+#### 冲突检测：
+
+如果 `client_id` 同时包含入口和出口标记（在正常情况下不应发生），插件会记录警告日志并忽略该连接以避免歧义：
+
+```bash
+WARN bridge-origin: client_id contains both ingress and egress markers, client_id=...
+```
+
+默认情况下并没有启动此插件，如果要开启此插件，必须在主配置文件 `rmqtt.toml` 中的 `plugins.default_startups` 配置中添加 `rmqtt-bridge-origin` 项，如：
+```bash
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+#Plug in configuration file directory
+plugins.dir = "rmqtt-plugins/"
+#Plug in started by default, when the mqtt server is started
+plugins.default_startups = [
+    #"rmqtt-plugin-template",
+    #"rmqtt-retainer",
+    #"rmqtt-auth-http",
+    #"rmqtt-cluster-broadcast",
+    #"rmqtt-cluster-raft",
+    #"rmqtt-sys-topic",
+    #"rmqtt-message-storage",
+    #"rmqtt-session-storage",
+    #"rmqtt-bridge-ingress-mqtt",
+    #"rmqtt-bridge-egress-mqtt",
+    "rmqtt-bridge-origin",
+    "rmqtt-web-hook",
+    "rmqtt-http-api"
+]
+```
+

--- a/rmqtt-bin/Cargo.toml
+++ b/rmqtt-bin/Cargo.toml
@@ -51,6 +51,7 @@ rmqtt-bridge-ingress-pulsar.workspace = true
 rmqtt-bridge-ingress-nats.workspace = true
 rmqtt-bridge-egress-nats.workspace = true
 rmqtt-bridge-egress-reductstore.workspace = true
+rmqtt-bridge-origin.workspace = true
 rmqtt-message-storage = { workspace = true, features = ["ram", "redis", "redis-cluster"] }
 rmqtt-session-storage = { workspace = true, features = ["sled", "redis", "redis-cluster"] }
 rmqtt-sys-topic.workspace = true
@@ -78,6 +79,7 @@ rmqtt-bridge-ingress-pulsar = { }
 rmqtt-bridge-ingress-nats = { }
 rmqtt-bridge-egress-nats = { }
 rmqtt-bridge-egress-reductstore = { }
+rmqtt-bridge-origin = { }
 rmqtt-message-storage = { immutable = true }
 rmqtt-session-storage = { immutable = true }
 rmqtt-sys-topic = { }

--- a/rmqtt-plugins/rmqtt-bridge-origin.toml
+++ b/rmqtt-plugins/rmqtt-bridge-origin.toml
@@ -1,0 +1,28 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-origin
+##--------------------------------------------------------------------
+##
+## This plugin identifies whether an MQTT client originates from a
+## bridge-ingress-mqtt or bridge-egress-mqtt connection by checking
+## the client_id against configurable markers.
+##
+## The identified bridge origin is stored in session.extra_attrs
+## under the configurable attr_key, making it available to other
+## plugins (e.g., for anti-loop or routing decisions).
+##
+## See: https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-origin.md
+##--------------------------------------------------------------------
+
+# Marker string to identify ingress bridge clients.
+# If a client_id contains this substring, it is treated as an ingress bridge client.
+# Default: ":ingress:"
+#ingress_marker = ":ingress:"
+
+# Marker string to identify egress bridge clients.
+# If a client_id contains this substring, it is treated as an egress bridge client.
+# Default: ":egress:"
+#egress_marker = ":egress:"
+
+# Key used to store BridgeOrigin in session.extra_attrs.
+# Default: "bridge_origin"
+#attr_key = "bridge_origin"

--- a/rmqtt-plugins/rmqtt-bridge-origin/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-bridge-origin/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rmqtt-bridge-origin"
+version.workspace = true
+description = "Bridge Origin plugin for RMQTT, identifies MQTT clients from bridge-ingress-mqtt or bridge-egress-mqtt connections"
+edition.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+rmqtt = { workspace = true, features = ["plugin"] }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["sync"] }
+log.workspace = true
+async-trait.workspace = true
+anyhow.workspace = true
+serde_json.workspace = true

--- a/rmqtt-plugins/rmqtt-bridge-origin/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-origin/src/config.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+use rmqtt::Result;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PluginConfig {
+    #[serde(default = "default_ingress_marker")]
+    pub ingress_marker: String,
+
+    #[serde(default = "default_egress_marker")]
+    pub egress_marker: String,
+}
+
+impl PluginConfig {
+    #[allow(dead_code)]
+    pub fn new(ingress_marker: String, egress_marker: String) -> Self {
+        Self { ingress_marker, egress_marker }
+    }
+
+    #[inline]
+    pub fn to_json(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::to_value(self)?)
+    }
+}
+
+fn default_ingress_marker() -> String {
+    ":ingress:".into()
+}
+
+fn default_egress_marker() -> String {
+    ":egress:".into()
+}
+
+impl Default for PluginConfig {
+    fn default() -> Self {
+        Self { ingress_marker: default_ingress_marker(), egress_marker: default_egress_marker() }
+    }
+}

--- a/rmqtt-plugins/rmqtt-bridge-origin/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-origin/src/config.rs
@@ -9,12 +9,16 @@ pub struct PluginConfig {
 
     #[serde(default = "default_egress_marker")]
     pub egress_marker: String,
+
+    /// Key used to store BridgeOrigin in session.extra_attrs.
+    #[serde(default = "default_attr_key")]
+    pub attr_key: String,
 }
 
 impl PluginConfig {
     #[allow(dead_code)]
-    pub fn new(ingress_marker: String, egress_marker: String) -> Self {
-        Self { ingress_marker, egress_marker }
+    pub fn new(ingress_marker: String, egress_marker: String, attr_key: String) -> Self {
+        Self { ingress_marker, egress_marker, attr_key }
     }
 
     #[inline]
@@ -31,8 +35,16 @@ fn default_egress_marker() -> String {
     ":egress:".into()
 }
 
+fn default_attr_key() -> String {
+    "bridge_origin".into()
+}
+
 impl Default for PluginConfig {
     fn default() -> Self {
-        Self { ingress_marker: default_ingress_marker(), egress_marker: default_egress_marker() }
+        Self {
+            ingress_marker: default_ingress_marker(),
+            egress_marker: default_egress_marker(),
+            attr_key: default_attr_key(),
+        }
     }
 }

--- a/rmqtt-plugins/rmqtt-bridge-origin/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-origin/src/lib.rs
@@ -132,10 +132,8 @@ impl Handler for BridgeOriginHandler {
 
                 if let Some(direction) = direction {
                     let extra_attrs = session.extra_attrs.clone();
-                    extra_attrs
-                        .write()
-                        .await
-                        .insert::<BridgeOrigin>("bridge_origin".into(), BridgeOrigin { direction });
+                    let key = cfg.attr_key.clone();
+                    extra_attrs.write().await.insert::<BridgeOrigin>(key, BridgeOrigin { direction });
                 }
             }
             _ => {

--- a/rmqtt-plugins/rmqtt-bridge-origin/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-origin/src/lib.rs
@@ -1,0 +1,147 @@
+#![deny(unsafe_code)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use rmqtt::{
+    context::ServerContext,
+    hook::{Handler, HookResult, Parameter, Register, ReturnType, Type},
+    macros::Plugin,
+    plugin::{PackageInfo, Plugin as _PluginTrait},
+    register, Result,
+};
+
+use config::PluginConfig;
+
+mod config;
+
+register!(BridgeOriginPlugin::new);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeDirection {
+    Ingress,
+    Egress,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BridgeOrigin {
+    pub direction: BridgeDirection,
+}
+
+impl BridgeOrigin {
+    #[inline]
+    pub fn is_ingress(&self) -> bool {
+        matches!(self.direction, BridgeDirection::Ingress)
+    }
+
+    #[inline]
+    pub fn is_egress(&self) -> bool {
+        matches!(self.direction, BridgeDirection::Egress)
+    }
+}
+
+#[derive(Plugin)]
+struct BridgeOriginPlugin {
+    scx: ServerContext,
+    register: Box<dyn Register>,
+    cfg: Arc<RwLock<PluginConfig>>,
+}
+
+impl BridgeOriginPlugin {
+    #[inline]
+    async fn new<N: Into<String>>(scx: ServerContext, name: N) -> Result<Self> {
+        let name: String = name.into();
+        let cfg = scx.plugins.read_config_default::<PluginConfig>(&name);
+        let cfg = Arc::new(RwLock::new(cfg?));
+        let register = scx.extends.hook_mgr().register();
+        log::info!("{name} BridgeOriginPlugin cfg: {cfg:?}", cfg = cfg.read().await);
+        Ok(Self { scx, register, cfg })
+    }
+}
+
+#[async_trait]
+impl _PluginTrait for BridgeOriginPlugin {
+    #[inline]
+    async fn init(&mut self) -> Result<()> {
+        log::info!("{} init", self.name());
+        self.register.add(Type::ClientConnected, Box::new(BridgeOriginHandler::new(self.cfg.clone()))).await;
+        log::info!("{} registered ClientConnected hook", self.name());
+        Ok(())
+    }
+
+    #[inline]
+    async fn get_config(&self) -> Result<serde_json::Value> {
+        self.cfg.read().await.to_json()
+    }
+
+    #[inline]
+    async fn load_config(&mut self) -> Result<()> {
+        let new_cfg = self.scx.plugins.read_config::<PluginConfig>(self.name())?;
+        *self.cfg.write().await = new_cfg;
+        log::info!("{} load_config ok", self.name());
+        Ok(())
+    }
+
+    #[inline]
+    async fn start(&mut self) -> Result<()> {
+        log::info!("{} start", self.name());
+        self.register.start().await;
+        Ok(())
+    }
+
+    #[inline]
+    async fn stop(&mut self) -> Result<bool> {
+        log::info!("{} stop", self.name());
+        self.register.stop().await;
+        Ok(false)
+    }
+}
+
+struct BridgeOriginHandler {
+    cfg: Arc<RwLock<PluginConfig>>,
+}
+
+impl BridgeOriginHandler {
+    fn new(cfg: Arc<RwLock<PluginConfig>>) -> Self {
+        Self { cfg }
+    }
+}
+
+#[async_trait]
+impl Handler for BridgeOriginHandler {
+    async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
+        match param {
+            Parameter::ClientConnected(session) => {
+                let client_id = &session.id.client_id;
+                let cfg = self.cfg.read().await;
+
+                let is_ingress = client_id.contains(&cfg.ingress_marker);
+                let is_egress = client_id.contains(&cfg.egress_marker);
+
+                let direction = if is_ingress {
+                    log::debug!("bridge-origin: detected ingress bridge client, client_id={}", client_id,);
+                    Some(BridgeDirection::Ingress)
+                } else if is_egress {
+                    log::debug!("bridge-origin: detected egress bridge client, client_id={}", client_id,);
+                    Some(BridgeDirection::Egress)
+                } else {
+                    None
+                };
+
+                if let Some(direction) = direction {
+                    let extra_attrs = session.extra_attrs.clone();
+                    extra_attrs
+                        .write()
+                        .await
+                        .insert::<BridgeOrigin>("bridge_origin".into(), BridgeOrigin { direction });
+                }
+            }
+            _ => {
+                log::error!("unimplemented, {param:?}")
+            }
+        }
+        (true, acc)
+    }
+}

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -88,6 +88,7 @@ plugins.default_startups = [
     #"rmqtt-bridge-egress-nats",
     #"rmqtt-bridge-ingress-nats",
     #"rmqtt-bridge-egress-reductstore",
+    "rmqtt-bridge-origin",
     #"rmqtt-web-hook",
     #"rmqtt-p2p-messaging",
     "rmqtt-http-api"


### PR DESCRIPTION
…client connections

  Add a new `rmqtt-bridge-origin` plugin that identifies whether an MQTT client
  originates from bridge-ingress-mqtt or bridge-egress-mqtt connections.

  Key components:
  - PluginConfig with configurable ingress/egress markers (default: ":ingress:", ":egress:")
  - BridgeOrigin + BridgeDirection data model for typed bridge origin metadata
  - ClientConnected hook handler that checks client_id against markers
  - Stores result in session.extra_attrs under "bridge_origin" key
  - Clean separation of concerns: only identifies origin, no anti-loop or routing logic

  The plugin follows existing RMQTT plugin conventions:
  - register! macro + #[derive(Plugin)] pattern
  - read_config_default for configuration loading
  - async Handler trait with hook registration via HookManager

  Files changed:
    A rmqtt-plugins/rmqtt-bridge-origin/Cargo.toml A rmqtt-plugins/rmqtt-bridge-origin/src/lib.rs A rmqtt-plugins/rmqtt-bridge-origin/src/config.rs
    M Cargo.toml              - add workspace dependency + patch entry
    M rmqtt-bin/Cargo.toml    - add binary dependency + plugins metadata
    M Cargo.lock               - auto-updated