### PR TITLE
docs: fix language switcher links in architecture and reference docs

### DIFF
--- a/docs/en_US/architecture/overview.md
+++ b/docs/en_US/architecture/overview.md
@@ -1,4 +1,4 @@
-[**English**](overview.md) | [简体中文](../zh_CN/architecture/overview.md)
+[**English**](overview.md) | [简体中文](../../zh_CN/architecture/overview.md)
 
 # RMQTT Architecture Overview
 

--- a/docs/en_US/development/getting-started.md
+++ b/docs/en_US/development/getting-started.md
@@ -1,4 +1,4 @@
-[**English**](getting-started.md) | [简体中文](../zh_CN/development/getting-started.md)
+[**English**](getting-started.md) | [简体中文](../../zh_CN/development/getting-started.md)
 
 # Getting Started with RMQTT Development
 

--- a/docs/en_US/development/plugin-development.md
+++ b/docs/en_US/development/plugin-development.md
@@ -1,4 +1,4 @@
-[**English**](plugin-development.md) | [简体中文](../zh_CN/development/plugin-development.md)
+[**English**](plugin-development.md) | [简体中文](../../zh_CN/development/plugin-development.md)
 
 # Plugin Development Guide
 

--- a/docs/en_US/development/testing.md
+++ b/docs/en_US/development/testing.md
@@ -1,4 +1,4 @@
-[**English**](testing.md) | [简体中文](../zh_CN/development/testing.md)
+[**English**](testing.md) | [简体中文](../../zh_CN/development/testing.md)
 
 # RMQTT Testing Guide
 

--- a/docs/en_US/reference/http-api.md
+++ b/docs/en_US/reference/http-api.md
@@ -1,4 +1,4 @@
-[**English**](http-api.md) | [简体中文](../zh_CN/reference/http-api.md)
+[**English**](http-api.md) | [简体中文](../../zh_CN/reference/http-api.md)
 
 # HTTP API Reference
 

--- a/docs/zh_CN/architecture/overview.md
+++ b/docs/zh_CN/architecture/overview.md
@@ -1,4 +1,4 @@
-[English](../en_US/architecture/overview.md) | [**简体中文**](overview.md)
+[English](../../en_US/architecture/overview.md) | [**简体中文**](overview.md)
 
 # RMQTT 架构概览
 

--- a/docs/zh_CN/development/getting-started.md
+++ b/docs/zh_CN/development/getting-started.md
@@ -1,4 +1,4 @@
-[English](../en_US/development/getting-started.md) | [**简体中文**](getting-started.md)
+[English](../../en_US/development/getting-started.md) | [**简体中文**](getting-started.md)
 
 # RMQTT 开发入门
 

--- a/docs/zh_CN/development/plugin-development.md
+++ b/docs/zh_CN/development/plugin-development.md
@@ -1,4 +1,4 @@
-[English](../en_US/development/plugin-development.md) | [**简体中文**](plugin-development.md)
+[English](../../en_US/development/plugin-development.md) | [**简体中文**](plugin-development.md)
 
 # 插件开发指南
 

--- a/docs/zh_CN/development/testing.md
+++ b/docs/zh_CN/development/testing.md
@@ -1,4 +1,4 @@
-[English](../en_US/development/testing.md) | [**简体中文**](testing.md)
+[English](../../en_US/development/testing.md) | [**简体中文**](testing.md)
 
 # RMQTT 测试指南
 

--- a/docs/zh_CN/reference/http-api.md
+++ b/docs/zh_CN/reference/http-api.md
@@ -1,4 +1,4 @@
-[English](../en_US/reference/http-api.md) | [**简体中文**](http-api.md)
+[English](../../en_US/reference/http-api.md) | [**简体中文**](http-api.md)
 
 # HTTP API 参考
 


### PR DESCRIPTION
- Update relative paths from `../zh_CN/` to `../../zh_CN/` in English docs
- Update relative paths from `../en_US/` to `../../en_US/` in Chinese docs
- Ensures correct navigation between English and Chinese documentation