### PR TITLE
feat(plugins): add disabled_default_startups config to exclude plugin…

### DIFF
--- a/rmqtt-bin/build.rs
+++ b/rmqtt-bin/build.rs
@@ -34,7 +34,7 @@ fn plugins(decoded: &toml::Value) {
             );
             // Use the extracted data to generate Rust code and add it to the inits vector
             inits.push(format!(
-                "    {plugin_id}::register_named(_scx, r#\"{name}\"#, {default_startup} || _default_startups.contains(&String::from(r#\"{name}\"#)), {immutable}).await.map_err(|e| anyhow::anyhow!(format!(r#\"Failed to register '{name}' plug-in, {{}} \"#, e.to_string())))?;"
+                "    {plugin_id}::register_named(_scx, r#\"{name}\"#, ({default_startup} || _default_startups.contains(&String::from(r#\"{name}\"#))) && !_disabled_default_startups.contains(&String::from(r#\"{name}\"#)), {immutable}).await.map_err(|e| anyhow::anyhow!(format!(r#\"Failed to register '{name}' plug-in, {{}} \"#, e.to_string())))?;"
             ));
         }
     }
@@ -45,7 +45,7 @@ fn plugins(decoded: &toml::Value) {
 
     plugin_rs.write_all(b"#[allow(clippy::all)]\n").unwrap();
     plugin_rs
-        .write_all(b"pub(crate) async fn registers(_scx: &rmqtt::context::ServerContext, _default_startups: Vec<String>) -> rmqtt::Result<()>{\n")
+        .write_all(b"pub(crate) async fn registers(_scx: &rmqtt::context::ServerContext, _default_startups: Vec<String>, _disabled_default_startups: Vec<String>) -> rmqtt::Result<()>{\n")
         .unwrap();
     plugin_rs.write_all(inits.join("\n").as_bytes()).unwrap();
     plugin_rs.write_all(b"\n    Ok(())\n}").unwrap();

--- a/rmqtt-bin/src/server.rs
+++ b/rmqtt-bin/src/server.rs
@@ -80,7 +80,13 @@ async fn main() -> Result<()> {
     scx.node.start_grpc_server(scx.clone(), conf.rpc.server_addr, conf.rpc.reuseaddr, conf.rpc.reuseport);
 
     //register plugin
-    plugin::registers(&scx, conf.plugins.default_startups.clone()).await.expect("register plugin failed");
+    plugin::registers(
+        &scx,
+        conf.plugins.default_startups.clone(),
+        conf.plugins.disabled_default_startups.clone(),
+    )
+    .await
+    .expect("register plugin failed");
 
     let mut builder = MqttServer::new(scx);
 

--- a/rmqtt-conf/src/lib.rs
+++ b/rmqtt-conf/src/lib.rs
@@ -316,6 +316,10 @@ pub struct Plugins {
     pub dir: String,
     #[serde(default)]
     pub default_startups: Vec<String>,
+    /// Plugins that should NOT be started even if they have `default_startup = true`
+    /// in `rmqtt-bin/Cargo.toml` metadata.
+    #[serde(default)]
+    pub disabled_default_startups: Vec<String>,
 }
 
 impl Plugins {

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -94,6 +94,15 @@ plugins.default_startups = [
     "rmqtt-http-api"
 ]
 
+#Disable plugins that have default_startup = true in Cargo.toml
+#These plugins will NOT be started even if default_startup = true
+#Example: Uncomment to disable rmqtt-acl and rmqtt-counter
+#plugins.disabled_default_startups = [
+#    "rmqtt-acl",
+#    "rmqtt-counter",
+#]
+plugins.disabled_default_startups = []
+
 
 ##--------------------------------------------------------------------
 ## MQTT


### PR DESCRIPTION
…s at runtime #336

**Problem**
Plugins with `default_startup = true` in Cargo.toml metadata are always loaded. There is no way to selectively disable specific built-in plugins without recompiling the binary.

**Solution**
Add `disabled_default_startups` configuration option that allows excluding specific plugins from startup even when they are marked as default_startup.

**Implementation**
- Add `disabled_default_startups: Vec<String>` field to `Plugins` config struct
- Pass `_disabled_default_startups` parameter to `registers()` function
- Modify build.rs generated code: exclude plugin if it's in disabled list
- Update rmqtt.toml with example configuration (commented out)

**Usage**
```toml
plugins.disabled_default_startups = [
    "rmqtt-acl",
    "rmqtt-counter",
]