### PR TITLE
docs: update version references and API documentation to v0.21.0

### DIFF
--- a/docs/en_US/README.md
+++ b/docs/en_US/README.md
@@ -20,7 +20,7 @@ Welcome to the RMQTT documentation. This index provides a structured overview of
 |----------|-------------|
 | [Architecture Overview](architecture/overview.md) | System architecture, crate layers, core modules, session lifecycle |
 | [Plugin System](../architecture/overview.md#plugin-system) | Plugin trait, lifecycle, registration pattern |
-| [Hook System](../architecture/overview.md#hook-system) | All 18 hook types, handler registration, priority |
+| [Hook System](../architecture/overview.md#hook-system) | All 23 hook types, handler registration, priority |
 | [Message Flow](../architecture/overview.md#message-flow) | End-to-end publish/subscribe flow with diagrams |
 
 ---

--- a/docs/en_US/architecture/overview.md
+++ b/docs/en_US/architecture/overview.md
@@ -153,7 +153,7 @@ rmqtt/src/
 ├── inflight.rs      # In-flight message tracking (QoS 1/2)
 ├── queue.rs         # Message queue with rate limiting
 │
-├── hook.rs          # Hook system — 10+ extension points
+├── hook.rs          # Hook system — 23 extension points
 ├── extend.rs        # Extension point storage (10 RwLock slots)
 ├── executor.rs      # Async task executor wrapper
 │
@@ -231,7 +231,7 @@ stateDiagram-v2
 
 ## Hook System
 
-The hook system is the primary extension mechanism. It provides 10+ interception points along the message processing pipeline.
+The hook system is the primary extension mechanism. It provides **23 interception points** along the message processing pipeline.
 
 ### Hook Trait
 
@@ -254,17 +254,21 @@ pub trait Handler: Send + Sync {
 | `ClientDisconnected` | Session ended | Continue |
 | `ClientSubscribe` | SUBSCRIBE received | Continue |
 | `ClientSubscribeCheckAcl` | Subscribe ACL check | `(bool, Option<SubscribeAclResult>)` |
+| `ClientKeepalive` | Keepalive timeout or ping received | Continue |
 | `ClientUnsubscribe` | UNSUBSCRIBE received | Continue |
 | `MessagePublish` | PUBLISH received | `(bool, Option<MessagePublishResult>)` |
 | `MessagePublishCheckAcl` | Publish ACL check | `(bool, Option<PublishAclResult>)` |
 | `MessageDelivered` | Message sent to client | Continue |
 | `MessageAcked` | Client acknowledged | Continue |
 | `MessageDropped` | Message dropped | Continue |
+| `MessageExpiryCheck` | Check if message has expired | Continue |
+| `MessageNonsubscribed` | No matching subscribers found | Continue |
 | `SessionCreated` | Session created | Continue |
 | `SessionTerminated` | Session destroyed | Continue |
 | `SessionSubscribed` | Subscription added | Continue |
 | `SessionUnsubscribed` | Subscription removed | Continue |
 | `OfflineMessage` | Offline message stored | Continue |
+| `OfflineInflightMessages` | Reconnecting client loads in-flight messages | Continue |
 | `GrpcMessageReceived` | Cross-node gRPC message | `(bool, Option<Vec<u8>>)` |
 
 ### Hook Registration Priority

--- a/docs/en_US/auth-http.md
+++ b/docs/en_US/auth-http.md
@@ -28,7 +28,7 @@ plugins/rmqtt-auth-http.toml
 http_timeout = "5s"
 http_headers.accept = "*/*"
 http_headers.Cache-Control = "no-cache"
-http_headers.User-Agent = "RMQTT/0.8.0"
+http_headers.User-Agent = "RMQTT/0.21.0"
 http_headers.Connection = "keep-alive"
 
 ## Disconnect if publishing is rejected
@@ -293,7 +293,7 @@ HTTP API basic request information and headers.
 http_timeout = "5s"
 http_headers.accept = "*/*"
 http_headers.Cache-Control = "no-cache"
-http_headers.User-Agent = "RMQTT/0.8.0"
+http_headers.User-Agent = "RMQTT/0.21.0"
 http_headers.Connection = "keep-alive"
 
 # If publishing a message is rejected, the connection will be disconnected.

--- a/docs/en_US/benchmark-testing.md
+++ b/docs/en_US/benchmark-testing.md
@@ -10,7 +10,7 @@ English | [简体中文](../zh_CN/benchmark-testing.md)
 | Disk        |                                           | 2T                                                              |
 | Container   | podman                                    | v4.4.1                                                          |
 | MQTT Bench  | docker.io/rmqtt/rmqtt-bench:latest        | v0.1.3                                                          |
-| MQTT Broker | docker.io/rmqtt/rmqtt:latest              | v0.3.0                                                         |
+| MQTT Broker | docker.io/rmqtt/rmqtt:latest              | v0.21.0                                                        |
 | Other       | MQTT Bench and MQTT Broker coexistence    |                                                                 |
 
 

--- a/docs/en_US/development/plugin-development.md
+++ b/docs/en_US/development/plugin-development.md
@@ -86,7 +86,7 @@ cd rmqtt-plugins/rmqtt-my-plugin
 ```toml
 [package]
 name = "rmqtt-my-plugin"
-version = "0.1.0"
+version.workspace = true
 description = "My custom RMQTT plugin"
 edition.workspace = true
 license.workspace = true

--- a/docs/en_US/http-api.md
+++ b/docs/en_US/http-api.md
@@ -123,7 +123,7 @@ Get the basic information of all nodes:
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/brokers"
 
-[{"datetime":"2022-07-24 23:01:31","node_id":1,"node_name":"1@127.0.0.1","node_status":"Running","sysdescr":"RMQTT Broker","uptime":"5 days 23 hours, 16 minutes, 3 seconds","version":"rmqtt/0.2.3-20220724094535"}]
+[{"datetime":"2022-07-24 23:01:31","node_id":1,"node_name":"1@127.0.0.1","running":true,"sysdescr":"RMQTT Broker","uptime":"5 days 23 hours, 16 minutes, 3 seconds","version":"rmqtt/0.21.0"}]
 ```
 
 Get the basic information of node 1 :
@@ -131,7 +131,7 @@ Get the basic information of node 1 :
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/brokers/1"
 
-{"datetime":"2022-07-24 23:01:31","node_id":1,"node_name":"1@127.0.0.1","node_status":"Running","sysdescr":"RMQTT Broker","uptime":"5 days 23 hours, 17 minutes, 15 seconds","version":"rmqtt/0.2.3-20220724094535"}
+{"datetime":"2022-07-24 23:01:31","node_id":1,"node_name":"1@127.0.0.1","running":true,"sysdescr":"RMQTT Broker","uptime":"5 days 23 hours, 17 minutes, 15 seconds","version":"rmqtt/0.21.0"}
 ```
 
 ## Node
@@ -175,7 +175,7 @@ Get the status of all nodes:
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/nodes"
 
-[{"boottime":"2022-06-30 05:20:24 UTC","connections":1,"disk_free":77382381568,"disk_total":88692346880,"load1":0.0224609375,"load15":0.0,"load5":0.0263671875,"memory_free":1457954816,"memory_total":2084057088,"memory_used":626102272,"node_id":1,"node_name":"1@127.0.0.1","node_status":"Running","uptime":"5 days 23 hours, 33 minutes, 0 seconds","version":"rmqtt/0.2.3-20220724094535"}]
+[{"boottime":"2022-06-30 05:20:24 UTC","connections":1,"disk_free":77382381568,"disk_total":88692346880,"load1":0.0224609375,"load15":0.0,"load5":0.0263671875,"memory_free":1457954816,"memory_total":2084057088,"memory_used":626102272,"node_id":1,"node_name":"1@127.0.0.1","running":true,"uptime":"5 days 23 hours, 33 minutes, 0 seconds","version":"rmqtt/0.21.0","rustc_version":"1.85.0"}]
 ```
 
 Get the status of the specified node:
@@ -183,7 +183,7 @@ Get the status of the specified node:
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/nodes/1"
 
-{"boottime":"2022-06-30 05:20:24 UTC","connections":1,"disk_free":77382381568,"disk_total":88692346880,"load1":0.0224609375,"load15":0.0,"load5":0.0263671875,"memory_free":1457954816,"memory_total":2084057088,"memory_used":626102272,"node_id":1,"node_name":"1@127.0.0.1","node_status":"Running","uptime":"5 days 23 hours, 33 minutes, 0 seconds","version":"rmqtt/0.2.3-20220724094535"}
+{"boottime":"2022-06-30 05:20:24 UTC","connections":1,"disk_free":77382381568,"disk_total":88692346880,"load1":0.0224609375,"load15":0.0,"load5":0.0263671875,"memory_free":1457954816,"memory_total":2084057088,"memory_used":626102272,"node_id":1,"node_name":"1@127.0.0.1","running":true,"uptime":"5 days 23 hours, 33 minutes, 0 seconds","version":"rmqtt/0.21.0","rustc_version":"1.85.0"}
 ```
 
 ## Client
@@ -226,6 +226,7 @@ Returns the information of all clients under the cluster.
 | [0].node_id             | Integer          | ID of the node to which the client is connected                                                                                   |
 | [0].clientid            | String           | Client identifier                                                                                                                 |
 | [0].username            | String           | User name of client when connecting                                                                                               |
+| [0].superuser           | Boolean          | Whether the client is a superuser                                                                                                 |
 | [0].proto_ver           | Integer          | Protocol version used by the client                                                                                               |
 | [0].ip_address          | String           | Client's IP address                                                                                                               |
 | [0].port                | Integer          | Client port                                                                                                                       | 
@@ -235,6 +236,7 @@ Returns the information of all clients under the cluster.
 | [0].connected           | Boolean          | Whether the client is connected                                                                                                   |
 | [0].keepalive           | Integer          | keepalive time, with the unit of second                                                                                           |
 | [0].clean_start         | Boolean          | Indicate whether the client is using a brand new session                                                                          |
+| [0].session_present     | Boolean          | Whether the client is connected to an existing session                                                                            |
 | [0].expiry_interval     | Integer          | Session expiration interval, with the unit of second                                                                              |
 | [0].created_at          | String           | Session creation time, in the format "YYYY-MM-DD HH:mm:ss"                                                                        |
 | [0].subscriptions_cnt   | Integer          | Number of subscriptions established by this client                                                                                |
@@ -243,7 +245,6 @@ Returns the information of all clients under the cluster.
 | [0].max_inflight        | Integer          | Maximum length of inflight                                                                                                        |
 | [0].mqueue_len          | Integer          | Current length of message queue                                                                                                   |
 | [0].max_mqueue          | Integer          | Maximum length of message queue                                                                                                   |
-| [0].extra_attrs         | Integer          | Number of Extended Attributes                                                                                                     |
 | [0].last_will           | Json             | Last Will Message, for example: { "message": "dGVzdCAvdGVzdC9sd3QgLi4u", "qos": 1, "retain": false, "topic": "/test/lwt" }        |
 
 **Examples:**
@@ -251,7 +252,7 @@ Returns the information of all clients under the cluster.
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/clients?_limit=10"
 
-[{"clean_start":true,"clientid":"be82ee31-7220-4cad-a724-aaad9a065012","connected":true,"connected_at":"2022-07-30 18:14:08","created_at":"2022-07-30 18:14:08","disconnected_at":"","expiry_interval":7200,"inflight":0,"ip_address":"183.193.169.110","keepalive":60,"max_inflight":16,"max_mqueue":1000,"max_subscriptions":0,"mqueue_len":0,"node_id":1,"port":10839,"proto_ver":4,"subscriptions_cnt":0,"username":"undefined"}]
+[{"clean_start":true,"session_present":true,"clientid":"be82ee31-7220-4cad-a724-aaad9a065012","connected":true,"connected_at":"2022-07-30 18:14:08","created_at":"2022-07-30 18:14:08","disconnected_at":"","expiry_interval":7200,"inflight":0,"ip_address":"183.193.169.110","keepalive":60,"max_inflight":16,"max_mqueue":1000,"max_subscriptions":0,"mqueue_len":0,"node_id":1,"port":10839,"proto_ver":4,"subscriptions_cnt":0,"superuser":false,"username":"undefined"}]
 ```
 
 ### GET /api/v1/clients/{clientid}
@@ -277,7 +278,7 @@ Query the specified client
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/clients/example1"
 
-{"clean_start":true,"clientid":"example1","connected":true,"connected_at":"2022-07-30 23:30:43","created_at":"2022-07-30 23:30:43","disconnected_at":"","expiry_interval":7200,"inflight":0,"ip_address":"183.193.169.110","keepalive":60,"max_inflight":16,"max_mqueue":1000,"max_subscriptions":0,"mqueue_len":0,"node_id":1,"port":11232,"proto_ver":4,"subscriptions_cnt":0,"username":"undefined"}
+{"clean_start":true,"session_present":true,"clientid":"example1","connected":true,"connected_at":"2022-07-30 23:30:43","created_at":"2022-07-30 23:30:43","disconnected_at":"","expiry_interval":7200,"inflight":0,"ip_address":"183.193.169.110","keepalive":60,"max_inflight":16,"max_mqueue":1000,"max_subscriptions":0,"mqueue_len":0,"node_id":1,"port":11232,"proto_ver":4,"subscriptions_cnt":0,"superuser":false,"username":"undefined"}
 ```
 
 ### DELETE /api/v1/clients/{clientid}
@@ -473,6 +474,7 @@ Publish MQTT message。
 | encoding | String    | Optional | plain  | The encoding used in the message body. Currently only plain and base64 are supported |
 | qos      | Integer   | Optional | 0      | QoS level                                  |
 | retain   | Boolean   | Optional | false  | Whether it is a retained message                                 |
+| properties | Object   | Optional |        | Publish properties (MQTT v5), including: `message_expiry_interval`, `topic_alias`, `response_topic`, `correlation_data`, `user_properties` |
 
 **Success Response Body (JSON):**
 
@@ -569,6 +571,10 @@ Returns information of all plugins in the cluster.
 | [0].plugins.name      | String           | Plugin name                                                                                                         |
 | [0].plugins.version   | String           | Plugin version                                                                                                      |
 | [0].plugins.descr     | String           | Plugin description                                                                                                  |
+| [0].plugins.authors   | String           | Plugin authors                                                                                                      |
+| [0].plugins.homepage  | String           | Plugin homepage                                                                                                     |
+| [0].plugins.license   | String           | Plugin license                                                                                                      |
+| [0].plugins.repository| String           | Plugin repository                                                                                                   |
 | [0].plugins.active    | Boolean          | Whether the plugin is active                                                                                        |
 | [0].plugins.inited    | Boolean          | Whether the plugin is initialized                                                                                   |
 | [0].plugins.immutable | Boolean          | Whether the plugin is immutable, Immutable plugins will not be able to be stopped, config modified, restarted, etc. |
@@ -579,7 +585,7 @@ Returns information of all plugins in the cluster.
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/plugins"
 
-[{"node":1,"plugins":[{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-raft","version":null},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-auth-http","version":null},{"active":true,"attrs":null,"descr":"","immutable":true,"inited":true,"name":"rmqtt-acl","version":"0.1.1"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-counter","version":"0.1.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-http-api","version":"0.1.1"},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-web-hook","version":null},{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-broadcast","version":null}]}]
+[{"node":1,"plugins":[{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-raft","version":null},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-auth-http","version":null},{"active":true,"attrs":null,"descr":"","immutable":true,"inited":true,"name":"rmqtt-acl","version":"0.21.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-counter","version":"0.21.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-http-api","version":"0.21.0"},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-web-hook","version":null},{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-broadcast","version":null}]}]
 ```
 
 ### GET /api/v1/plugins/{node}
@@ -600,6 +606,10 @@ Return the plugin information under the specified node
 | [0].name       | String           | Plugin name                       |
 | [0].version    | String           | Plugin version                      |
 | [0].descr      | String           | Plugin description                  |
+| [0].authors    | String           | Plugin authors                     |
+| [0].homepage   | String           | Plugin homepage                    |
+| [0].license    | String           | Plugin license                     |
+| [0].repository | String           | Plugin repository                  |
 | [0].active     | Boolean          | Whether the plugin is active                        |
 | [0].inited     | Boolean          | Whether the plugin is initialized                 |
 | [0].immutable  | Boolean          | Whether the plugin is immutable, Immutable plugins will not be able to be stopped, config modified, restarted, etc. |
@@ -610,7 +620,7 @@ Return the plugin information under the specified node
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/plugins/1"
 
-[{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-raft","version":null},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-auth-http","version":null},{"active":true,"attrs":null,"descr":"","immutable":true,"inited":true,"name":"rmqtt-acl","version":"0.1.1"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-counter","version":"0.1.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-http-api","version":"0.1.1"},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-web-hook","version":null},{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-broadcast","version":null}]
+[{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-raft","version":null},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-auth-http","version":null},{"active":true,"attrs":null,"descr":"","immutable":true,"inited":true,"name":"rmqtt-acl","version":"0.21.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-counter","version":"0.21.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-http-api","version":"0.21.0"},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-web-hook","version":null},{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-broadcast","version":null}]
 ```
 
 ### GET /api/v1/plugins/{node}/{plugin}

--- a/docs/en_US/install.md
+++ b/docs/en_US/install.md
@@ -17,13 +17,13 @@ Get the binary package of the corresponding OS from [RMQTT Download](https://git
 1. Download the ZIP package from [GitHub Release](https://github.com/rmqtt/rmqtt/releases).
 
 ```bash
-$ wget "https://github.com/rmqtt/rmqtt/releases/download/0.3.0/rmqtt-0.3.0-x86_64-unknown-linux-musl.zip"
+$ wget "https://github.com/rmqtt/rmqtt/releases/download/0.21.0/rmqtt-0.21.0-x86_64-unknown-linux-musl.zip"
 ```
 
 2. Decompress the zip package you downloaded from [GitHub Release](https://github.com/rmqtt/rmqtt/releases).
 
 ```bash
-$ unzip rmqtt-0.3.0-x86_64-unknown-linux-musl.zip -d /app/
+$ unzip rmqtt-0.21.0-x86_64-unknown-linux-musl.zip -d /app/
 ```
 
 3. Modify the permissions

--- a/docs/en_US/testing-report.md
+++ b/docs/en_US/testing-report.md
@@ -103,7 +103,7 @@ cargo build -p rmqtt-test --release
 | Disk | 2 TB |
 | Container | Podman v4.4.1 |
 | MQTT Bench | `docker.io/rmqtt/rmqtt-bench:latest` (v0.1.3) |
-| MQTT Broker | `docker.io/rmqtt/rmqtt:latest` (v0.3.0) |
+| MQTT Broker | `docker.io/rmqtt/rmqtt:latest` (v0.21.0) |
 
 *Note: MQTT Bench and MQTT Broker run on the same host.*
 

--- a/docs/zh_CN/README.md
+++ b/docs/zh_CN/README.md
@@ -20,7 +20,7 @@
 |----------|-------------|
 | [架构概览](architecture/overview.md) | 系统架构、crate 分层、核心模块、会话生命周期 |
 | [插件系统](../architecture/overview.md#插件系统) | Plugin trait、生命周期、注册模式 |
-| [钩子系统](../architecture/overview.md#钩子系统) | 18 种钩子类型、Handler 注册、优先级 |
+| [钩子系统](../architecture/overview.md#钩子系统) | 23 种钩子类型、Handler 注册、优先级 |
 
 ---
 

--- a/docs/zh_CN/architecture/overview.md
+++ b/docs/zh_CN/architecture/overview.md
@@ -148,7 +148,7 @@ rmqtt/src/
 ├── fitter.rs        # 主题过滤匹配引擎
 ├── inflight.rs      # 进行中消息追踪 (QoS 1/2)
 ├── queue.rs         # 带速率限制的消息队列
-├── hook.rs          # 钩子系统 — 10+ 扩展点
+├── hook.rs          # 钩子系统 — 23 个扩展点
 ├── extend.rs        # 扩展点存储 (10 个 RwLock 插槽)
 ├── executor.rs      # 异步任务执行器包装
 ├── types.rs         # 核心数据类型 (~3000 行)
@@ -222,7 +222,7 @@ stateDiagram-v2
 
 ## 钩子系统
 
-钩子系统是 RMQTT 的主要扩展机制，在消息处理管道的各个阶段提供了 10+ 个拦截点。
+钩子系统是 RMQTT 的主要扩展机制，在消息处理管道的各个阶段提供了 **23 个拦截点**。
 
 ### Hook Trait
 
@@ -245,17 +245,21 @@ pub trait Handler: Send + Sync {
 | `ClientDisconnected` | 会话已结束 | Continue |
 | `ClientSubscribe` | 收到 SUBSCRIBE | Continue |
 | `ClientSubscribeCheckAcl` | 订阅 ACL 检查 | `(bool, Option<SubscribeAclResult>)` |
+| `ClientKeepalive` | 保活超时或收到 ping | Continue |
 | `ClientUnsubscribe` | 收到 UNSUBSCRIBE | Continue |
 | `MessagePublish` | 收到 PUBLISH | `(bool, Option<MessagePublishResult>)` |
 | `MessagePublishCheckAcl` | 发布 ACL 检查 | `(bool, Option<PublishAclResult>)` |
 | `MessageDelivered` | 消息已发送给客户端 | Continue |
 | `MessageAcked` | 客户端已确认 | Continue |
 | `MessageDropped` | 消息被丢弃 | Continue |
+| `MessageExpiryCheck` | 检查消息是否过期 | Continue |
+| `MessageNonsubscribed` | 无匹配订阅者 | Continue |
 | `SessionCreated` | 会话已创建 | Continue |
 | `SessionTerminated` | 会话已销毁 | Continue |
 | `SessionSubscribed` | 订阅已添加 | Continue |
 | `SessionUnsubscribed` | 订阅已移除 | Continue |
 | `OfflineMessage` | 离线消息已存储 | Continue |
+| `OfflineInflightMessages` | 重连客户端加载 in-flight 消息 | Continue |
 | `GrpcMessageReceived` | 跨节点 gRPC 消息 | `(bool, Option<Vec<u8>>)` |
 
 ### 钩子注册优先级

--- a/docs/zh_CN/auth-http.md
+++ b/docs/zh_CN/auth-http.md
@@ -29,7 +29,7 @@ plugins/rmqtt-auth-http.toml
 http_timeout = "5s"
 http_headers.accept = "*/*"
 http_headers.Cache-Control = "no-cache"
-http_headers.User-Agent = "RMQTT/0.8.0"
+http_headers.User-Agent = "RMQTT/0.21.0"
 http_headers.Connection = "keep-alive"
 
 ## Disconnect if publishing is rejected
@@ -283,7 +283,7 @@ HTTP API 基础请求信息，请求头。
 http_timeout = "5s"
 http_headers.accept = "*/*"
 http_headers.Cache-Control = "no-cache"
-http_headers.User-Agent = "RMQTT/0.8.0"
+http_headers.User-Agent = "RMQTT/0.21.0"
 http_headers.Connection = "keep-alive"
 
 # 如果发布消息被拒绝，则断开连接

--- a/docs/zh_CN/benchmark-testing.md
+++ b/docs/zh_CN/benchmark-testing.md
@@ -10,7 +10,7 @@
 | 磁盘          |                                           | 2T                                                              |
 | 容器          | podman                                    | v4.4.1                                                          |
 | MQTT Bench  | docker.io/rmqtt/rmqtt-bench:latest        | v0.1.3                                                          |
-| MQTT Broker | docker.io/rmqtt/rmqtt:latest              | v0.3.0                                                         |
+| MQTT Broker | docker.io/rmqtt/rmqtt:latest              | v0.21.0                                                        |
 | 其它          | MQTT Bench和MQTT Broker同服         |                                                                 |
 
 

--- a/docs/zh_CN/development/plugin-development.md
+++ b/docs/zh_CN/development/plugin-development.md
@@ -29,7 +29,7 @@ new(scx, name) → load_config() → init() → start() → (运行态) → stop
 ```toml
 [package]
 name = "rmqtt-my-plugin"
-version = "0.1.0"
+version.workspace = true
 description = "My custom RMQTT plugin"
 
 [dependencies]

--- a/docs/zh_CN/http-api.md
+++ b/docs/zh_CN/http-api.md
@@ -121,7 +121,7 @@ $ curl -i -X GET "http://localhost:6060/api/v1"
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/brokers"
 
-[{"datetime":"2022-07-24 23:01:31","node_id":1,"node_name":"1@127.0.0.1","node_status":"Running","sysdescr":"RMQTT Broker","uptime":"5 days 23 hours, 16 minutes, 3 seconds","version":"rmqtt/0.2.3-20220724094535"}]
+[{"datetime":"2022-07-24 23:01:31","node_id":1,"node_name":"1@127.0.0.1","running":true,"sysdescr":"RMQTT Broker","uptime":"5 days 23 hours, 16 minutes, 3 seconds","version":"rmqtt/0.21.0"}]
 ```
 
 获取节点 1 的基本信息：
@@ -129,7 +129,7 @@ $ curl -i -X GET "http://localhost:6060/api/v1/brokers"
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/brokers/1"
 
-{"datetime":"2022-07-24 23:01:31","node_id":1,"node_name":"1@127.0.0.1","node_status":"Running","sysdescr":"RMQTT Broker","uptime":"5 days 23 hours, 17 minutes, 15 seconds","version":"rmqtt/0.2.3-20220724094535"}
+{"datetime":"2022-07-24 23:01:31","node_id":1,"node_name":"1@127.0.0.1","running":true,"sysdescr":"RMQTT Broker","uptime":"5 days 23 hours, 17 minutes, 15 seconds","version":"rmqtt/0.21.0"}
 ```
 
 ## 节点
@@ -173,7 +173,7 @@ $ curl -i -X GET "http://localhost:6060/api/v1/brokers/1"
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/nodes"
 
-[{"boottime":"2022-06-30 05:20:24 UTC","connections":1,"disk_free":77382381568,"disk_total":88692346880,"load1":0.0224609375,"load15":0.0,"load5":0.0263671875,"memory_free":1457954816,"memory_total":2084057088,"memory_used":626102272,"node_id":1,"node_name":"1@127.0.0.1","node_status":"Running","uptime":"5 days 23 hours, 33 minutes, 0 seconds","version":"rmqtt/0.2.3-20220724094535"}]
+[{"boottime":"2022-06-30 05:20:24 UTC","connections":1,"disk_free":77382381568,"disk_total":88692346880,"load1":0.0224609375,"load15":0.0,"load5":0.0263671875,"memory_free":1457954816,"memory_total":2084057088,"memory_used":626102272,"node_id":1,"node_name":"1@127.0.0.1","running":true,"uptime":"5 days 23 hours, 33 minutes, 0 seconds","version":"rmqtt/0.21.0","rustc_version":"1.85.0"}]
 ```
 
 获取指定节点的状态：
@@ -181,7 +181,7 @@ $ curl -i -X GET "http://localhost:6060/api/v1/nodes"
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/nodes/1"
 
-{"boottime":"2022-06-30 05:20:24 UTC","connections":1,"disk_free":77382381568,"disk_total":88692346880,"load1":0.0224609375,"load15":0.0,"load5":0.0263671875,"memory_free":1457954816,"memory_total":2084057088,"memory_used":626102272,"node_id":1,"node_name":"1@127.0.0.1","node_status":"Running","uptime":"5 days 23 hours, 33 minutes, 0 seconds","version":"rmqtt/0.2.3-20220724094535"}
+{"boottime":"2022-06-30 05:20:24 UTC","connections":1,"disk_free":77382381568,"disk_total":88692346880,"load1":0.0224609375,"load15":0.0,"load5":0.0263671875,"memory_free":1457954816,"memory_total":2084057088,"memory_used":626102272,"node_id":1,"node_name":"1@127.0.0.1","running":true,"uptime":"5 days 23 hours, 33 minutes, 0 seconds","version":"rmqtt/0.21.0"}
 ```
 
 ## 客户端
@@ -224,6 +224,7 @@ $ curl -i -X GET "http://localhost:6060/api/v1/nodes/1"
 | [0].node_id             | Integer          | 客户端所连接的节点ID                                                                |
 | [0].clientid            | String           | 客户端标识符                                                                     |
 | [0].username            | String           | 客户端连接时使用的用户名                                                               | 
+| [0].superuser           | Boolean          | 客户端是否为超级用户                                                                 |
 | [0].proto_ver           | Integer          | 客户端使用的协议版本                                                                 |
 | [0].ip_address          | String           | 客户端的 IP 地址                                                                 |
 | [0].port                | Integer          | 客户端的端口                                                                     | 
@@ -233,6 +234,7 @@ $ curl -i -X GET "http://localhost:6060/api/v1/nodes/1"
 | [0].connected           | Boolean          | 客户端是否处于连接状态                                                                |
 | [0].keepalive           | Integer          | 保持连接时间，单位：秒                                                                |
 | [0].clean_start         | Boolean          | 指示客户端是否使用了全新的会话                                                            |
+| [0].session_present     | Boolean          | 客户端是否连接到现有会话                                                                |
 | [0].expiry_interval     | Integer          | 会话过期间隔，单位：秒                                                                |
 | [0].created_at          | String           | 会话创建时间，格式为 "YYYY-MM-DD HH:mm:ss"                                           |
 | [0].subscriptions_cnt   | Integer          | 此客户端已建立的订阅数量                                                               |
@@ -241,7 +243,6 @@ $ curl -i -X GET "http://localhost:6060/api/v1/nodes/1"
 | [0].max_inflight        | Integer          | 飞行队列最大长度                                                                   |
 | [0].mqueue_len          | Integer          | 消息队列当前长度                                                                   |
 | [0].max_mqueue          | Integer          | 消息队列最大长度                                                                   |
-| [0].extra_attrs         | Integer          | 扩展属性数量                                                                     |
 | [0].last_will           | Json             | 遗嘱消息, 例如：{ "message": "dGVzdCAvdGVzdC9sd3QgLi4u", "qos": 1, "retain": false, "topic": "/test/lwt" } |
 
 
@@ -472,6 +473,7 @@ $ curl -i -X GET "http://localhost:6060/api/v1/routes/foo%2f1"
 | encoding | String    | Optional | plain  | 消息正文使用的编码方式，目前仅支持 `plain` 与 `base64` 两种 |
 | qos      | Integer   | Optional | 0      | QoS 等级                                  |
 | retain   | Boolean   | Optional | false  | 是否为保留消息                                 |
+| properties | Object   | Optional |        | 发布属性 (MQTT v5)，包括：`message_expiry_interval`, `topic_alias`, `response_topic`, `correlation_data`, `user_properties` |
 
 **Success Response Body (JSON):**
 
@@ -568,6 +570,10 @@ true
 | [0].plugins.name      | String           | 插件名称                             |
 | [0].plugins.version   | String           | 插件版本                             |
 | [0].plugins.descr     | String           | 插件描述                             |
+| [0].plugins.authors   | String           | 插件作者                             |
+| [0].plugins.homepage  | String           | 插件主页                             |
+| [0].plugins.license   | String           | 插件许可证                            |
+| [0].plugins.repository| String           | 插件仓库                             |
 | [0].plugins.active    | Boolean          | 插件是否启动                           |
 | [0].plugins.inited    | Boolean          | 插件是否已经初始化                        |
 | [0].plugins.immutable | Boolean          | 插件是否不可变，不可变插件将不能被停止，不能修改配置，不能重启等 |
@@ -578,7 +584,7 @@ true
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/plugins"
 
-[{"node":1,"plugins":[{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-raft","version":null},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-auth-http","version":null},{"active":true,"attrs":null,"descr":"","immutable":true,"inited":true,"name":"rmqtt-acl","version":"0.1.1"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-counter","version":"0.1.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-http-api","version":"0.1.1"},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-web-hook","version":null},{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-broadcast","version":null}]}]
+[{"node":1,"plugins":[{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-raft","version":null},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-auth-http","version":null},{"active":true,"attrs":null,"descr":"","immutable":true,"inited":true,"name":"rmqtt-acl","version":"0.21.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-counter","version":"0.21.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-http-api","version":"0.21.0"},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-web-hook","version":null},{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-broadcast","version":null}]}]
 ```
 
 ### GET /api/v1/plugins/{node}
@@ -599,6 +605,10 @@ $ curl -i -X GET "http://localhost:6060/api/v1/plugins"
 | [0].name       | String           | 插件名称                           |
 | [0].version    | String           | 插件版本                           |
 | [0].descr      | String           | 插件描述                           |
+| [0].authors    | String           | 插件作者                           |
+| [0].homepage   | String           | 插件主页                           |
+| [0].license    | String           | 插件许可证                          |
+| [0].repository | String           | 插件仓库                           |
 | [0].active     | Boolean          | 插件是否启动                         |
 | [0].inited     | Boolean          | 插件是否已经初始化                      |
 | [0].immutable  | Boolean          | 插件是否不可变，不可变插件将不能被停止，不有修改配置，不能重启等 |
@@ -609,7 +619,7 @@ $ curl -i -X GET "http://localhost:6060/api/v1/plugins"
 ```bash
 $ curl -i -X GET "http://localhost:6060/api/v1/plugins/1"
 
-[{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-raft","version":null},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-auth-http","version":null},{"active":true,"attrs":null,"descr":"","immutable":true,"inited":true,"name":"rmqtt-acl","version":"0.1.1"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-counter","version":"0.1.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-http-api","version":"0.1.1"},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-web-hook","version":null},{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-broadcast","version":null}]
+[{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-raft","version":null},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-auth-http","version":null},{"active":true,"attrs":null,"descr":"","immutable":true,"inited":true,"name":"rmqtt-acl","version":"0.21.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-counter","version":"0.21.0"},{"active":true,"attrs":null,"descr":"","immutable":false,"inited":true,"name":"rmqtt-http-api","version":"0.21.0"},{"active":false,"attrs":null,"descr":null,"immutable":false,"inited":false,"name":"rmqtt-web-hook","version":null},{"active":false,"attrs":null,"descr":null,"immutable":true,"inited":false,"name":"rmqtt-cluster-broadcast","version":null}]
 ```
 
 ### GET /api/v1/plugins/{node}/{plugin}

--- a/docs/zh_CN/install.md
+++ b/docs/zh_CN/install.md
@@ -17,13 +17,13 @@ RMQTT 目前支持的操作系统:
 1. 从[GitHub Release](https://github.com/rmqtt/rmqtt/releases) 下载zip包。
 
 ```bash
-$ wget "https://github.com/rmqtt/rmqtt/releases/download/0.3.0/rmqtt-0.3.0-x86_64-unknown-linux-musl.zip"
+$ wget "https://github.com/rmqtt/rmqtt/releases/download/0.21.0/rmqtt-0.21.0-x86_64-unknown-linux-musl.zip"
 ```
 
 2. 解压从[GitHub Release](https://github.com/rmqtt/rmqtt/releases) 下载的zip包。
 
 ```bash
-$ unzip rmqtt-0.3.0-x86_64-unknown-linux-musl.zip -d /app/
+$ unzip rmqtt-0.21.0-x86_64-unknown-linux-musl.zip -d /app/
 ```
 
 3. 修改权限

--- a/docs/zh_CN/testing-report.md
+++ b/docs/zh_CN/testing-report.md
@@ -103,7 +103,7 @@ cargo build -p rmqtt-test --release
 | 磁盘 | 2 TB |
 | 容器 | Podman v4.4.1 |
 | 测试工具 | `rmqtt/rmqtt-bench:latest` (v0.1.3) |
-| MQTT Broker | `rmqtt/rmqtt:latest` (v0.3.0) |
+| MQTT Broker | `rmqtt/rmqtt:latest` (v0.21.0) |
 
 *测试客户端和 Broker 同机部署。*
 


### PR DESCRIPTION
**Version Updates**
- Update all version references from v0.3.0/v0.8.0 to v0.21.0 across documentation
- Update Docker image tags, download URLs, and example version strings
- Update HTTP API response examples with current version numbers

**Hook System Documentation**
- Correct hook count from 18/10+ to 23 interception points
- Add missing hook types: `ClientKeepalive`, `MessageExpiryCheck`, `MessageNonsubscribed`, `OfflineInflightMessages`
- Update both English and Chinese documentation

**HTTP API Reference**
- Add `superuser` field to client responses
- Add `session_present` field to client responses
- Add `properties` field to publish request (MQTT v5)
- Add `authors`, `homepage`, `license`, `repository` fields to plugin responses
- Update example JSON responses with current field structure
- Remove deprecated `extra_attrs` field

**Plugin Development Guide**
- Change plugin version from hardcoded `0.1.0` to `version.workspace = true`
- Standardizes version management across all plugins

**Other Improvements**
- Update User-Agent header examples from 0.8.0 to 0.21.0
- Update benchmark and test report version references
- Fix broken anchor links in documentation index

**Files Changed**
- docs/en_US/README.md
- docs/en_US/architecture/overview.md
- docs/en_US/auth-http.md
- docs/en_US/benchmark-testing.md
- docs/en_US/development/plugin-development.md
- docs/en_US/http-api.md
- docs/en_US/install.md
- docs/en_US/testing-report.md
- docs/zh_CN/README.md
- docs/zh_CN/architecture/overview.md
- docs/zh_CN/auth-http.md
- docs/zh_CN/benchmark-testing.md
- docs/zh_CN/development/plugin-development.md
- docs/zh_CN/http-api.md
- docs/zh_CN/install.md
- docs/zh_CN/testing-report.md