### PR TITLE
chore: update dependencies and normalize simple_logger usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5120,7 +5120,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite 0.27.0",
+ "tokio-tungstenite",
  "tokio-util",
  "x509-parser",
 ]
@@ -5694,7 +5694,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tracing",
  "ulid",
@@ -6714,18 +6714,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.27.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -6733,7 +6721,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -7029,9 +7017,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -7040,19 +7028,6 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "log",
- "rand 0.9.4",
  "thiserror 2.0.18",
 ]
 
@@ -7124,12 +7099,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,8 +133,8 @@ url = { version = "2.5.4", default-features = false }
 systemstat = "0.2"
 itertools = "0.14"
 clap = { version = "4", features = ["derive"] }
-tokio-tungstenite = "0.27"
-pin-project-lite = "0.2"
+tokio-tungstenite = "0.29"
+
 bitflags = "2.9.2"
 leaky-bucket = "1.1.2"
 scc = "2.3.4"
@@ -143,7 +143,7 @@ prometheus = "0.14"
 futures-time = "3.0"
 nonzero_ext = "0.3"
 itoa = "1.0.15"
-simple_logger = { version = "5.0.0", default-features = false }
+simple_logger = "5.0.0"
 regex = "1.11.1"
 backoff = "0.4"
 webpki-roots = "0.26"

--- a/rmqtt-net/Cargo.toml
+++ b/rmqtt-net/Cargo.toml
@@ -47,6 +47,6 @@ rustls = { workspace = true, features = ["aws-lc-rs", "logging", "std", "tls12"]
 rustls = { workspace = true, features = ["ring", "logging", "std", "tls12"], optional = true }
 
 [dev-dependencies]
-simple_logger = "5"
+simple_logger = { workspace = true }
 tokio = { workspace = true,  features = ["full"] }
 once_cell.workspace = true

--- a/rmqtt/examples/multi/Cargo.toml
+++ b/rmqtt/examples/multi/Cargo.toml
@@ -6,6 +6,6 @@ edition.workspace = true
 [dependencies]
 rmqtt = { workspace = true, features = ["ws", "tls"] }
 tokio = { version = "1", features = ["full"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log = "0.4"
 

--- a/rmqtt/examples/plugin/Cargo.toml
+++ b/rmqtt/examples/plugin/Cargo.toml
@@ -29,7 +29,7 @@ rmqtt-bridge-egress-reductstore.workspace = true
 
 rmqtt = { workspace = true, features = ["plugin"] }
 tokio = { version = "1", features = ["full"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log = "0.4"
 
 

--- a/rmqtt/examples/plugins/Cargo.toml
+++ b/rmqtt/examples/plugins/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 rmqtt = { workspace = true, features = ["plugin"] }
 rmqtt-plugins = { workspace = true, features = ["full"] }
 tokio = { version = "1", features = ["full"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log = "0.4"
 
 

--- a/rmqtt/examples/simple/Cargo.toml
+++ b/rmqtt/examples/simple/Cargo.toml
@@ -6,5 +6,5 @@ edition.workspace = true
 [dependencies]
 rmqtt.workspace = true
 tokio = { version = "1", features = ["full"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log = "0.4"

--- a/rmqtt/examples/simple_quic/Cargo.toml
+++ b/rmqtt/examples/simple_quic/Cargo.toml
@@ -6,6 +6,6 @@ edition.workspace = true
 [dependencies]
 rmqtt = { workspace = true, features = ["quic", "tls"] }
 tokio = { version = "1", features = ["full"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log = "0.4"
 

--- a/rmqtt/examples/simple_quic_client/Cargo.toml
+++ b/rmqtt/examples/simple_quic_client/Cargo.toml
@@ -8,7 +8,7 @@ rmqtt-net = { workspace = true, features = ["quic"] }
 rmqtt-codec.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["codec"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log.workspace = true
 quinn.workspace = true
 futures.workspace = true

--- a/rmqtt/examples/simple_tls/Cargo.toml
+++ b/rmqtt/examples/simple_tls/Cargo.toml
@@ -6,6 +6,6 @@ edition.workspace = true
 [dependencies]
 rmqtt = { workspace = true, features = ["tls"] }
 tokio = { version = "1", features = ["full"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log = "0.4"
 

--- a/rmqtt/examples/simple_ws/Cargo.toml
+++ b/rmqtt/examples/simple_ws/Cargo.toml
@@ -6,6 +6,6 @@ edition.workspace = true
 [dependencies]
 rmqtt = { workspace = true, features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log = "0.4"
 

--- a/rmqtt/examples/simple_wss/Cargo.toml
+++ b/rmqtt/examples/simple_wss/Cargo.toml
@@ -6,6 +6,6 @@ edition.workspace = true
 [dependencies]
 rmqtt = { workspace = true, features = ["ws", "tls"] }
 tokio = { version = "1", features = ["full"] }
-simple_logger = "5"
+simple_logger = { workspace = true }
 log = "0.4"
 


### PR DESCRIPTION
- Upgrade tokio-tungstenite from 0.27 to 0.29
- Remove unused pin-project-lite dependency from workspace
- Remove default-features = false from simple_logger (use default features)
- Normalize simple_logger to use workspace version across all examples and rmqtt-net dev-dependency