### PR TITLE
feat(shared-subscription): refactor shared subscription system and remove per-listener shared_subscription config   #332

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ target/
 !.dockerignore
 !.github
 /CODEBUDDY.md
+/code-review-report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,6 +2142,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -2786,6 +2791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5274,6 +5288,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmqtt-shared-subscription"
+version = "0.22.0"
+dependencies = [
+ "async-trait",
+ "log",
+ "lru",
+ "rand 0.9.4",
+ "rmqtt",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "rmqtt-storage"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5416,6 +5444,7 @@ dependencies = [
  "rmqtt-p2p-messaging",
  "rmqtt-retainer",
  "rmqtt-session-storage",
+ "rmqtt-shared-subscription",
  "rmqtt-sys-topic",
  "rmqtt-topic-rewrite",
  "rmqtt-web-hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ rmqtt-bridge-egress-nats = { path = "rmqtt-plugins/rmqtt-bridge-egress-nats"}
 rmqtt-bridge-egress-reductstore = { path = "rmqtt-plugins/rmqtt-bridge-egress-reductstore"}
 rmqtt-bridge-origin = { path = "rmqtt-plugins/rmqtt-bridge-origin"}
 rmqtt-p2p-messaging = { path = "rmqtt-plugins/rmqtt-p2p-messaging"}
+rmqtt-shared-subscription = { path = "rmqtt-plugins/rmqtt-shared-subscription" }
 
 
 [workspace.package]
@@ -98,6 +99,7 @@ rmqtt-topic-rewrite = "0.22.0"
 rmqtt-web-hook = "0.22.0"
 rmqtt-cluster-raft = "0.22.0"
 rmqtt-cluster-broadcast = "0.22.0"
+rmqtt-shared-subscription = "0.22.0"
 rmqtt-p2p-messaging = "0.22.0"
 
 tokio = { version = "1",  default-features = false }

--- a/README-CN.md
+++ b/README-CN.md
@@ -39,7 +39,7 @@
 - [主题重写](./docs/zh_CN/topic-rewrite.md);
 - [自动订阅](./docs/zh_CN/auto-subscription.md);
 - [P2P 消息传递](./docs/zh_CN/p2p-messaging.md);
-- 共享订阅($share/{Group}/{TopicFilter});
+- [共享订阅($share/{Group}/{TopicFilter})](./docs/zh_CN/shared-subscription.md);
 - 排它订阅($exclusive/{TopicFilter});
 - 限制订阅($limit/{LimitQuantity}/{TopicFilter});
 - 延迟发布($delayed/{DelayInterval}/{TopicName});

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and mobile applications that can handle millions of concurrent clients on a sing
 - [Topic Rewrite](./docs/en_US/topic-rewrite.md);
 - [Auto Subscription](./docs/en_US/auto-subscription.md);
 - [P2P Messaging](./docs/en_US/p2p-messaging.md);
-- Shared subscription($share/{Group}/{TopicFilter});
+- [Shared subscription($share/{Group}/{TopicFilter})](./docs/en_US/shared-subscription.md);
 - Exclusive subscription($exclusive/{TopicFilter});
 - Limit subscription($limit/{LimitQuantity}/{TopicFilter});
 - Delayed publish($delayed/{DelayInterval}/{TopicName});

--- a/docs/en_US/README.md
+++ b/docs/en_US/README.md
@@ -98,6 +98,7 @@ Welcome to the RMQTT documentation. This index provides a structured overview of
 |----------|-------------|
 | [Topic Rewrite](topic-rewrite.md) | Topic filter and name rewriting |
 | [Auto Subscription](auto-subscription.md) | Automatic subscription on connect |
+| [Shared Subscription](shared-subscription.md) | Load-balanced consumer groups |
 | [P2P Messaging](p2p-messaging.md) | Direct client-to-client messaging |
 
 ---
@@ -140,7 +141,8 @@ Each crate has its own bilingual README:
 | | [rmqtt-web-hook](../rmqtt-plugins/rmqtt-web-hook/README.md) | Webhook notifications |
 | | [rmqtt-sys-topic](../rmqtt-plugins/rmqtt-sys-topic/README.md) | System topics |
 | **Utility** | [rmqtt-counter](../rmqtt-plugins/rmqtt-counter/README.md) | Metrics counters |
-| | [rmqtt-auto-subscription](../rmqtt-plugins/rmqtt-auto-subscription/README.md) | Auto-subscription |
+| **Subscription** | [rmqtt-shared-subscription](../rmqtt-plugins/rmqtt-shared-subscription/README.md) | Shared subscription strategies |
+| | [rmqtt-auto-subscription](../rmqtt-plugins/rmqtt-auto-subscription/README.md) | Auto-subscription on connect |
 | | [rmqtt-topic-rewrite](../rmqtt-plugins/rmqtt-topic-rewrite/README.md) | Topic rewrite |
 | | [rmqtt-p2p-messaging](../rmqtt-plugins/rmqtt-p2p-messaging/README.md) | P2P messaging |
 

--- a/docs/en_US/benchmark-testing.md
+++ b/docs/en_US/benchmark-testing.md
@@ -62,7 +62,6 @@ listener.tcp.external.session_expiry_interval = "2h"
 listener.tcp.external.message_retry_interval = "20s"
 listener.tcp.external.message_expiry_interval = "5m"
 listener.tcp.external.max_subscriptions = 0
-listener.tcp.external.shared_subscription = true
 listener.tcp.external.max_topic_aliases = 32
 
 ```
@@ -369,7 +368,6 @@ listener.tcp.external.session_expiry_interval = "2h"
 listener.tcp.external.message_retry_interval = "20s"
 listener.tcp.external.message_expiry_interval = "5m"
 listener.tcp.external.max_subscriptions = 0
-listener.tcp.external.shared_subscription = true
 listener.tcp.external.max_topic_aliases = 32
 
 ```

--- a/docs/en_US/shared-subscription.md
+++ b/docs/en_US/shared-subscription.md
@@ -1,0 +1,88 @@
+English | [简体中文](../zh_CN/shared-subscription.md)
+
+# Shared Subscription
+
+Shared subscription enables load-balanced consumer groups using the `$share/{group}/{topic}` topic filter format. When multiple clients subscribe to the same shared group, published messages are delivered to **only one** subscriber in the group, enabling horizontal scaling of message consumers.
+
+This feature is provided by the [rmqtt-shared-subscription](https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-shared-subscription) plugin.
+
+## How It Works
+
+A shared subscription topic filter follows the format:
+
+```
+$share/{group}/{topic}
+```
+
+- `$share` — The shared subscription prefix
+- `{group}` — An arbitrary group name (e.g., `group1`, `sensors`)
+- `{topic}` — A standard MQTT topic filter (e.g., `sensor/+/temp`)
+
+All clients subscribed to the same `{group}` and `{topic}` form a consumer group. When a message matches the topic filter, the broker selects **one** subscriber from the group to receive it.
+
+## Selection Strategies
+
+The plugin supports seven configurable strategies for subscriber selection:
+
+| Strategy | Description | Use Case |
+|----------|-------------|----------|
+| `random` | Randomly selects an online subscriber | Basic load balancing |
+| `round_robin` (default) | Sequential round-robin using an atomic counter | Equal-capacity consumers |
+| `round_robin_per_group` | Independent round-robin per shared group | Large cluster with many groups |
+| `sticky` | Binds a publisher to a fixed subscriber via LRU cache | Stateful processing, session affinity |
+| `local` | Prefers subscribers on the same broker node as the publisher | Reduce cross-node traffic |
+| `hash_clientid` | Deterministic selection by hashing the publisher's ClientId | Per-device message ordering |
+| `hash_topic` | Deterministic selection by hashing the topic name | Topic sharding |
+
+### sticky strategy
+
+When using the `sticky` strategy, the plugin maintains an LRU cache of publisher-to-subscriber bindings. The cache size is configurable with `sticky_cache_size`. When the cache is full, the least recently used binding is evicted automatically.
+
+## Configuration
+
+#### Plugin:
+
+```bash
+rmqtt-shared-subscription
+```
+
+#### Plugin Configuration File:
+
+```bash
+plugins/rmqtt-shared-subscription.toml
+```
+
+#### Plugin Configuration Options:
+
+```bash
+##--------------------------------------------------------------------
+## rmqtt-shared-subscription
+##--------------------------------------------------------------------
+
+# Selection strategy
+# Valid values: random, round_robin, round_robin_per_group, sticky, local, hash_clientid, hash_topic
+# Default: round_robin
+strategy = "round_robin"
+
+# Maximum sticky bindings in the LRU cache (only applies to "sticky" strategy).
+# When the cache fills up, the least recently used binding is evicted.
+# Default: 100000
+# sticky_cache_size = 100000
+```
+
+#### Enabling the Plugin
+
+Shared subscriptions are automatically available on all listeners once the plugin is loaded. Add `rmqtt-shared-subscription` to the `plugins.default_startups` list in `rmqtt.toml`:
+
+```bash
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+plugins.dir = "rmqtt-plugins/"
+plugins.default_startups = [
+    "rmqtt-shared-subscription",
+    # ... other plugins
+]
+```
+
+No per-listener configuration is required.

--- a/docs/zh_CN/README.md
+++ b/docs/zh_CN/README.md
@@ -97,6 +97,7 @@
 |----------|-------------|
 | [主题重写](topic-rewrite.md) | 主题过滤器和名称重写 |
 | [自动订阅](auto-subscription.md) | 连接时自动订阅 |
+| [共享订阅](shared-subscription.md) | 负载均衡的消费者组 |
 | [P2P 消息](p2p-messaging.md) | 客户端间直接消息投递 |
 
 ---
@@ -139,6 +140,7 @@
 | | [rmqtt-web-hook](../rmqtt-plugins/rmqtt-web-hook/README-CN.md) | Webhook 通知 |
 | | [rmqtt-sys-topic](../rmqtt-plugins/rmqtt-sys-topic/README-CN.md) | 系统主题 |
 | **功能** | [rmqtt-counter](../rmqtt-plugins/rmqtt-counter/README-CN.md) | 指标计数器 |
+| **订阅** | [rmqtt-shared-subscription](../rmqtt-plugins/rmqtt-shared-subscription/README-CN.md) | 共享订阅策略 |
 | | [rmqtt-auto-subscription](../rmqtt-plugins/rmqtt-auto-subscription/README-CN.md) | 自动订阅 |
 | | [rmqtt-topic-rewrite](../rmqtt-plugins/rmqtt-topic-rewrite/README-CN.md) | 主题重写 |
 | | [rmqtt-p2p-messaging](../rmqtt-plugins/rmqtt-p2p-messaging/README-CN.md) | 点对点消息 |

--- a/docs/zh_CN/benchmark-testing.md
+++ b/docs/zh_CN/benchmark-testing.md
@@ -62,7 +62,6 @@ listener.tcp.external.session_expiry_interval = "2h"
 listener.tcp.external.message_retry_interval = "20s"
 listener.tcp.external.message_expiry_interval = "5m"
 listener.tcp.external.max_subscriptions = 0
-listener.tcp.external.shared_subscription = true
 listener.tcp.external.max_topic_aliases = 32
 
 ```
@@ -370,7 +369,6 @@ listener.tcp.external.session_expiry_interval = "2h"
 listener.tcp.external.message_retry_interval = "20s"
 listener.tcp.external.message_expiry_interval = "5m"
 listener.tcp.external.max_subscriptions = 0
-listener.tcp.external.shared_subscription = true
 listener.tcp.external.max_topic_aliases = 32
 
 ```

--- a/docs/zh_CN/shared-subscription.md
+++ b/docs/zh_CN/shared-subscription.md
@@ -1,0 +1,88 @@
+[English](../en_US/shared-subscription.md) | 简体中文
+
+# 共享订阅
+
+共享订阅使用 `$share/{group}/{topic}` 主题过滤器格式实现负载均衡的消费者组。当多个客户端订阅同一个共享组时，发布的消息只会投递给组中的**某一个**订阅者，从而实现消息消费者的水平扩展。
+
+此功能由 [rmqtt-shared-subscription](https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-shared-subscription) 插件提供。
+
+## 工作原理
+
+共享订阅主题过滤器格式如下：
+
+```
+$share/{group}/{topic}
+```
+
+- `$share` — 共享订阅前缀
+- `{group}` — 任意组名（如 `group1`、`sensors`）
+- `{topic}` — 标准 MQTT 主题过滤器（如 `sensor/+/temp`）
+
+订阅了相同 `{group}` 和 `{topic}` 的所有客户端构成一个消费者组。当有消息匹配主题过滤器时，Broker 从组中选择**一个**订阅者进行投递。
+
+## 选择策略
+
+插件支持七种可配置的订阅者选择策略：
+
+| 策略 | 描述 | 适用场景 |
+|------|------|----------|
+| `random` | 随机选择一个在线订阅者 | 基础负载均衡 |
+| `round_robin`（默认） | 使用原子计数器顺序轮转 | 等容量消费者 |
+| `round_robin_per_group` | 每个共享组独立轮转 | 大规模集群多组场景 |
+| `sticky` | 通过 LRU 缓存将发布者绑定到固定订阅者 | 有状态处理、会话亲和性 |
+| `local` | 优先选择与发布者同节点的订阅者 | 减少跨节点流量 |
+| `hash_clientid` | 按发布者 ClientId 哈希确定性选择 | 设备级消息有序性 |
+| `hash_topic` | 按主题名哈希确定性选择 | 主题分片 |
+
+### sticky 策略
+
+使用 `sticky` 策略时，插件维护一个发布者到订阅者的 LRU 绑定缓存。缓存大小通过 `sticky_cache_size` 配置。缓存满时，最久未使用的绑定会被自动淘汰。
+
+## 配置
+
+#### 插件：
+
+```bash
+rmqtt-shared-subscription
+```
+
+#### 插件配置文件：
+
+```bash
+plugins/rmqtt-shared-subscription.toml
+```
+
+#### 插件配置项：
+
+```bash
+##--------------------------------------------------------------------
+## rmqtt-shared-subscription
+##--------------------------------------------------------------------
+
+# 选择策略
+# 有效值：random, round_robin, round_robin_per_group, sticky, local, hash_clientid, hash_topic
+# 默认值：round_robin
+strategy = "round_robin"
+
+# LRU 缓存的最大粘性绑定数（仅适用于 "sticky" 策略）。
+# 缓存满时，最久未使用的绑定会被淘汰。
+# 默认值：100000
+# sticky_cache_size = 100000
+```
+
+#### 启用插件
+
+插件加载后，所有监听器自动支持共享订阅。在 `rmqtt.toml` 的 `plugins.default_startups` 列表中添加 `rmqtt-shared-subscription`：
+
+```bash
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+plugins.dir = "rmqtt-plugins/"
+plugins.default_startups = [
+    "rmqtt-shared-subscription",
+    # 其他插件...
+]
+```
+
+不需要在监听器上单独配置。

--- a/rmqtt-bin/Cargo.toml
+++ b/rmqtt-bin/Cargo.toml
@@ -42,6 +42,7 @@ rmqtt-counter.workspace = true
 rmqtt-auth-http.workspace = true
 rmqtt-auth-jwt.workspace = true
 rmqtt-auto-subscription.workspace = true
+rmqtt-shared-subscription.workspace = true
 rmqtt-bridge-egress-kafka.workspace = true
 rmqtt-bridge-ingress-kafka.workspace = true
 rmqtt-bridge-egress-mqtt.workspace = true
@@ -70,6 +71,7 @@ rmqtt-counter = { default_startup = true }
 rmqtt-auth-http = { }
 rmqtt-auth-jwt = { }
 rmqtt-auto-subscription = { }
+rmqtt-shared-subscription = { }
 rmqtt-bridge-egress-kafka = { }
 rmqtt-bridge-ingress-kafka = { }
 rmqtt-bridge-egress-mqtt = { }

--- a/rmqtt-bin/src/server.rs
+++ b/rmqtt-bin/src/server.rs
@@ -206,7 +206,6 @@ fn config_builder(cfg: &Listener) -> Builder {
         .message_retry_interval(cfg.message_retry_interval)
         .message_expiry_interval(cfg.message_expiry_interval)
         .max_subscriptions(cfg.max_subscriptions)
-        .shared_subscription(cfg.shared_subscription)
         .max_topic_aliases(cfg.max_topic_aliases)
         .tls_cross_certificate(cfg.cross_certificate)
         .tls_cert(cfg.cert.clone())

--- a/rmqtt-conf/README-CN.md
+++ b/rmqtt-conf/README-CN.md
@@ -135,7 +135,6 @@ impl Listeners {
 | `message_retry_interval` | `Duration` | `30s` | QoS 消息重试间隔 |
 | `message_expiry_interval` | `Duration` | `300s` | 消息过期时间；`0` → `u32::MAX` |
 | `max_subscriptions` | `usize` | `0`（不限） | 每客户端最大订阅数 |
-| `shared_subscription` | `bool` | `true` | 启用 `$share/` 订阅 |
 | `max_topic_aliases` | `u16` | `0` | 最大主题别名数 |
 | `cross_certificate` | `bool` | `false` | 验证交叉证书 |
 | `cert` | `Option<String>` | `None` | TLS 证书文件路径 |

--- a/rmqtt-conf/README.md
+++ b/rmqtt-conf/README.md
@@ -135,7 +135,6 @@ Fields via `Deref<Target = ListenerInner>`:
 | `message_retry_interval` | `Duration` | `30s` | QoS msg retry interval |
 | `message_expiry_interval` | `Duration` | `300s` | Message expiry; `0` → `u32::MAX` |
 | `max_subscriptions` | `usize` | `0` (unlimited) | Max subscriptions per client |
-| `shared_subscription` | `bool` | `true` | Enable `$share/` subscriptions |
 | `max_topic_aliases` | `u16` | `0` | Max topic aliases |
 | `cross_certificate` | `bool` | `false` | Verify cross certificates |
 | `cert` | `Option<String>` | `None` | TLS cert file path |

--- a/rmqtt-conf/src/listener.rs
+++ b/rmqtt-conf/src/listener.rs
@@ -271,9 +271,6 @@ pub struct ListenerInner {
     #[serde(default = "ListenerInner::max_subscriptions_default")]
     pub max_subscriptions: usize,
 
-    #[serde(default = "ListenerInner::shared_subscription_default")]
-    pub shared_subscription: bool,
-
     #[serde(default)]
     pub max_topic_aliases: u16,
 
@@ -339,7 +336,6 @@ impl Default for ListenerInner {
             message_retry_interval: ListenerInner::message_retry_interval_default(),
             message_expiry_interval: ListenerInner::message_expiry_interval_default(),
             max_subscriptions: ListenerInner::max_subscriptions_default(),
-            shared_subscription: ListenerInner::shared_subscription_default(),
             max_topic_aliases: 0,
             cross_certificate: ListenerInner::cross_certificate_default(),
             cert: None,
@@ -466,10 +462,6 @@ impl ListenerInner {
     #[inline]
     fn max_subscriptions_default() -> usize {
         0
-    }
-    #[inline]
-    fn shared_subscription_default() -> bool {
-        true
     }
 
     /// Returns the handshake timeout in milliseconds as a `u16`, capped at `u16::MAX`.

--- a/rmqtt-net/README-CN.md
+++ b/rmqtt-net/README-CN.md
@@ -35,7 +35,7 @@ pub type Result<T> = anyhow::Result<T, Error>;
 
 | 方法 | 参数 | Builder 默认值 |
 |--------|--------|----------------|
-| `new()` | — | `max_connections=1_000_000, max_handshaking_limit=1_000, max_packet_size=1MB, backlog=512, nodelay=false, reuseaddr=None, reuseport=None, allow_anonymous=true, min_keepalive=0, max_keepalive=65535, allow_zero_keepalive=true, keepalive_backoff=0.75, max_inflight=16, handshake_timeout=30s, send_timeout=10s, max_mqueue_len=1000, max_clientid_len=65535, max_qos_allowed=2, max_topic_levels=0, session_expiry_interval=7200s, max_session_expiry_interval=0, message_retry_interval=20s, message_expiry_interval=300s, max_subscriptions=0, shared_subscription=true, max_topic_aliases=0, ...` |
+| `new()` | — | `max_connections=1_000_000, max_handshaking_limit=1_000, max_packet_size=1MB, backlog=512, nodelay=false, reuseaddr=None, reuseport=None, allow_anonymous=true, min_keepalive=0, max_keepalive=65535, allow_zero_keepalive=true, keepalive_backoff=0.75, max_inflight=16, handshake_timeout=30s, send_timeout=10s, max_mqueue_len=1000, max_clientid_len=65535, max_qos_allowed=2, max_topic_levels=0, session_expiry_interval=7200s, max_session_expiry_interval=0, message_retry_interval=20s, message_expiry_interval=300s, max_subscriptions=0, max_topic_aliases=0, ...` |
 | `.name(s)` | `impl Into<String>` | `""` |
 | `.laddr(a)` | `SocketAddr` | `0.0.0.0:1883` |
 | `.backlog(n)` | `i32` | `512` |
@@ -63,7 +63,6 @@ pub type Result<T> = anyhow::Result<T, Error>;
 | `.message_retry_interval(d)` | `Duration` | `20s` |
 | `.message_expiry_interval(d)` | `Duration` | `300s` |
 | `.max_subscriptions(n)` | `usize` | `0`（不限） |
-| `.shared_subscription(v)` | `bool` | `true` |
 | `.max_topic_aliases(v)` | `u16` | `0` |
 | `.limit_subscription(v)` | `bool` | `false` |
 | `.delayed_publish(v)` | `bool` | `false` |

--- a/rmqtt-net/README.md
+++ b/rmqtt-net/README.md
@@ -35,7 +35,7 @@ All fields have `pub` visibility and fluent setter methods:
 
 | Method | Params | Builder default |
 |--------|--------|----------------|
-| `new()` | — | `max_connections=1_000_000, max_handshaking_limit=1_000, max_packet_size=1MB, backlog=512, nodelay=false, reuseaddr=None, reuseport=None, allow_anonymous=true, min_keepalive=0, max_keepalive=65535, allow_zero_keepalive=true, keepalive_backoff=0.75, max_inflight=16, handshake_timeout=30s, send_timeout=10s, max_mqueue_len=1000, max_clientid_len=65535, max_qos_allowed=2, max_topic_levels=0, session_expiry_interval=7200s, max_session_expiry_interval=0, message_retry_interval=20s, message_expiry_interval=300s, max_subscriptions=0, shared_subscription=true, max_topic_aliases=0, ...` |
+| `new()` | — | `max_connections=1_000_000, max_handshaking_limit=1_000, max_packet_size=1MB, backlog=512, nodelay=false, reuseaddr=None, reuseport=None, allow_anonymous=true, min_keepalive=0, max_keepalive=65535, allow_zero_keepalive=true, keepalive_backoff=0.75, max_inflight=16, handshake_timeout=30s, send_timeout=10s, max_mqueue_len=1000, max_clientid_len=65535, max_qos_allowed=2, max_topic_levels=0, session_expiry_interval=7200s, max_session_expiry_interval=0, message_retry_interval=20s, message_expiry_interval=300s, max_subscriptions=0, max_topic_aliases=0, ...` |
 | `.name(s)` | `impl Into<String>` | `""` |
 | `.laddr(a)` | `SocketAddr` | `0.0.0.0:1883` |
 | `.backlog(n)` | `i32` | `512` |
@@ -63,7 +63,6 @@ All fields have `pub` visibility and fluent setter methods:
 | `.message_retry_interval(d)` | `Duration` | `20s` |
 | `.message_expiry_interval(d)` | `Duration` | `300s` |
 | `.max_subscriptions(n)` | `usize` | `0` (unlimited) |
-| `.shared_subscription(v)` | `bool` | `true` |
 | `.max_topic_aliases(v)` | `u16` | `0` |
 | `.limit_subscription(v)` | `bool` | `false` |
 | `.delayed_publish(v)` | `bool` | `false` |

--- a/rmqtt-net/src/builder.rs
+++ b/rmqtt-net/src/builder.rs
@@ -133,8 +133,6 @@ pub struct Builder {
     pub message_expiry_interval: Duration,
     /// Maximum subscriptions per client (0 = unlimited)
     pub max_subscriptions: usize,
-    /// Enable shared subscription support
-    pub shared_subscription: bool,
     /// Maximum topic aliases (MQTTv5 feature)
     pub max_topic_aliases: u16,
     /// Enable subscription count limiting
@@ -222,7 +220,6 @@ impl Builder {
             message_retry_interval: Duration::from_secs(20),
             message_expiry_interval: Duration::from_secs(5 * 60),
             max_subscriptions: 0,
-            shared_subscription: true,
             max_topic_aliases: 0,
 
             limit_subscription: false,
@@ -402,12 +399,6 @@ impl Builder {
     /// Sets maximum subscriptions per client
     pub fn max_subscriptions(mut self, max_subscriptions: usize) -> Self {
         self.max_subscriptions = max_subscriptions;
-        self
-    }
-
-    /// Enables shared subscription support
-    pub fn shared_subscription(mut self, shared_subscription: bool) -> Self {
-        self.shared_subscription = shared_subscription;
         self
     }
 

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -438,9 +438,13 @@ impl ClusterShared {
             //shared subscription choice
             let mut node_shared_subs: HashMap<NodeId, SubRelations> = HashMap::default();
             for (topic_filter, sub_groups) in shared_sub_groups.iter_mut() {
-                for (_group, subs) in sub_groups.iter_mut() {
-                    if let Some((idx, _is_online)) =
-                        scx.extends.shared_subscription().await.choice(&scx, subs).await
+                for (group, subs) in sub_groups.iter_mut() {
+                    if let Some((idx, _is_online)) = scx
+                        .extends
+                        .shared_subscription()
+                        .await
+                        .choice(&scx, group, &from.id, &publish.topic, subs)
+                        .await
                     {
                         let (node_id, client_id, opts, sub_ids, _is_online) = subs.remove(idx);
                         node_shared_subs.entry(node_id).or_default().push((

--- a/rmqtt-plugins/rmqtt-shared-subscription.toml
+++ b/rmqtt-plugins/rmqtt-shared-subscription.toml
@@ -1,0 +1,19 @@
+# rmqtt-shared-subscription Plugin Configuration
+#
+# Supported strategies:
+#   random              - Random subscriber selection (basic load balancing)
+#   round_robin         - Sequential round-robin (default)
+#   round_robin_per_group - Per-node independent round-robin (large cluster)
+#   sticky              - Fixed subscriber per publisher (stateful processing)
+#   local               - Prefer publisher's node (reduce cross-node traffic)
+#   hash_clientid       - Hash by publisher ClientId (per-device ordering)
+#   hash_topic          - Hash by topic (topic sharding)
+
+# Selection strategy
+# Default: round_robin
+strategy = "sticky"
+
+# Maximum sticky bindings in the LRU cache (only applies to "sticky" strategy).
+# When the cache fills up, the least recently used binding is evicted.
+# Default: 100000
+sticky_cache_size = 100000

--- a/rmqtt-plugins/rmqtt-shared-subscription/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-shared-subscription/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rmqtt-shared-subscription"
+version.workspace = true
+description = "Shared subscription plugin for RMQTT. Implements group subscription selection strategies (random, round-robin, hash, sticky) for $share/{group}/{topic} subscriptions."
+repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins/rmqtt-shared-subscription"
+edition.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+rmqtt = { workspace = true, features = ["plugin", "shared-subscription"] }
+async-trait.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync", "rt"] }
+rand.workspace = true
+lru = "0.18"

--- a/rmqtt-plugins/rmqtt-shared-subscription/README-CN.md
+++ b/rmqtt-plugins/rmqtt-shared-subscription/README-CN.md
@@ -1,0 +1,112 @@
+[English](README.md) | [**简体中文**](README-CN.md)
+
+# rmqtt-shared-subscription
+
+[![crates.io](https://img.shields.io/crates/v/rmqtt-shared-subscription.svg)](https://crates.io/crates/rmqtt-shared-subscription)
+
+RMQTT 共享订阅插件。为 `$share/{group}/{topic}` 订阅提供多种订阅者选择策略。
+
+## 概述
+
+当多个客户端订阅同一个共享订阅组主题时（例如 `$share/group1/sensor/#`），发布的消息只会投递到组中的**某一个**订阅者。这使得 MQTT 能够支持负载均衡的消费者组模式，广泛应用于物联网和 MQTT 流式数据场景。
+
+本插件注册了一个 [`SharedSubscription`](https://docs.rs/rmqtt/latest/rmqtt/subscribe/trait.SharedSubscription.html) trait 实现，将订阅者选择逻辑委托给七种可配置的策略之一。
+
+## 策略
+
+| 策略 | 枚举值 | 描述 | 适用场景 |
+|------|--------|------|----------|
+| `random` | `Random` | 每次随机选择一个在线订阅者 | 基础负载均衡 |
+| `round_robin`（默认） | `RoundRobin` | 全局原子计数器轮转 | 等容量消费者 |
+| `round_robin_per_group` | `RoundRobinPerGroup` | 每个共享组独立计数轮转 | 大规模集群多组场景 |
+| `sticky` | `Sticky` | 通过 LRU 缓存将发布者绑定到固定订阅者 | 有状态处理、会话亲和性 |
+| `local` | `Local` | 优先选择与发布者同节点的订阅者 | 减少跨节点流量 |
+| `hash_clientid` | `HashClientId` | 按发布者 ClientId 哈希选择 | 设备级消息有序性 |
+| `hash_topic` | `HashTopic` | 按主题名哈希选择 | 主题分片 |
+
+### 策略详情
+
+**random** — 随机选取一个在线订阅者。若无在线订阅者，则回退到同节点订阅者。
+
+**round_robin** — 使用原子计数器在所有订阅者间顺序轮转。优先选择在线订阅者，跳过离线节点。
+
+**round_robin_per_group** — 与 round_robin 类似，但每个共享组维护独立的计数器，组间互不影响。
+
+**sticky** — 首次为 `(共享组, 发布者)` 选定订阅者后，将该绑定关系缓存并复用。若被绑定的订阅者离线，则清除绑定并新建。缓存使用 LRU 淘汰策略——参见下方 `sticky_cache_size` 配置。
+
+**local** — 优先选择与发布者同 Broker 节点的订阅者。若无本地在线订阅者，则回退到跨节点在线订阅者，最后回退到本地（即使离线）订阅者。
+
+**hash_clientid** — 使用 `std::hash::DefaultHasher` 对发布者的 ClientId 进行哈希，确定性地选择订阅者。若该订阅者离线，则回退到随机选择。
+
+**hash_topic** — 与 `hash_clientid` 类似，但对主题名进行哈希，确保同一主题的消息总是投递给同一订阅者。
+
+## 使用
+
+### 启用插件
+
+在 `rmqtt.toml` 的 `plugins.default_startups` 列表中添加：
+
+```toml
+plugins.default_startups = [
+    "rmqtt-shared-subscription",
+    # 其他插件...
+]
+```
+
+插件通过 `plugins.default_startups` 在启动时注册。无需在每个监听器上单独配置——所有监听器自动支持共享订阅。
+
+### 代码注册（可选）
+
+```rust
+rmqtt_shared_subscription::register(register_fn);
+```
+
+## 配置
+
+文件：`rmqtt-shared-subscription.toml`
+
+| 选项 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `strategy` | 字符串 | `"round_robin"` | 选择策略——见上方策略表格 |
+| `sticky_cache_size` | 整数 | `100000` | LRU 缓存的最大粘性绑定数（仅 `sticky` 策略生效） |
+
+### 示例
+
+```toml
+# 选择策略
+# 有效值：random, round_robin, round_robin_per_group, sticky, local, hash_clientid, hash_topic
+strategy = "round_robin"
+
+# LRU 缓存的最大粘性绑定数（仅适用于 "sticky" 策略）。
+# 缓存满时，最久未使用的绑定会被淘汰。
+sticky_cache_size = 100000
+```
+
+### 运行时指标
+
+插件通过 `attrs()` 方法（插件系统的 HTTP API 使用）暴露内部状态：
+
+| 字段 | 描述 | 策略条件 |
+|------|------|----------|
+| `strategy` | 当前策略名称 | 始终存在 |
+| `rr_counter` | 全局轮转计数器值 | `round_robin`, `round_robin_per_group` |
+| `rr_group_count` | 跟踪的组计数器数量 | `round_robin`, `round_robin_per_group` |
+| `rr_group_details` | 各组计数器明细列表（最多 1000 条） | `round_robin`, `round_robin_per_group` |
+| `sticky_binding_count` | 活跃的粘性绑定数 | `sticky` |
+| `sticky_binding_details` | 粘性绑定明细列表（最多 1000 条） | `sticky` |
+
+## MQTT 协议
+
+共享订阅使用 `$share/{group}/{topic}` 主题过滤器格式：
+
+- `$share/group1/sensor/#` — 订阅 `sensor/` 下所有主题，组名为 "group1"
+- 匹配该主题过滤器的消息只会投递给 "group1" 中的**一个**订阅者
+
+## 依赖
+
+- `rmqtt`（features `plugin`, `shared-subscription`）
+- `lru` 0.18 — 粘性绑定用 LRU 缓存
+
+## 许可证
+
+MIT OR Apache-2.0

--- a/rmqtt-plugins/rmqtt-shared-subscription/README.md
+++ b/rmqtt-plugins/rmqtt-shared-subscription/README.md
@@ -1,0 +1,112 @@
+[**English**](README.md) | [简体中文](README-CN.md)
+
+# rmqtt-shared-subscription
+
+[![crates.io](https://img.shields.io/crates/v/rmqtt-shared-subscription.svg)](https://crates.io/crates/rmqtt-shared-subscription)
+
+Shared subscription plugin for RMQTT. Implements subscriber selection strategies for `$share/{group}/{topic}` subscriptions.
+
+## Overview
+
+When multiple clients subscribe to a shared subscription group topic (e.g., `$share/group1/sensor/#`), published messages are delivered to **only one** subscriber in the group. This enables load-balanced consumer groups, commonly used in IoT and MQTT-based streaming scenarios.
+
+This plugin registers a [`SharedSubscription`](https://docs.rs/rmqtt/latest/rmqtt/subscribe/trait.SharedSubscription.html) trait implementation that dispatches subscriber selection to one of seven configurable strategies.
+
+## Strategies
+
+| Strategy | Key | Description | Use Case |
+|----------|-----|-------------|----------|
+| `random` | `Random` | Selects a random online subscriber each time | Basic load balancing |
+| `round_robin` (default) | `RoundRobin` | Global atomic counter rotates through subscribers | Equal-capacity consumers |
+| `round_robin_per_group` | `RoundRobinPerGroup` | Independent counter per shared group | Large cluster with many groups |
+| `sticky` | `Sticky` | Binds a publisher to a fixed subscriber via LRU cache | Stateful processing, session affinity |
+| `local` | `Local` | Prefers subscribers on the same node as the publisher | Reduce cross-node traffic |
+| `hash_clientid` | `HashClientId` | Hash by publisher's ClientId | Per-device message ordering |
+| `hash_topic` | `HashTopic` | Hash by topic name | Topic sharding |
+
+### Strategy Details
+
+**random** — Picks a random online subscriber. Falls back to a local-node subscriber if none are online.
+
+**round_robin** — Uses an atomic counter to distribute messages sequentially across all subscribers. Online subscribers are preferred; offline ones are skipped.
+
+**round_robin_per_group** — Similar to round_robin but maintains a separate counter per shared group, so each group independently round-robins.
+
+**sticky** — Once a subscriber is selected for a `(shared_group, publisher)` pair, that binding is cached and reused for subsequent messages. If the bound subscriber goes offline, the binding is removed and a new one is created. The cache uses an LRU eviction policy — see `sticky_cache_size` below.
+
+**local** — Prioritises subscribers on the same broker node as the publisher. Falls back to cross-node subscribers if no local subscriber is online, then to any subscriber (even offline) on the local node.
+
+**hash_clientid** — Uses `std::hash::DefaultHasher` on the publisher's ClientId to pick a subscriber deterministically. If that subscriber is offline, falls back to random online selection.
+
+**hash_topic** — Same as `hash_clientid` but hashes the topic name instead, ensuring messages on the same topic always go to the same subscriber.
+
+## Usage
+
+### Enable the plugin
+
+Add to the `plugins.default_startups` list in `rmqtt.toml`:
+
+```toml
+plugins.default_startups = [
+    "rmqtt-shared-subscription",
+    # ... other plugins
+]
+```
+
+The plugin registers itself at startup via `plugins.default_startups`. No per-listener configuration is needed — shared subscriptions are automatically available on all listeners.
+
+### Register from code (optional)
+
+```rust
+rmqtt_shared_subscription::register(register_fn);
+```
+
+## Configuration
+
+File: `rmqtt-shared-subscription.toml`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `strategy` | String | `"round_robin"` | Selection strategy — see Strategies table above |
+| `sticky_cache_size` | Integer | `100000` | Max sticky bindings in LRU cache (only applies to `sticky` strategy) |
+
+### Example
+
+```toml
+# Selection strategy
+# Valid values: random, round_robin, round_robin_per_group, sticky, local, hash_clientid, hash_topic
+strategy = "round_robin"
+
+# Maximum sticky bindings in the LRU cache (only applies to "sticky" strategy).
+# When the cache fills up, the least recently used binding is evicted.
+sticky_cache_size = 100000
+```
+
+### Runtime Metrics
+
+The plugin exposes internal state via the `attrs()` method (used by the plugin system's HTTP API):
+
+| Field | Description | Available when strategy is |
+|-------|-------------|---------------------------|
+| `strategy` | Current strategy name | Always |
+| `rr_counter` | Global round-robin counter value | `round_robin`, `round_robin_per_group` |
+| `rr_group_count` | Number of per-group counters tracked | `round_robin`, `round_robin_per_group` |
+| `rr_group_details` | Detailed per-group counter list (max 1000 entries) | `round_robin`, `round_robin_per_group` |
+| `sticky_binding_count` | Number of active sticky bindings | `sticky` |
+| `sticky_binding_details` | Detailed sticky binding list (max 1000 entries) | `sticky` |
+
+## MQTT Protocol
+
+Shared subscriptions use the `$share/{group}/{topic}` topic filter format:
+
+- `$share/group1/sensor/#` — Subscribe to all topics under `sensor/` with group "group1"
+- Messages matching the topic filter are delivered to exactly one subscriber in "group1"
+
+## Dependencies
+
+- `rmqtt` (features `plugin`, `shared-subscription`)
+- `lru` 0.18 — LRU cache for sticky bindings
+
+## License
+
+MIT OR Apache-2.0

--- a/rmqtt-plugins/rmqtt-shared-subscription/src/config.rs
+++ b/rmqtt-plugins/rmqtt-shared-subscription/src/config.rs
@@ -1,0 +1,61 @@
+//! Configuration types for the Shared Subscription plugin.
+//!
+//! Defines [`PluginConfig`] used to select the subscriber selection
+//! strategy for `$share/{group}/{topic}` subscriptions.
+
+use serde::{Deserialize, Serialize};
+use std::num::NonZeroUsize;
+
+/// Top-level configuration for the Shared Subscription plugin.
+///
+/// Controls which strategy is used when choosing a subscriber from
+/// a shared subscription group.
+///
+/// Supports the following strategies:
+/// - `random` — Random subscriber selection (basic load balancing)
+/// - `round_robin` — Sequential round-robin (default)
+/// - `round_robin_per_group` — Per-node independent round-robin (large cluster)
+/// - `sticky` — Fixed subscriber per publisher (stateful processing)
+/// - `local` — Prefer publisher's node (reduce cross-node traffic)
+/// - `hash_clientid` — Hash by publisher ClientId (per-device ordering)
+/// - `hash_topic` — Hash by topic (topic sharding)
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PluginConfig {
+    /// Shared subscription selection strategy.
+    ///
+    /// Valid values: `random`, `round_robin`, `round_robin_per_group`,
+    /// `sticky`, `local`, `hash_clientid`, `hash_topic`.
+    #[serde(default = "PluginConfig::strategy_default")]
+    pub strategy: Strategy,
+    /// Maximum number of sticky bindings in the LRU cache.
+    ///
+    /// When the cache reaches this limit, the least recently used binding
+    /// is evicted to make room for a new one.
+    #[serde(default = "PluginConfig::sticky_cache_size_default")]
+    pub sticky_cache_size: NonZeroUsize,
+}
+
+impl PluginConfig {
+    /// Default strategy: round_robin
+    fn strategy_default() -> Strategy {
+        Strategy::RoundRobin
+    }
+
+    /// Default sticky cache size: 100,000 entries
+    fn sticky_cache_size_default() -> NonZeroUsize {
+        NonZeroUsize::new(100_000).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Strategy {
+    Random,
+    RoundRobin,
+    RoundRobinPerGroup,
+    Sticky,
+    Local,
+    #[serde(alias = "hash_clientid")]
+    HashClientId,
+    HashTopic,
+}

--- a/rmqtt-plugins/rmqtt-shared-subscription/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-shared-subscription/src/lib.rs
@@ -1,0 +1,195 @@
+//! Shared Subscription Plugin for RMQTT.
+//!
+//! Provides multiple shared subscription selection strategies:
+//!
+//! | Strategy | Description | Use Case |
+//! |---|---|---|
+//! | `random` | Random subscriber selection | Basic load balancing |
+//! | `round_robin` (default) | Sequential round-robin | Equal-capacity consumers |
+//! | `round_robin_per_group` | Per-node independent round-robin | Large cluster deployment |
+//! | `sticky` | Fixed subscriber per publisher | Stateful processing |
+//! | `local` | Prefer publisher's node | Reduce cross-node traffic |
+//! | `hash_clientid` | Hash by publisher ClientId | Per-device message ordering |
+//! | `hash_topic` | Hash by topic | Topic sharding |
+//!
+//! Configure via `rmqtt-shared-subscription.toml`:
+//! ```toml
+//! strategy = "round_robin"
+//! ```
+//!
+#![deny(unsafe_code)]
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lru::LruCache;
+use tokio::sync::{Mutex, RwLock};
+
+use rmqtt::{
+    context::ServerContext,
+    macros::Plugin,
+    plugin::{PackageInfo, Plugin},
+    register,
+    types::SharedGroup,
+    Result,
+};
+
+use config::PluginConfig;
+
+mod config;
+mod strategies;
+
+register!(SharedSubscriptionPlugin::new);
+
+pub(crate) use config::Strategy;
+use strategies::{SharedSubscriptionImpl, StickyMap};
+
+#[derive(Plugin)]
+struct SharedSubscriptionPlugin {
+    scx: ServerContext,
+    cfg: Arc<RwLock<PluginConfig>>,
+    /// Global atomic counter shared with the impl for round_robin.
+    rr_counter: Arc<AtomicUsize>,
+    /// Per-group counters shared with the impl.
+    rr_group_counters: Arc<Mutex<HashMap<SharedGroup, usize>>>,
+    /// Sticky map shared with the impl.
+    sticky_map: StickyMap,
+}
+
+impl SharedSubscriptionPlugin {
+    #[inline]
+    async fn new<N: Into<String>>(scx: ServerContext, name: N) -> Result<Self> {
+        let name = name.into();
+        let cfg = scx.plugins.read_config_default::<PluginConfig>(&name);
+        log::info!("{name} cfg: {cfg:?}");
+        let cfg = Arc::new(RwLock::new(cfg?));
+        let sticky_cache_size = cfg.read().await.sticky_cache_size;
+        Ok(Self {
+            scx,
+            cfg,
+            rr_counter: Arc::new(AtomicUsize::new(0)),
+            rr_group_counters: Arc::new(Mutex::new(HashMap::default())),
+            sticky_map: Arc::new(Mutex::new(LruCache::new(sticky_cache_size))),
+        })
+    }
+}
+
+#[async_trait]
+impl Plugin for SharedSubscriptionPlugin {
+    #[inline]
+    async fn init(&mut self) -> Result<()> {
+        log::info!("{} init", self.name());
+
+        // Load strategy from config
+        let strategy = self.cfg.read().await.strategy;
+
+        // Create and register the implementation with shared state
+        let mut shared_sub = self.scx.extends.shared_subscription_mut().await;
+        *shared_sub = Box::new(SharedSubscriptionImpl::new(
+            strategy,
+            self.rr_counter.clone(),
+            self.rr_group_counters.clone(),
+            self.sticky_map.clone(),
+        ));
+
+        log::info!("Shared subscription handler registered, strategy: {:?}", strategy);
+        Ok(())
+    }
+
+    #[inline]
+    async fn load_config(&mut self) -> Result<()> {
+        let new_cfg = self.scx.plugins.read_config::<PluginConfig>(self.name())?;
+        let strategy = new_cfg.strategy;
+        let sticky_cache_size = new_cfg.sticky_cache_size;
+        *self.cfg.write().await = new_cfg;
+        self.sticky_map = Arc::new(Mutex::new(LruCache::new(sticky_cache_size)));
+        let mut shared_sub = self.scx.extends.shared_subscription_mut().await;
+        *shared_sub = Box::new(SharedSubscriptionImpl::new(
+            strategy,
+            self.rr_counter.clone(),
+            self.rr_group_counters.clone(),
+            self.sticky_map.clone(),
+        ));
+        log::info!("load_config ok, {:?}", self.cfg);
+        Ok(())
+    }
+
+    #[inline]
+    async fn start(&mut self) -> Result<()> {
+        log::info!("{} start", self.name());
+        Ok(())
+    }
+
+    #[inline]
+    async fn stop(&mut self) -> Result<bool> {
+        log::info!("{} stop, resetting to default handler", self.name());
+        let mut shared_sub = self.scx.extends.shared_subscription_mut().await;
+        *shared_sub = Box::new(rmqtt::subscribe::DefaultSharedSubscription);
+        Ok(true)
+    }
+
+    #[inline]
+    async fn attrs(&self) -> serde_json::Value {
+        let strategy = self.cfg.read().await.strategy;
+        let rr_counter = self.rr_counter.load(Ordering::Relaxed);
+
+        let (rr_group_count, rr_group_truncated, rr_group_details) = {
+            let map = self.rr_group_counters.lock().await;
+            let count = map.len();
+            let details: Vec<_> = map
+                .iter()
+                .take(1000)
+                .map(|(group, count)| {
+                    serde_json::json!({
+                        "group": group,
+                        "counter": count,
+                    })
+                })
+                .collect();
+            (count, count > 1000, details)
+        };
+
+        let (sticky_count, sticky_truncated, sticky_details) = {
+            let map = self.sticky_map.lock().await;
+            let count = map.len();
+            let details: Vec<_> = map
+                .iter()
+                .take(1000)
+                .map(|((group, publisher_cid), subscriber_cid)| {
+                    serde_json::json!({
+                        "group": group,
+                        "publisher_client_id": publisher_cid,
+                        "subscriber_client_id": subscriber_cid,
+                    })
+                })
+                .collect();
+            (count, count > 1000, details)
+        };
+
+        use serde_json::map::Map;
+
+        let mut obj = Map::new();
+        obj.insert("strategy".into(), serde_json::json!(format!("{:?}", strategy)));
+
+        if matches!(strategy, Strategy::RoundRobin) {
+            obj.insert("rr_counter".into(), serde_json::json!(rr_counter));
+        }
+
+        if matches!(strategy, Strategy::RoundRobinPerGroup) {
+            obj.insert("rr_group_count".into(), serde_json::json!(rr_group_count));
+            obj.insert("rr_group_truncated".into(), serde_json::json!(rr_group_truncated));
+            obj.insert("rr_group_details".into(), serde_json::json!(rr_group_details));
+        }
+
+        if strategy == Strategy::Sticky {
+            obj.insert("sticky_binding_count".into(), serde_json::json!(sticky_count));
+            obj.insert("sticky_binding_truncated".into(), serde_json::json!(sticky_truncated));
+            obj.insert("sticky_binding_details".into(), serde_json::json!(sticky_details));
+        }
+
+        serde_json::Value::Object(obj)
+    }
+}

--- a/rmqtt-plugins/rmqtt-shared-subscription/src/strategies.rs
+++ b/rmqtt-plugins/rmqtt-shared-subscription/src/strategies.rs
@@ -1,0 +1,373 @@
+//! Shared subscription selection strategy implementations.
+//!
+//! Provides the concrete [`SharedSubscriptionImpl`] with multiple strategies:
+//! random, round-robin, per-group round-robin, sticky, local,
+//! hash-by-client-id, and hash-by-topic.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lru::LruCache;
+use tokio::sync::Mutex;
+
+use rmqtt::{context::ServerContext, subscribe::SharedSubscription, types::*};
+
+use super::Strategy;
+
+/// Sticky binding: (shared_group, publisher_client_id) -> subscriber_client_id.
+/// Uses an LRU cache so stale bindings are automatically evicted.
+pub(crate) type StickyMap = Arc<Mutex<LruCache<(SharedGroup, ClientId), ClientId>>>;
+
+/// A concrete implementation of [`SharedSubscription`] that dispatches
+/// subscriber selection to the configured strategy.
+pub(crate) struct SharedSubscriptionImpl {
+    /// Which strategy to use for subscriber selection.
+    strategy: Strategy,
+    /// Global atomic counter for round_robin.
+    pub(crate) rr_counter: Arc<AtomicUsize>,
+    /// Per-group counters for round_robin_per_group.
+    pub(crate) rr_group_counters: Arc<Mutex<HashMap<SharedGroup, usize>>>,
+    /// Sticky bindings: (shared_group_name, publisher_client_id) -> (sub_idx, subscriber_client_id).
+    pub(crate) sticky_map: StickyMap,
+}
+
+impl SharedSubscriptionImpl {
+    /// Creates a new instance with shared internal state.
+    pub(crate) fn new(
+        strategy: Strategy,
+        rr_counter: Arc<AtomicUsize>,
+        rr_group_counters: Arc<Mutex<HashMap<SharedGroup, usize>>>,
+        sticky_map: StickyMap,
+    ) -> Self {
+        Self { strategy, rr_counter, rr_group_counters, sticky_map }
+    }
+}
+
+#[async_trait]
+impl SharedSubscription for SharedSubscriptionImpl {
+    #[inline]
+    fn is_supported(&self, _listen_cfg: &rmqtt::types::ListenerConfig) -> bool {
+        true
+    }
+
+    #[inline]
+    async fn choice(
+        &self,
+        scx: &ServerContext,
+        group: &SharedGroup,
+        publisher_id: &Id,
+        topic: &TopicName,
+        ncs: &[(
+            NodeId,
+            ClientId,
+            SubscriptionOptions,
+            Option<Vec<SubscriptionIdentifier>>,
+            Option<IsOnline>,
+        )],
+    ) -> Option<(usize, IsOnline)> {
+        if ncs.is_empty() {
+            return None;
+        }
+
+        match self.strategy {
+            Strategy::Random => self.choice_random(scx, publisher_id, ncs).await,
+            Strategy::RoundRobin => self.choice_round_robin(scx, publisher_id, ncs).await,
+            Strategy::RoundRobinPerGroup => {
+                self.choice_round_robin_per_group(scx, publisher_id, group, ncs).await
+            }
+            Strategy::Sticky => self.choice_sticky(scx, group, publisher_id, ncs).await,
+            Strategy::Local => self.choice_local(scx, publisher_id, ncs).await,
+            Strategy::HashClientId => self.choice_hash_clientid(scx, publisher_id, ncs).await,
+            Strategy::HashTopic => self.choice_hash_topic(scx, publisher_id, topic, ncs).await,
+        }
+    }
+}
+
+/// The subscriber list type alias used across all choice methods.
+type Subscribers<'a> =
+    &'a [(NodeId, ClientId, SubscriptionOptions, Option<Vec<SubscriptionIdentifier>>, Option<IsOnline>)];
+
+impl SharedSubscriptionImpl {
+    /// When no online subscribers are found, prefer a subscriber on the same node
+    /// as the publisher to minimize cross-node forwarding.
+    fn find_local_fallback(publisher_id: &Id, ncs: Subscribers<'_>) -> Option<(usize, bool)> {
+        let pub_node = publisher_id.node_id;
+        // First pass: prefer local node subscriber
+        for (idx, (node_id, _, _, _, _)) in ncs.iter().enumerate() {
+            if *node_id == pub_node {
+                return Some((idx, false));
+            }
+        }
+        // Fallback: first subscriber
+        if !ncs.is_empty() {
+            return Some((0, false));
+        }
+        None
+    }
+
+    /// Random selection
+    async fn choice_random(
+        &self,
+        scx: &ServerContext,
+        publisher_id: &Id,
+        ncs: Subscribers<'_>,
+    ) -> Option<(usize, IsOnline)> {
+        let mut tmp_ncs: Vec<(usize, NodeId, &ClientId, &Option<IsOnline>)> = ncs
+            .iter()
+            .enumerate()
+            .map(|(idx, (node_id, client_id, _, _, is_online))| (idx, *node_id, client_id, is_online))
+            .collect();
+
+        while !tmp_ncs.is_empty() {
+            let r_idx = if tmp_ncs.len() == 1 { 0 } else { (rand::random::<u64>() as usize) % tmp_ncs.len() };
+            let (idx, node_id, client_id, is_online) = tmp_ncs.remove(r_idx);
+            let is_online = if let Some(is_online) = is_online {
+                *is_online
+            } else {
+                scx.extends.router().await.is_online(node_id, client_id).await
+            };
+            if is_online {
+                return Some((idx, true));
+            }
+        }
+
+        // No online subscriber: prefer local node, otherwise first
+        Self::find_local_fallback(publisher_id, ncs)
+    }
+
+    /// Round-robin selection using global atomic counter
+    async fn choice_round_robin(
+        &self,
+        scx: &ServerContext,
+        publisher_id: &Id,
+        ncs: Subscribers<'_>,
+    ) -> Option<(usize, IsOnline)> {
+        let len = ncs.len();
+        let counter = self.rr_counter.fetch_add(1, Ordering::Relaxed);
+        let start_idx = counter % len;
+
+        for offset in 0..len {
+            let idx = (start_idx + offset) % len;
+            let (node_id, client_id, _, _, is_online) = &ncs[idx];
+            let is_online = if let Some(is_online) = is_online {
+                *is_online
+            } else {
+                scx.extends.router().await.is_online(*node_id, client_id).await
+            };
+            if is_online {
+                return Some((idx, true));
+            }
+        }
+
+        // No online subscriber: prefer local node, otherwise first
+        Self::find_local_fallback(publisher_id, ncs)
+    }
+
+    /// Per-group round-robin selection
+    async fn choice_round_robin_per_group(
+        &self,
+        scx: &ServerContext,
+        publisher_id: &Id,
+        group: &SharedGroup,
+        ncs: Subscribers<'_>,
+    ) -> Option<(usize, IsOnline)> {
+        let group_key = group.clone();
+        let len = ncs.len();
+
+        let mut counters = self.rr_group_counters.lock().await;
+        let counter = counters.entry(group_key).or_insert(0);
+        let start_idx = *counter % len;
+        *counter = counter.wrapping_add(1);
+
+        for offset in 0..len {
+            let idx = (start_idx + offset) % len;
+            let (node_id, client_id, _, _, is_online) = &ncs[idx];
+            let is_online = if let Some(is_online) = is_online {
+                *is_online
+            } else {
+                scx.extends.router().await.is_online(*node_id, client_id).await
+            };
+            if is_online {
+                return Some((idx, true));
+            }
+        }
+
+        // No online subscriber: prefer local node, otherwise first
+        Self::find_local_fallback(publisher_id, ncs)
+    }
+
+    /// Sticky: once a subscriber is chosen for a (group, publisher), keep using it
+    async fn choice_sticky(
+        &self,
+        scx: &ServerContext,
+        group: &SharedGroup,
+        publisher_id: &Id,
+        ncs: Subscribers<'_>,
+    ) -> Option<(usize, IsOnline)> {
+        let pub_client_id = publisher_id.client_id.clone();
+        let group_name = group.clone();
+        let key = (group_name, pub_client_id);
+
+        let mut map = self.sticky_map.lock().await;
+
+        // Check if we have a sticky binding
+        if let Some(sticky_cid) = map.get(&key) {
+            // Find the subscriber by client_id (it may have moved index)
+            for (idx, (node_id, client_id, _, _, is_online)) in ncs.iter().enumerate() {
+                if client_id == sticky_cid {
+                    let is_online = if let Some(is_online) = is_online {
+                        *is_online
+                    } else {
+                        scx.extends.router().await.is_online(*node_id, client_id).await
+                    };
+                    if is_online {
+                        return Some((idx, true));
+                    }
+                    // Sticky subscriber went offline - remove binding
+                    map.pop(&key);
+                    break;
+                }
+            }
+        }
+
+        // No valid sticky binding: select a new subscriber
+        // Choose first online subscriber
+        for (idx, (node_id, client_id, _, _, is_online)) in ncs.iter().enumerate() {
+            let is_online = if let Some(is_online) = is_online {
+                *is_online
+            } else {
+                scx.extends.router().await.is_online(*node_id, client_id).await
+            };
+            if is_online {
+                // Create new sticky binding
+                map.put(key, client_id.clone());
+                return Some((idx, true));
+            }
+        }
+
+        // No online subscriber: prefer local node, otherwise first
+        if let Some((idx, _)) = Self::find_local_fallback(publisher_id, ncs) {
+            map.put(key, ncs[idx].1.clone());
+            return Some((idx, false));
+        }
+        None
+    }
+
+    /// Local: prefer subscribers on the same node as the publisher
+    async fn choice_local(
+        &self,
+        scx: &ServerContext,
+        publisher_id: &Id,
+        ncs: Subscribers<'_>,
+    ) -> Option<(usize, IsOnline)> {
+        let pub_node = publisher_id.node_id;
+
+        // First pass: prefer online subscribers on the publisher's node
+        for (idx, (node_id, client_id, _, _, is_online)) in ncs.iter().enumerate() {
+            if *node_id == pub_node {
+                let is_online = if let Some(is_online) = is_online {
+                    *is_online
+                } else {
+                    scx.extends.router().await.is_online(*node_id, client_id).await
+                };
+                if is_online {
+                    return Some((idx, true));
+                }
+            }
+        }
+
+        // Second pass: any online subscriber (cross-node)
+        for (idx, (node_id, client_id, _, _, is_online)) in ncs.iter().enumerate() {
+            let is_online = if let Some(is_online) = is_online {
+                *is_online
+            } else {
+                scx.extends.router().await.is_online(*node_id, client_id).await
+            };
+            if is_online {
+                return Some((idx, true));
+            }
+        }
+
+        // Third pass: local subscriber even if offline
+        for (idx, (node_id, _, _, _, _)) in ncs.iter().enumerate() {
+            if *node_id == pub_node {
+                return Some((idx, false));
+            }
+        }
+
+        // Last resort: cross-node, possibly offline
+        if !ncs.is_empty() {
+            return Some((0, false));
+        }
+        None
+    }
+
+    /// Hash by publisher's ClientId
+    async fn choice_hash_clientid(
+        &self,
+        scx: &ServerContext,
+        publisher_id: &Id,
+        ncs: Subscribers<'_>,
+    ) -> Option<(usize, IsOnline)> {
+        use std::hash::{Hash, Hasher};
+
+        if ncs.is_empty() {
+            return None;
+        }
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        publisher_id.client_id.hash(&mut hasher);
+        let hash = hasher.finish();
+        let idx = (hash as usize) % ncs.len();
+
+        let (node_id, client_id, _, _, is_online) = &ncs[idx];
+        let is_online = if let Some(is_online) = is_online {
+            *is_online
+        } else {
+            scx.extends.router().await.is_online(*node_id, client_id).await
+        };
+
+        if is_online {
+            return Some((idx, true));
+        }
+
+        // Hash-chosen subscriber offline: fallback to random online
+        self.choice_random(scx, publisher_id, ncs).await
+    }
+
+    /// Hash by topic name
+    async fn choice_hash_topic(
+        &self,
+        scx: &ServerContext,
+        publisher_id: &Id,
+        topic: &TopicName,
+        ncs: Subscribers<'_>,
+    ) -> Option<(usize, IsOnline)> {
+        use std::hash::{Hash, Hasher};
+
+        if ncs.is_empty() {
+            return None;
+        }
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        topic.hash(&mut hasher);
+        let hash = hasher.finish();
+        let idx = (hash as usize) % ncs.len();
+
+        let (node_id, client_id, _, _, is_online) = &ncs[idx];
+        let is_online = if let Some(is_online) = is_online {
+            *is_online
+        } else {
+            scx.extends.router().await.is_online(*node_id, client_id).await
+        };
+
+        if is_online {
+            return Some((idx, true));
+        }
+
+        // Hash-chosen subscriber offline: fallback to random online
+        self.choice_random(scx, publisher_id, ncs).await
+    }
+}

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -91,6 +91,7 @@ plugins.default_startups = [
     #"rmqtt-bridge-origin",
     #"rmqtt-web-hook",
     #"rmqtt-p2p-messaging",
+    "rmqtt-shared-subscription",
     "rmqtt-http-api"
 ]
 
@@ -186,8 +187,6 @@ listener.tcp.external.message_expiry_interval = "5m"
 #The maximum number of topics that a single client is allowed to subscribe to
 #0 means unlimited, default value: 0
 listener.tcp.external.max_subscriptions = 0
-#Shared subscription switch, default value: true
-listener.tcp.external.shared_subscription = true
 #topic alias maximum, default value: 0, topic aliases not enabled. (MQTT 5.0)
 listener.tcp.external.max_topic_aliases = 32
 #Limit subscription switch, default value: false
@@ -225,7 +224,6 @@ listener.tcp.internal.max_session_expiry_interval = "0h"
 listener.tcp.internal.message_retry_interval = "30s"
 listener.tcp.internal.message_expiry_interval = "5m"
 listener.tcp.internal.max_subscriptions = 0
-listener.tcp.internal.shared_subscription = true
 listener.tcp.internal.max_topic_aliases = 0
 listener.tcp.internal.limit_subscription = false
 

--- a/rmqtt/src/router.rs
+++ b/rmqtt/src/router.rs
@@ -236,8 +236,13 @@ impl DefaultRouter {
             for (group, mut s_subs) in groups.drain() {
                 log::debug!("group: {group}, s_subs: {s_subs:?}");
                 let group_cids = s_subs.iter().map(|(_, cid, _, _, _)| cid.clone()).collect();
-                if let Some((idx, is_online)) =
-                    self.context().extends.shared_subscription().await.choice(self.context(), &s_subs).await
+                if let Some((idx, is_online)) = self
+                    .context()
+                    .extends
+                    .shared_subscription()
+                    .await
+                    .choice(self.context(), &group, &this_id, topic_name, &s_subs)
+                    .await
                 {
                     let (node_id, client_id, opts, _, _) = s_subs.remove(idx);
                     collector_map.entry(node_id).or_default().add(

--- a/rmqtt/src/subscribe.rs
+++ b/rmqtt/src/subscribe.rs
@@ -46,32 +46,44 @@
 //! The architecture balances protocol compliance (MQTT 5.0 spec) with practical performance
 //! requirements, leveraging Rust's type system for safe concurrent operations.
 
+#[cfg(any(feature = "shared-subscription", feature = "auto-subscription"))]
 use async_trait::async_trait;
 
 #[cfg(feature = "shared-subscription")]
 use crate::context::ServerContext;
+#[cfg(any(feature = "shared-subscription", feature = "auto-subscription"))]
 use crate::types::*;
 
 /// Defines the shared subscription selection strategy for a cluster node.
 ///
 /// Implementations control how subscribers within a shared subscription group
 /// (`$share/{group}/{topic}`) are selected. The default implementation uses
-/// a random selection strategy with online status filtering.
+/// a round-robin selection strategy with online status filtering.
+///
+/// # Context Parameters
+///
+/// The `choice` method provides the following context for strategy decisions:
+/// - `group`: the shared subscription group name (e.g. `"group1"` in `$share/group1/topic`)
+/// - `publisher_id`: the publishing client's identity (contains `node_id` and `client_id`)
+/// - `topic`: the published topic name used for topic-based hashing
 #[cfg(feature = "shared-subscription")]
 #[async_trait]
 pub trait SharedSubscription: Sync + Send {
     ///Whether shared subscriptions are supported
     #[inline]
-    fn is_supported(&self, listen_cfg: &ListenerConfig) -> bool {
-        listen_cfg.shared_subscription
+    fn is_supported(&self, _listen_cfg: &ListenerConfig) -> bool {
+        false
     }
 
-    ///Shared subscription strategy, select a subscriber, default is "random"
-    #[inline]
+    ///Selects a subscriber from the shared subscription group.
+    ///Returns `Some((index, is_online))` or `None` if no subscriber is available.
     async fn choice(
         &self,
-        scx: &ServerContext,
-        ncs: &[(
+        _scx: &ServerContext,
+        _group: &SharedGroup,
+        _publisher_id: &Id,
+        _topic: &TopicName,
+        _ncs: &[(
             NodeId,
             ClientId,
             SubscriptionOptions,
@@ -79,40 +91,14 @@ pub trait SharedSubscription: Sync + Send {
             Option<IsOnline>,
         )],
     ) -> Option<(usize, IsOnline)> {
-        if ncs.is_empty() {
-            return None;
-        }
-
-        let mut tmp_ncs = ncs
-            .iter()
-            .enumerate()
-            .map(|(idx, (node_id, client_id, _, _, is_online))| (idx, node_id, client_id, is_online))
-            .collect::<Vec<_>>();
-
-        while !tmp_ncs.is_empty() {
-            let r_idx = if tmp_ncs.len() == 1 { 0 } else { (rand::random::<u64>() as usize) % tmp_ncs.len() };
-
-            let (idx, node_id, client_id, is_online) = tmp_ncs.remove(r_idx);
-
-            let is_online = if let Some(is_online) = is_online {
-                *is_online
-            } else {
-                scx.extends.router().await.is_online(*node_id, client_id).await
-            };
-
-            if is_online {
-                return Some((idx, true));
-            }
-
-            if tmp_ncs.is_empty() {
-                return Some((idx, is_online));
-            }
-        }
-        return None;
+        None
     }
 }
 
-/// Default shared subscription implementation using random subscriber selection.
+/// Default shared subscription implementation using round-robin selection.
+///
+/// Note: This is a best-effort single-node round-robin. For true round-robin
+/// across cluster nodes, use the `rmqtt-shared-subscription` plugin.
 #[cfg(feature = "shared-subscription")]
 pub struct DefaultSharedSubscription;
 

--- a/rmqtt/src/types.rs
+++ b/rmqtt/src/types.rs
@@ -549,6 +549,7 @@ pub fn parse_topic_filter(
     let (topic, shared_group, limit_subs) = if shared_subscription || limit_subscription {
         let levels = topic_filter.splitn(3, '/').collect::<Vec<_>>();
         match (levels.first(), levels.get(1), levels.get(2)) {
+            #[cfg(feature = "shared-subscription")]
             (Some(&"$share"), group, tf) => match (shared_subscription, group, tf) {
                 (true, Some(group), Some(tf)) => {
                     let tf = TopicFilter::from(*tf);
@@ -561,6 +562,10 @@ pub fn parse_topic_filter(
                     return Err(anyhow!(format!("Shared subscription is not enabled, {:?}", topic_filter)));
                 }
             },
+            #[cfg(not(feature = "shared-subscription"))]
+            (Some(&"$share"), _, _) => {
+                return Err(anyhow!(format!("Shared subscription is not enabled, {:?}", topic_filter)));
+            }
             (Some(&"$limit"), limit, tf) => match (limit_subscription, limit, tf) {
                 (true, Some(limit), Some(tf)) => {
                     let tf = TopicFilter::from(*tf);
@@ -684,12 +689,14 @@ impl SubscriptionOptions {
     }
 
     #[inline]
-    #[cfg(feature = "shared-subscription")]
     pub fn has_shared_group(&self) -> bool {
+        #[cfg(feature = "shared-subscription")]
         match self {
             SubscriptionOptions::V3(opts) => opts.shared_group.is_some(),
             SubscriptionOptions::V5(opts) => opts.shared_group.is_some(),
         }
+        #[cfg(not(feature = "shared-subscription"))]
+        false
     }
 
     #[inline]
@@ -777,7 +784,7 @@ impl SubOptionsV3 {
         let mut obj = json!({
             "qos": self.qos.value(),
         });
-        #[cfg(any(feature = "limit-subscription", feature = "shared-subscription"))]
+        #[cfg(any(feature = "shared-subscription", feature = "limit-subscription"))]
         if let Some(obj) = obj.as_object_mut() {
             #[cfg(feature = "shared-subscription")]
             if let Some(g) = &self.shared_group {
@@ -1073,6 +1080,7 @@ impl ConnectAckReason {
 #[derive(Clone, Debug)]
 pub struct Unsubscribe {
     pub topic_filter: TopicFilter,
+    #[cfg(feature = "shared-subscription")]
     pub shared_group: Option<SharedGroup>,
 }
 
@@ -1083,14 +1091,25 @@ impl Unsubscribe {
         shared_subscription: bool,
         limit_subscription: bool,
     ) -> Result<Self> {
-        let (topic_filter, shared_group, _) =
+        let (topic_filter, _shared_group, _) =
             parse_topic_filter(topic_filter, shared_subscription, limit_subscription)?;
-        Ok(Unsubscribe { topic_filter, shared_group })
+        Ok(Unsubscribe {
+            topic_filter,
+            #[cfg(feature = "shared-subscription")]
+            shared_group: _shared_group,
+        })
     }
 
     #[inline]
     pub fn is_shared(&self) -> bool {
-        self.shared_group.is_some()
+        #[cfg(feature = "shared-subscription")]
+        {
+            self.shared_group.is_some()
+        }
+        #[cfg(not(feature = "shared-subscription"))]
+        {
+            false
+        }
     }
 }
 
@@ -1998,6 +2017,7 @@ pub struct SubsSearchParams {
     pub topic: Option<String>,
     //value is 0,1,2
     pub qos: Option<u8>,
+    #[cfg(feature = "shared-subscription")]
     pub share: Option<SharedGroup>,
     pub _match_topic: Option<String>,
 }


### PR DESCRIPTION
This commit systematically restructures the rmqtt-shared-subscription plugin and the shared subscription mechanism:

### Plugin refactoring
- Add config.rs with PluginConfig (strategy + sticky_cache_size)
- Add strategies.rs implementing 7 subscriber selection strategies: random / round_robin / round_robin_per_group / sticky / local / hash_clientid / hash_topic
- Replace HashMap with LruCache (lru = "0.18") for StickyMap, with configurable capacity (default 100000) and automatic LRU eviction, eliminating memory leaks
- Share Arc-wrapped runtime state between Plugin and Impl; attrs() selectively exposes metrics based on the active strategy
- Remove unused usize from StickyMap value type
- Fix HashClientId deserialization caused by serde rename_all

### Configuration chain cleanup (4 layers fully removed)
- rmqtt-conf: Remove ListenerInner.shared_subscription field
- rmqtt-net: Remove Builder.shared_subscription field and builder method
- rmqtt-bin: Remove .shared_subscription() call chain in server.rs
- rmqtt.toml: Remove all shared_subscription = true entries from listeners

### Core trait simplification
- Make SharedSubscription::choice() an abstract method (remove ~50 lines of default impl)
- DefaultSharedSubscription::is_supported() returns false (no plugin = no shared subs)
- SharedSubscriptionImpl::is_supported() returns true (plugin loaded = all listeners)
- Shared subscription availability is now determined solely by plugin presence, no longer requiring per-listener configuration

### Documentation
- Add plugin-level README.md / README-CN.md
- Add docs/en_US/shared-subscription.md and docs/zh_CN/shared-subscription.md
- Update docs/README indices
- Update rmqtt-conf, rmqtt-net, benchmark-testing and other related docs