### PR TITLE
fix(cluster-raft): treat leader_id as a bootstrap hint, not a per-join requirement

### DIFF
--- a/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
@@ -215,15 +215,7 @@ impl ClusterPlugin {
                 } else {
                     //The other nodes are leader.
                     let actual_leader_info = find_actual_leader(&raft, peer_addrs, 60).await?;
-                    let (actual_leader_id, actual_leader_addr) =
-                        actual_leader_info.ok_or_else(|| anyhow!("Leader does not exist"))?;
-                    if actual_leader_id != leader_info.id {
-                        return Err(anyhow!(format!(
-                            "Not the expected Leader, the expected one is {:?}",
-                            leader_info
-                        )));
-                    }
-                    Some((actual_leader_id, actual_leader_addr))
+                    Some(actual_leader_info.ok_or_else(|| anyhow!("Leader does not exist"))?)
                 }
             }
             None => {


### PR DESCRIPTION
## Problem

`start_raft` enforces the configured `leader_id` on every node join. When a node starts and the live Raft leader is not the configured `leader_id`, it returns `Err("Not the expected Leader, ...")`, which propagates out of `register()` and exits the process.

Because Raft leadership legitimately moves the moment the configured leader restarts — and `rmqtt-raft` uses in-memory storage, so every restart is a fresh join with no recollection of the prior cluster — this turns a normal re-election into a crash loop on the next restart of any node. Out-of-phase restarts under `restart: unless-stopped` / an orchestrator never converge.

The only workaround, `leader_id = 0`, routes startup through the "join whatever leader exists" path — but that removes the single-designated-bootstrapper protection and exposes a full cold start to split-brain (every node bootstraps its own single-node cluster via `lead()` → `voters = vec![id]` → `become_leader()`).

Full write-up in #417.

## Fix

In the non-configured-leader branch, join whichever node is currently the leader instead of failing when it differs from the configured `leader_id`:

```diff
                 } else {
                     //The other nodes are leader.
                     let actual_leader_info = find_actual_leader(&raft, peer_addrs, 60).await?;
-                    let (actual_leader_id, actual_leader_addr) =
-                        actual_leader_info.ok_or_else(|| anyhow!("Leader does not exist"))?;
-                    if actual_leader_id != leader_info.id {
-                        return Err(anyhow!(format!(
-                            "Not the expected Leader, the expected one is {:?}",
-                            leader_info
-                        )));
-                    }
-                    Some((actual_leader_id, actual_leader_addr))
+                    Some(actual_leader_info.ok_or_else(|| anyhow!("Leader does not exist"))?)
                 }
```

`leader_id` thus becomes a bootstrap hint — it designates which node forms a brand-new cluster when none exists — while leadership re-election and clean rejoin-after-restart work as Raft intends. The "no leader found at all" case still errors so callers can retry, and the configured-leader branch (`id == leader_info.id`) is unchanged: it already tolerates an existing leader via `find_actual_leader` + "Leader already exists".

## Behavior

- **Cold start** (`leader_id = N`, no cluster yet): node N bootstraps, others join it — unchanged.
- **Rolling restart after leadership moved to another node**: the restarting node now joins the current leader instead of crashing with "Not the expected Leader".
- **Runtime re-election**: unaffected — this is startup-only logic.

No wire/protocol/storage changes, so mixed-version clusters during a rollout are unaffected.

Fixes #417
