### PR TITLE
docs: correct version references in root README files

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -138,7 +138,7 @@ curl "http://127.0.0.1:6066/api/v1/health/check"
 
 ```toml
 [dependencies]
-rmqtt = "0.22"
+rmqtt = "0.21"
 ```
 
 更多关于库模式的使用说明，请参考 [RMQTT 库使用文档](./rmqtt/README-CN.md) 。

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ In addition to running as a standalone MQTT Broker/Server, rmqtt also provides a
 
 ```toml
 [dependencies]
-rmqtt = "0.22"
+rmqtt = "0.21"
 ```
 
 For more details about using rmqtt in library mode, please refer to the [RMQTT Library Documentation](./rmqtt/README.md).
@@ -231,16 +231,16 @@ The `rmqtt-test` crate provides a custom test harness with functional, stress, a
 ### Benchmark
 
 #### Environment
-| Item        | Content                                   |                                                              |
-|-------------|-------------------------------------------|--------------------------------------------------------------|
-| System      | x86_64 GNU/Linux                          | Rocky Linux 9.2 (Blue Onyx)                                  |
+| Item        | Content                                   |                                                                 |
+|-------------|-------------------------------------------|-----------------------------------------------------------------|
+| System      | x86_64 GNU/Linux                          | Rocky Linux 9.2 (Blue Onyx)                                     |
 | CPU         | Intel(R) Xeon(R) CPU E5-2696 v3 @ 2.30GHz | 72(CPU(s)) = 18(Core(s)) * 2(Thread(s) per core) * 2(Socket(s)) |
-| Memory      | DDR3/2333                                 | 128G                                                         |
-| Disk        |                                           | 2T                                                           |
-| Container   | podman                                    | v4.4.1                                                       |
-| MQTT Bench  | docker.io/rmqtt/rmqtt-bench:latest        | v0.1.3                                                       |
-| MQTT Broker | docker.io/rmqtt/rmqtt:latest              | v0.3.0                                                       |
-| Other       | MQTT Bench and MQTT Broker coexistence    |                                                              |
+| Memory      | DDR3/2333                                 | 128G                                                            |
+| Disk        |                                           | 2T                                                              |
+| Container   | podman                                    | v4.4.1                                                          |
+| MQTT Bench  | docker.io/rmqtt/rmqtt-bench:latest        | v0.1.3                                                          |
+| MQTT Broker | docker.io/rmqtt/rmqtt:latest              | v0.3.0                                                          |
+| Other       | MQTT Bench and MQTT Broker coexistence    |                                                                 |
 
 #### Connection Concurrency Performance
 | Item                  | Single Node       | Raft Cluster Mode |


### PR DESCRIPTION
- Revert library version from 0.22 to 0.21 (current stable release)
- Fix table formatting alignment in benchmark environment section