### PR TITLE
refactor: replace String keys with ByteString in ExtraAttrs and bridge-origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4962,6 +4962,7 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytestring",
  "log",
  "rmqtt",
  "serde",

--- a/rmqtt-plugins/rmqtt-bridge-origin/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-bridge-origin/Cargo.toml
@@ -15,3 +15,4 @@ log.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true
+bytestring.workspace = true

--- a/rmqtt-plugins/rmqtt-bridge-origin/src/config.rs
+++ b/rmqtt-plugins/rmqtt-bridge-origin/src/config.rs
@@ -3,6 +3,7 @@
 //! Defines markers used to identify ingress/egress bridge connections
 //! in session metadata, and the attribute key for storing origin info.
 
+use bytestring::ByteString;
 use serde::{Deserialize, Serialize};
 
 use rmqtt::Result;
@@ -18,13 +19,13 @@ pub struct PluginConfig {
 
     /// Key used to store BridgeOrigin in session.extra_attrs.
     #[serde(default = "default_attr_key")]
-    pub attr_key: String,
+    pub attr_key: ByteString,
 }
 
 impl PluginConfig {
     /// Creates a new `PluginConfig` with the given marker and key values.
     #[allow(dead_code)]
-    pub fn new(ingress_marker: String, egress_marker: String, attr_key: String) -> Self {
+    pub fn new(ingress_marker: String, egress_marker: String, attr_key: ByteString) -> Self {
         Self { ingress_marker, egress_marker, attr_key }
     }
 
@@ -42,7 +43,7 @@ fn default_egress_marker() -> String {
     ":egress:".into()
 }
 
-fn default_attr_key() -> String {
+fn default_attr_key() -> ByteString {
     "bridge_origin".into()
 }
 

--- a/rmqtt-plugins/rmqtt-bridge-origin/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-bridge-origin/src/lib.rs
@@ -143,9 +143,11 @@ impl Handler for BridgeOriginHandler {
                 };
 
                 if let Some(direction) = direction {
-                    let extra_attrs = session.extra_attrs.clone();
-                    let key = cfg.attr_key.clone();
-                    extra_attrs.write().await.insert::<BridgeOrigin>(key, BridgeOrigin { direction });
+                    session
+                        .extra_attrs
+                        .write()
+                        .await
+                        .insert::<BridgeOrigin>(cfg.attr_key.clone(), BridgeOrigin { direction });
                 }
             }
             _ => {

--- a/rmqtt/src/types.rs
+++ b/rmqtt/src/types.rs
@@ -2229,88 +2229,8 @@ impl SessionSubs {
     }
 }
 
-// pub struct ExtraData<K, T> {
-//     attrs: Arc<parking_lot::RwLock<HashMap<K, T>>>,
-// }
-//
-// impl<K, T> Deref for ExtraData<K, T> {
-//     type Target = Arc<parking_lot::RwLock<HashMap<K, T>>>;
-//     #[inline]
-//     fn deref(&self) -> &Self::Target {
-//         &self.attrs
-//     }
-// }
-//
-// impl<K, T> Serialize for ExtraData<K, T>
-// where
-//     K: serde::Serialize,
-//     T: serde::Serialize,
-// {
-//     #[inline]
-//     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-//     where
-//         S: Serializer,
-//     {
-//         self.attrs.read().deref().serialize(serializer)
-//     }
-// }
-//
-// impl<'de, K, T> Deserialize<'de> for ExtraData<K, T>
-// where
-//     K: Eq + Hash,
-//     K: serde::de::DeserializeOwned,
-//     T: serde::de::DeserializeOwned,
-// {
-//     #[inline]
-//     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-//     where
-//         D: Deserializer<'de>,
-//     {
-//         let v = HashMap::deserialize(deserializer)?;
-//         Ok(Self { attrs: Arc::new(parking_lot::RwLock::new(v)) })
-//     }
-// }
-//
-// impl<K, T> Default for ExtraData<K, T>
-// where
-//     K: Eq + Hash,
-// {
-//     fn default() -> Self {
-//         Self::new()
-//     }
-// }
-// impl<K, T> ExtraData<K, T>
-// where
-//     K: Eq + Hash,
-// {
-//     #[inline]
-//     pub fn new() -> Self {
-//         Self { attrs: Arc::new(parking_lot::RwLock::new(HashMap::default())) }
-//     }
-//
-//     #[inline]
-//     pub fn len(&self) -> usize {
-//         self.attrs.read().len()
-//     }
-//
-//     #[inline]
-//     pub fn is_empty(&self) -> bool {
-//         self.attrs.read().is_empty()
-//     }
-//
-//     #[inline]
-//     pub fn clear(&self) {
-//         self.attrs.write().clear()
-//     }
-//
-//     #[inline]
-//     pub fn insert(&self, key: K, value: T) {
-//         self.attrs.write().insert(key, value);
-//     }
-// }
-//
 pub struct ExtraAttrs {
-    attrs: HashMap<String, Box<dyn Any + Sync + Send>>,
+    attrs: HashMap<ByteString, Box<dyn Any + Sync + Send>>,
 }
 
 impl Default for ExtraAttrs {
@@ -2341,7 +2261,7 @@ impl ExtraAttrs {
     }
 
     #[inline]
-    pub fn insert<T: Any + Sync + Send>(&mut self, key: String, value: T) {
+    pub fn insert<T: Any + Sync + Send>(&mut self, key: ByteString, value: T) {
         self.attrs.insert(key, Box::new(value));
     }
 
@@ -2358,7 +2278,7 @@ impl ExtraAttrs {
     #[inline]
     pub fn get_default_mut<T: Any + Sync + Send, F: Fn() -> T>(
         &mut self,
-        key: String,
+        key: ByteString,
         def_fn: F,
     ) -> Option<&mut T> {
         self.attrs.entry(key).or_insert_with(|| Box::new(def_fn())).downcast_mut::<T>()


### PR DESCRIPTION
**Motivation**
- `ByteString` is more efficient for string keys (reference-counted, cheap clone)
- Reduces memory overhead and clone costs for frequently accessed extra attributes
- Better alignment with MQTT topic and client ID handling patterns

**Changes**
- `ExtraAttrs`: Change key type from `String` to `ByteString`
- Update `insert()`, `get()`, `get_mut()`, `get_default_mut()` signatures accordingly
- `bridge-origin`: Change `attr_key` config field from `String` to `ByteString`
- Update `default_attr_key()` return type and `new()` constructor
- Add missing `bytestring` dependency to bridge-origin
- Simplify bridge-origin handler code (remove intermediate variables, direct chaining)
- Remove commented-out `ExtraData` struct (dead code cleanup)

**Benefits**
- More efficient key storage and comparison
- Better integration with existing MQTT codec types
- Reduced string allocations