### PR TITLE
feat(codec): enhance size limit errors with contextual information

### DIFF
--- a/rmqtt-codec/src/error.rs
+++ b/rmqtt-codec/src/error.rs
@@ -81,8 +81,8 @@ pub enum DecodeError {
     // MQTT v3 only
     #[error("Packet id is required")]
     PacketIdRequired,
-    #[error("Max size exceeded")]
-    MaxSizeExceeded,
+    #[error("Max size exceeded: size={size}, max={max}")]
+    MaxSizeExceeded { size: u32, max: u32 },
     #[error("utf8 error")]
     Utf8Error,
     #[error("io error, {:?}", _0)]
@@ -107,7 +107,7 @@ impl ToReasonCode for DecodeError {
             DecodeError::InvalidClientId => DisconnectReasonCode::NotAuthorized,
             DecodeError::UnsupportedPacketType => DisconnectReasonCode::ImplementationSpecificError,
             DecodeError::PacketIdRequired => DisconnectReasonCode::ProtocolError,
-            DecodeError::MaxSizeExceeded => DisconnectReasonCode::PacketTooLarge,
+            DecodeError::MaxSizeExceeded { .. } => DisconnectReasonCode::PacketTooLarge,
             DecodeError::Utf8Error => DisconnectReasonCode::PayloadFormatInvalid,
             DecodeError::Io(_) => DisconnectReasonCode::UnspecifiedError,
         }
@@ -117,8 +117,8 @@ impl ToReasonCode for DecodeError {
 /// Errors that occur when encoding/serializing MQTT packets to a byte stream
 #[derive(Deserialize, Serialize, Debug, Clone, thiserror::Error)]
 pub enum EncodeError {
-    #[error("Packet is bigger than peer's Maximum Packet Size")]
-    OverMaxPacketSize,
+    #[error("Packet is bigger than peer's Maximum Packet Size: size={size}, max={max}")]
+    OverMaxPacketSize { size: u32, max: u32 },
     #[error("Invalid length")]
     InvalidLength,
     #[error("Malformed packet")]
@@ -140,7 +140,7 @@ impl From<io::Error> for EncodeError {
 impl ToReasonCode for EncodeError {
     fn to_reason_code(&self) -> DisconnectReasonCode {
         match self {
-            EncodeError::OverMaxPacketSize => DisconnectReasonCode::PacketTooLarge,
+            EncodeError::OverMaxPacketSize { .. } => DisconnectReasonCode::PacketTooLarge,
             EncodeError::InvalidLength => DisconnectReasonCode::MalformedPacket,
             EncodeError::MalformedPacket => DisconnectReasonCode::MalformedPacket,
             EncodeError::PacketIdRequired => DisconnectReasonCode::ProtocolError,

--- a/rmqtt-codec/src/v3/codec.rs
+++ b/rmqtt-codec/src/v3/codec.rs
@@ -66,7 +66,10 @@ impl Decoder for Codec {
                             // check max message size
                             let max_size = self.max_size.get();
                             if max_size != 0 && max_size < remaining_length {
-                                return Err(DecodeError::MaxSizeExceeded);
+                                return Err(DecodeError::MaxSizeExceeded {
+                                    size: remaining_length,
+                                    max: max_size,
+                                });
                             }
                             src.advance(consumed + 1);
                             self.state.set(DecodeState::Frame(FixedHeader { first_byte, remaining_length }));
@@ -131,7 +134,10 @@ mod tests {
 
         let mut buf = BytesMut::new();
         buf.extend_from_slice(b"\0\x09");
-        assert_eq!(codec.decode(&mut buf).map_err(|e| matches!(e, DecodeError::MaxSizeExceeded)), Err(true));
+        assert_eq!(
+            codec.decode(&mut buf).map_err(|e| matches!(e, DecodeError::MaxSizeExceeded { .. })),
+            Err(true)
+        );
     }
 
     #[test]

--- a/rmqtt-codec/src/v5/codec.rs
+++ b/rmqtt-codec/src/v5/codec.rs
@@ -142,7 +142,10 @@ impl Decoder for Codec {
                                 log::debug!(
                                     "MaxSizeExceeded max-size: {max_in_size}, remaining: {remaining_length}"
                                 );
-                                return Err(DecodeError::MaxSizeExceeded);
+                                return Err(DecodeError::MaxSizeExceeded {
+                                    size: remaining_length,
+                                    max: max_in_size,
+                                });
                             }
                             src.advance(consumed + 1);
                             self.state.set(DecodeState::Frame(FixedHeader { first_byte, remaining_length }));
@@ -222,7 +225,7 @@ impl Encoder<Packet> for Codec {
         let max_size = if max_out_size != 0 { max_out_size } else { MAX_PACKET_SIZE };
         let content_size = item.encoded_size(max_size);
         if content_size > max_size as usize {
-            return Err(EncodeError::OverMaxPacketSize);
+            return Err(EncodeError::OverMaxPacketSize { size: content_size as u32, max: max_size });
         }
         dst.reserve(content_size + 5);
         item.encode(dst, content_size as u32)?; // safe: max_size <= u32 max value
@@ -239,6 +242,9 @@ mod tests {
         let mut codec = Codec::new(5, 5);
         let mut buf = BytesMut::new();
         buf.extend_from_slice(b"\0\x09");
-        assert_eq!(codec.decode(&mut buf).map_err(|e| matches!(e, DecodeError::MaxSizeExceeded)), Err(true));
+        assert_eq!(
+            codec.decode(&mut buf).map_err(|e| matches!(e, DecodeError::MaxSizeExceeded { .. })),
+            Err(true)
+        );
     }
 }


### PR DESCRIPTION
- Add size and max fields to `DecodeError::MaxSizeExceeded` variant
- Add size and max fields to `EncodeError::OverMaxPacketSize` variant
- Update error messages to include actual and maximum size values
- Update error matching in tests to use wildcard pattern

This improves debuggability by providing actionable information when packet size limits are exceeded.