### PR TITLE
refactor(msgstore): add async callback support and back-pressure limits

### DIFF
--- a/docs/en_US/store-message.md
+++ b/docs/en_US/store-message.md
@@ -32,6 +32,10 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/docs/zh_CN/store-message.md
+++ b/docs/zh_CN/store-message.md
@@ -31,6 +31,10 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##默认值: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-broadcast/1/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-broadcast/1/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-broadcast/2/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-broadcast/2/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-broadcast/3/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-broadcast/3/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-raft-3/1/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-cluster-raft.toml
@@ -11,7 +11,7 @@ node_grpc_batch_size = 128
 ##Client concurrent request limit
 node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
-node_grpc_client_timeout = "60s"
+node_grpc_client_timeout = "10s"
 
 #Raft peer address list
 raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]

--- a/examples/cluster-raft-3/1/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-raft-3/2/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-cluster-raft.toml
@@ -11,7 +11,7 @@ node_grpc_batch_size = 128
 ##Client concurrent request limit
 node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
-node_grpc_client_timeout = "60s"
+node_grpc_client_timeout = "10s"
 
 #Raft peer address list
 raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]

--- a/examples/cluster-raft-3/2/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-raft-3/3/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-cluster-raft.toml
@@ -11,7 +11,7 @@ node_grpc_batch_size = 128
 ##Client concurrent request limit
 node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
-node_grpc_client_timeout = "60s"
+node_grpc_client_timeout = "10s"
 
 #Raft peer address list
 raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]

--- a/examples/cluster-raft-3/3/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-raft-5/1/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-cluster-raft.toml
@@ -11,7 +11,7 @@ node_grpc_batch_size = 128
 #Client concurrent request limit
 node_grpc_client_concurrency_limit = 128
 #Connect and send to server timeout
-node_grpc_client_timeout = "60s"
+node_grpc_client_timeout = "10s"
 #Raft peer address list
 raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005", "4@127.0.0.1:6006", "5@127.0.0.1:6007"]
 

--- a/examples/cluster-raft-5/1/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 #redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-raft-5/2/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 #redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-raft-5/3/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 #redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-raft-5/4/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 #redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/examples/cluster-raft-5/5/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 #redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -12,12 +12,11 @@ use rust_box::task_exec_queue::{SpawnExt, TaskExecQueue};
 
 use rmqtt::context::ServerContext;
 use rmqtt::net::MqttError;
-use rmqtt::shared::{DefaultShared, Shared};
+use rmqtt::shared::{DefaultShared, Entry, MessageLoadCallback, Shared};
 use rmqtt::types::{HealthInfo, MsgID, NodeHealthStatus};
 use rmqtt::{
     grpc::{GrpcClient, GrpcClients, Message, MessageBroadcaster, MessageReply, MessageSender, MessageType},
     session::Session,
-    shared::Entry,
     types::{
         ClientId, ForwardedCount, ForwardedRecipients, From, Id, IsAdmin, IsOnline, NodeId, NodeName,
         OfflineSession, Publish, Reason, SessionStatus, SharedGroup, SharedGroupType, SubRelations,
@@ -793,6 +792,55 @@ impl Shared for ClusterShared {
             Ok(msgs)
         } else {
             message_mgr.get(client_id, topic_filter, group).await
+        }
+    }
+
+    #[inline]
+    async fn message_load_with(
+        &self,
+        client_id: &str,
+        topic_filter: &str,
+        group: Option<&SharedGroup>,
+        cb: Arc<dyn MessageLoadCallback>,
+    ) -> Result<()> {
+        let message_mgr = self.scx.extends.message_mgr().await;
+        if message_mgr.merge_on_read() {
+            let msgs = message_mgr.get(client_id, topic_filter, group).await?;
+            cb.on_messages(msgs).await?;
+
+            if !self.grpc_clients.is_empty() {
+                let cb2 = cb.clone();
+                MessageBroadcaster::new(
+                    self.grpc_clients.clone(),
+                    self.message_type,
+                    Message::MessageGet(
+                        ClientId::from(client_id),
+                        TopicFilter::from(topic_filter),
+                        group.cloned(),
+                    ),
+                    Some(self.rw_timeout),
+                )
+                .join_all_with_async(move |reply| {
+                    let msgs = match reply {
+                        Ok(MessageReply::MessageGet(msgs)) => msgs,
+                        Ok(other) => {
+                            log::error!("unexpected reply: {other:?}");
+                            vec![]
+                        }
+                        Err(e) => {
+                            log::warn!("Message::MessageGet failed, {e:?}");
+                            vec![]
+                        }
+                    };
+                    let cb2 = cb2.clone();
+                    async move { cb2.on_messages(msgs).await }
+                })
+                .await;
+            }
+            Ok(())
+        } else {
+            let msgs = message_mgr.get(client_id, topic_filter, group).await?;
+            cb.on_messages(msgs).await
         }
     }
 

--- a/rmqtt-plugins/rmqtt-cluster-raft.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft.toml
@@ -16,7 +16,7 @@ node_grpc_batch_size = 128
 ##Client concurrent request limit
 node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
-node_grpc_client_timeout = "15s"
+node_grpc_client_timeout = "10s"
 
 # The list of Raft peer addresses for the nodes in the cluster.
 # Each entry contains the node ID and the corresponding IP address and port for Raft consensus communication.

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -27,7 +27,7 @@ use rmqtt::{
     grpc::{GrpcClient, GrpcClients, Message, MessageBroadcaster, MessageReply, MessageSender, MessageType},
     router::Router,
     session::Session,
-    shared::{DefaultShared, Entry, Shared},
+    shared::{DefaultShared, Entry, MessageLoadCallback, Shared},
     types::{
         ForwardedCount, ForwardedRecipients, From, Id, IsAdmin, NodeId, NodeName, OfflineSession, Publish,
         Reason, SessionStatus, SubRelations, SubRelationsMap, SubsSearchParams, SubsSearchResult, Subscribe,
@@ -666,6 +666,11 @@ impl Shared for ClusterShared {
     ) -> Result<Vec<(MsgID, From, Publish)>> {
         let message_mgr = self.scx.extends.message_mgr().await;
         if message_mgr.merge_on_read() {
+            log::debug!(
+                "message_load start, client_id: {client_id}, grpc_clients: {}, rw_timeout: {:?}",
+                self.grpc_clients.len(),
+                self.rw_timeout
+            );
             let mut msgs = message_mgr.get(client_id, topic_filter, group).await?;
             if !self.grpc_clients.is_empty() {
                 let grpc_clients = self.grpc_clients.clone();
@@ -681,23 +686,27 @@ impl Shared for ClusterShared {
                         Message::MessageGet(client_id, topic_filter, group),
                         Some(rw_timeout),
                     )
-                    .join_all()
+                    .join_all_with(|r| r)
                     .await
                 }
                 .spawn(&self.exec)
                 .result()
                 .await
                 .map_err(|_| anyhow!("ClusterShared::message_load task execution failure"))?;
-                for (_, reply) in replys {
-                    let reply = reply?;
+
+                for (node_id, reply) in replys {
                     match reply {
-                        MessageReply::Error(e) => return Err(anyhow!(e)),
-                        MessageReply::MessageGet(res) => {
+                        Err(e) => {
+                            log::warn!("Message::MessageGet failed, node_id: {node_id}, {e:?}")
+                        }
+                        Ok(MessageReply::Error(e)) => {
+                            log::warn!("Message::MessageGet failed, node_id: {node_id}, {e:?}")
+                        }
+                        Ok(MessageReply::MessageGet(res)) => {
                             msgs.extend(res);
                         }
                         _ => {
-                            log::error!("unreachable!(), reply: {reply:?}");
-                            return Err(anyhow!("unreachable!()"));
+                            log::error!("unreachable!(), node_id: {node_id}, reply: {reply:?}");
                         }
                     }
                 }
@@ -705,6 +714,74 @@ impl Shared for ClusterShared {
             Ok(msgs)
         } else {
             message_mgr.get(client_id, topic_filter, group).await
+        }
+    }
+
+    #[inline]
+    async fn message_load_with(
+        &self,
+        client_id: &str,
+        topic_filter: &str,
+        group: Option<&SharedGroup>,
+        cb: Arc<dyn MessageLoadCallback>,
+    ) -> Result<()> {
+        let message_mgr = self.scx.extends.message_mgr().await;
+        if message_mgr.merge_on_read() {
+            log::debug!(
+                "message_load_with start, client_id: {client_id}, grpc_clients: {}, rw_timeout: {:?}",
+                self.grpc_clients.len(),
+                self.rw_timeout
+            );
+            let msgs = message_mgr.get(client_id, topic_filter, group).await?;
+            cb.on_messages(msgs).await?;
+
+            if !self.grpc_clients.is_empty() {
+                let grpc_clients = self.grpc_clients.clone();
+                let message_type = self.message_type;
+                let rw_timeout = self.rw_timeout;
+                let client_id = ClientId::from(client_id);
+                let topic_filter = TopicFilter::from(topic_filter);
+                let group = group.cloned();
+                let cb2 = cb.clone();
+                let replys: Vec<(NodeId, Result<()>)> = async move {
+                    MessageBroadcaster::new(
+                        grpc_clients,
+                        message_type,
+                        Message::MessageGet(client_id, topic_filter, group),
+                        Some(rw_timeout),
+                    )
+                    .join_all_with_async(move |reply| {
+                        let msgs = match reply {
+                            Ok(MessageReply::MessageGet(msgs)) => msgs,
+                            Ok(other) => {
+                                log::error!("unexpected reply: {other:?}");
+                                vec![]
+                            }
+                            Err(e) => {
+                                log::warn!("Message::MessageGet failed, {e:?}");
+                                vec![]
+                            }
+                        };
+                        let cb2 = cb2.clone();
+                        async move { cb2.on_messages(msgs).await }
+                    })
+                    .await
+                }
+                .spawn(&self.exec)
+                .result()
+                .await
+                .map_err(|_| anyhow!("ClusterShared::message_load_with task execution failure"))?;
+
+                for (node_id, result) in replys {
+                    if let Err(e) = result {
+                        log::warn!("Message::MessageGet failed, node_id: {node_id}, {e:?}")
+                    }
+                }
+            }
+            Ok(())
+        } else {
+            let msgs = message_mgr.get(client_id, topic_filter, group).await?;
+            cb.on_messages(msgs).await
         }
     }
 

--- a/rmqtt-plugins/rmqtt-message-storage.toml
+++ b/rmqtt-plugins/rmqtt-message-storage.toml
@@ -10,6 +10,11 @@ storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
 storage.ram.encode = true
 
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
 ##redis
 storage.redis.url = "redis://127.0.0.1:6379/"
 storage.redis.prefix = "message-{node}"

--- a/rmqtt-plugins/rmqtt-message-storage/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-message-storage/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["sync", "time"] }
 rmqtt-storage = { workspace = true, default-features = false, features = ["ttl"], optional = true}
 #rmqtt-storage = { path = "../../../rmqtt-storage", default-features = false, features = ["ttl"], optional = true}
-rust-box.workspace = true
+rust-box = { workspace = true, features = ["task-exec-queue", "task-exec-queue-rate"] }
 futures.workspace = true
 futures-time.workspace = true
 async-trait.workspace = true

--- a/rmqtt-plugins/rmqtt-message-storage/README-CN.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README-CN.md
@@ -35,6 +35,8 @@ rmqtt_message_storage::register(&scx, true, false).await?;
 | `storage.ram.cache_capacity` | string | `"3G"` | 内存缓存容量 |
 | `storage.ram.cache_max_count` | integer | `1_000_000` | 最大缓存条目数 |
 | `storage.ram.encode` | boolean | `true` | 启用消息编码 |
+| `storage.ram.workers` | integer | `1000` | 任务执行队列的工作线程数 |
+| `storage.ram.queue_max` | integer | `300000` | 任务队列最大积压量（背压保护） |
 
 ### Redis 后端
 

--- a/rmqtt-plugins/rmqtt-message-storage/README.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README.md
@@ -35,6 +35,8 @@ File: `rmqtt-message-storage.toml`
 | `storage.ram.cache_capacity` | string | `"3G"` | In-memory cache capacity |
 | `storage.ram.cache_max_count` | integer | `1_000_000` | Maximum cache entry count |
 | `storage.ram.encode` | boolean | `true` | Enable message encoding |
+| `storage.ram.workers` | integer | `1000` | Task execution queue worker threads |
+| `storage.ram.queue_max` | integer | `300000` | Maximum task queue backlog (back-pressure limit) |
 
 ### Redis Backend
 

--- a/rmqtt-plugins/rmqtt-message-storage/src/config.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/config.rs
@@ -134,6 +134,12 @@ pub struct RamConfig {
     pub encode: bool,
     #[serde(default = "RamConfig::merge_on_read_default")]
     pub merge_on_read: bool,
+
+    /// Maximum number of pending tasks in the TaskExecQueue.
+    /// Beyond this, new tasks are rejected.
+    /// Default: 300_000
+    #[serde(default = "RamConfig::queue_max_default")]
+    pub queue_max: usize,
 }
 
 impl Default for RamConfig {
@@ -144,6 +150,7 @@ impl Default for RamConfig {
             cache_max_count: usize::MAX,
             encode: false,
             merge_on_read: true,
+            queue_max: Self::queue_max_default(),
         }
     }
 }
@@ -151,5 +158,9 @@ impl Default for RamConfig {
 impl RamConfig {
     fn merge_on_read_default() -> bool {
         true
+    }
+
+    fn queue_max_default() -> usize {
+        300_000
     }
 }

--- a/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
@@ -183,9 +183,8 @@ impl MessageMgr {
                 let topic_values = mgr.topic_tree.read().await.values_size();
                 let forwardeds = mgr.forwardeds_count().await;
                 let expiries = mgr.expiries.read().await.len();
-                let exec_active_count = mgr.exec.active_count();
-                let exec_waiting_count = mgr.exec.waiting_count();
                 let messages_bytes_size = mgr.messages_bytes_size_get();
+                let msg_queue_count = mgr.msg_queue_count_get();
                 serde_json::json!({
                     "storage_engine": "Ram",
                     "message": {
@@ -196,9 +195,8 @@ impl MessageMgr {
                         "forwardeds": forwardeds,
                         "expiries": expiries,
                         "bytes_size": messages_bytes_size,
+                        "msg_queue_count": msg_queue_count,
                     },
-                    "exec_active_count": exec_active_count,
-                    "exec_waiting_count": exec_waiting_count,
                 })
             }
             #[cfg(any(feature = "redis", feature = "redis-cluster"))]

--- a/rmqtt-plugins/rmqtt-message-storage/src/ram.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/ram.rs
@@ -18,7 +18,6 @@ use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use futures_time::{self, future::FutureExt};
 use get_size2::GetSize;
-use rust_box::task_exec_queue::{Builder, TaskExecQueue};
 use tokio::{sync::RwLock, time::sleep};
 
 use rmqtt::{
@@ -53,7 +52,6 @@ enum Msg {
 #[derive(Clone)]
 pub struct RamMessageManager {
     inner: Arc<RamMessageManagerInner>,
-    pub(crate) exec: TaskExecQueue,
 }
 
 impl RamMessageManager {
@@ -63,13 +61,7 @@ impl RamMessageManager {
         cleanup_count: usize,
         timeout: Duration,
     ) -> Result<RamMessageManager> {
-        let (exec, task_runner) = Builder::default().workers(1000).queue_max(300_000).build();
-
-        tokio::spawn(async move {
-            task_runner.await;
-        });
-
-        let (msg_tx, msg_rx) = mpsc::channel::<Msg>(300_000);
+        let (msg_tx, msg_rx) = mpsc::channel::<Msg>(cfg.queue_max);
         let msg_queue_count = Arc::new(AtomicIsize::new(0));
 
         let this = Self {
@@ -86,7 +78,6 @@ impl RamMessageManager {
                 msg_queue_count,
                 timeout,
             }),
-            exec,
         };
 
         Ok(this.serve(cleanup_count, msg_rx))
@@ -191,6 +182,11 @@ impl RamMessageManager {
     }
 
     #[inline]
+    pub(crate) fn msg_queue_count_get(&self) -> isize {
+        self.msg_queue_count.load(Ordering::SeqCst)
+    }
+
+    #[inline]
     async fn remove_expired_messages(&self, max_limit: usize) -> Result<usize> {
         let now = timestamp_millis();
         let inner = self.inner.as_ref();
@@ -277,6 +273,7 @@ impl RamMessageManager {
         }
     }
 
+    #[allow(dead_code)]
     #[inline]
     fn messages_get(&self, msg_id: &MsgID) -> Result<Option<StoredMessage>> {
         if self.cfg.encode {
@@ -286,6 +283,21 @@ impl RamMessageManager {
                 Ok(None)
             }
         } else if let Some(msg) = self.messages.get(msg_id) {
+            Ok(Some(msg.get().0.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[inline]
+    async fn messages_get_async(&self, msg_id: &MsgID) -> Result<Option<StoredMessage>> {
+        if self.cfg.encode {
+            if let Some(msg) = self.messages_encode.get_async(msg_id).await {
+                Ok(Some(StoredMessage::decode(&msg.get().0).map_err(|e| anyhow!(e))?))
+            } else {
+                Ok(None)
+            }
+        } else if let Some(msg) = self.messages.get_async(msg_id).await {
             Ok(Some(msg.get().0.clone()))
         } else {
             Ok(None)
@@ -370,6 +382,7 @@ impl RamMessageManager {
             topic.push(Level::SingleWildcard);
         }
 
+        let now = std::time::Instant::now();
         let msg_ids = {
             inner
                 .topic_tree
@@ -380,42 +393,63 @@ impl RamMessageManager {
                 .map(|(_, msg_id)| *msg_id)
                 .collect::<Vec<_>>()
         };
+        let elaps = now.elapsed();
+        if elaps.as_millis() > 100 {
+            log::warn!(
+                "slow matches operation, client_id: {}, topic_filter: {}, group: {:?}, elapsed: {:?}",
+                client_id,
+                topic_filter,
+                group,
+                elaps
+            );
+        }
 
-        let matcheds = msg_ids
-            .into_iter()
-            .filter_map(|msg_id| {
-                if let Ok(Some(msg)) = self.messages_get(&msg_id) {
-                    // Use get() instead of entry().or_default() to avoid
-                    // creating an empty BTreeMap orphan in forwardeds.
-                    let is_forwarded = self.inner.forwardeds.get(&msg_id).is_some_and(|cids| {
-                        if cids.contains_key(client_id) {
-                            true
-                        } else if let Some(group) = group {
-                            //Check if subscription is shared
-                            cids.iter().any(|(_, tf_g)| {
-                                tf_g.as_ref().is_some_and(|(tf, g)| g == group && tf == topic_filter)
-                            })
-                        } else {
-                            false
-                        }
-                    });
+        let count = msg_ids.len();
+        let mut matcheds = Vec::with_capacity(count);
 
-                    log::debug!("is_forwarded: {is_forwarded}");
-                    if is_forwarded
-                        || msg.is_expiry()
-                        || msg.publish.target_clientid.as_ref().is_some_and(|t_cid| t_cid != client_id)
-                    {
-                        None
+        for (i, msg_id) in msg_ids.into_iter().enumerate() {
+            if (i & 1023) == 1023 {
+                tokio::task::yield_now().await;
+            }
+            let now = std::time::Instant::now();
+            if let Ok(Some(msg)) = self.messages_get_async(&msg_id).await {
+                // Use get() instead of entry().or_default() to avoid
+                // creating an empty BTreeMap orphan in forwardeds.
+                let is_forwarded = self.inner.forwardeds.get_async(&msg_id).await.is_some_and(|cids| {
+                    if cids.contains_key(client_id) {
+                        true
+                    } else if let Some(group) = group {
+                        //Check if subscription is shared
+                        cids.iter().any(|(_, tf_g)| {
+                            tf_g.as_ref().is_some_and(|(tf, g)| g == group && tf == topic_filter)
+                        })
                     } else {
-                        // Record is deferred to the caller after
-                        // confirming successful delivery.
-                        Some((msg_id, msg.from, msg.publish))
+                        false
                     }
-                } else {
-                    None
+                });
+
+                log::debug!("is_forwarded: {is_forwarded}, is_expiry: {}", msg.is_expiry());
+                if is_forwarded
+                    || msg.is_expiry()
+                    || msg.publish.target_clientid.as_ref().is_some_and(|t_cid| t_cid != client_id)
+                {
+                    continue;
                 }
-            })
-            .collect::<Vec<_>>();
+                // Record is deferred to the caller after
+                // confirming successful delivery.
+                matcheds.push((msg_id, msg.from, msg.publish));
+            }
+            let elaps = now.elapsed();
+            if elaps.as_millis() > 100 {
+                log::warn!(
+                "slow messages_get_async operation, client_id: {}, topic_filter: {}, group: {:?}, elapsed: {:?}",
+                client_id,
+                topic_filter,
+                group,
+                elaps
+            );
+            }
+        }
         Ok(matcheds)
     }
 
@@ -437,9 +471,9 @@ impl RamMessageManager {
             inner.forwardeds.len(),
             self.messages_bytes_size_get(),
             inner.id_gen.load(Ordering::Relaxed),
-            self.exec.waiting_count(),
-            self.exec.active_count(),
-            self.exec.rate().await
+            0,
+            0,
+            0,
         )
     }
 
@@ -511,7 +545,19 @@ impl MessageManager for RamMessageManager {
         topic_filter: &str,
         group: Option<&SharedGroup>,
     ) -> Result<Vec<(MsgID, From, Publish)>> {
-        self._get(client_id, topic_filter, group).await
+        let now = std::time::Instant::now();
+        let res = self._get(client_id, topic_filter, group).await;
+        let elaps = now.elapsed();
+        if elaps.as_secs() > 1 {
+            log::warn!(
+                "slow message fetch operation, client_id: {}, topic_filter: {}, group: {:?}, elapsed: {:?}",
+                client_id,
+                topic_filter,
+                group,
+                elaps
+            );
+        }
+        res
     }
 
     #[inline]
@@ -529,7 +575,10 @@ impl MessageManager for RamMessageManager {
             Ok(send_fut.await)
         };
         match res {
-            Ok(Ok(())) => Ok(()),
+            Ok(Ok(())) => {
+                self.msg_queue_count.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
             Ok(Err(e)) => {
                 log::warn!("RamMessageManager mark_forwarded error, {e:?}");
                 Err(anyhow!(e))
@@ -557,7 +606,7 @@ impl MessageManager for RamMessageManager {
 
     #[inline]
     async fn max(&self) -> isize {
-        self.exec.completed_count().await
+        self.messages_count() as isize
     }
 
     #[inline]

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -49,10 +49,13 @@
 //!
 //! Note: All message types below 1000 are reserved for internal use.
 //!
+use std::future::Future;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::stream::FuturesUnordered;
 use futures::FutureExt;
 use futures::StreamExt;
 use rust_box::handy_grpc::client::Mailbox;
@@ -73,6 +76,9 @@ use crate::types::{
 };
 use crate::utils::Counter;
 use crate::Result;
+
+/// Internal type alias for async join_all_with handler futures.
+type JoinAllWithAsyncFut<R> = FuturesUnordered<Pin<Box<dyn Future<Output = (NodeId, Result<R>)> + Send>>>;
 
 /// gRPC server for inter-node cluster communication.
 ///
@@ -407,6 +413,67 @@ impl MessageBroadcaster {
             senders.push(fut.boxed());
         }
         futures::future::join_all(senders).await
+    }
+
+    #[inline]
+    pub async fn join_all_with<R, F>(self, handler: F) -> Vec<(NodeId, Result<R>)>
+    where
+        R: Send + Sync + 'static,
+        F: Fn(Result<MessageReply>) -> Result<R> + Send + Sync,
+    {
+        let msg = self.msg;
+        let msg_type = self.msg_type;
+        let timeout = self.timeout;
+
+        let mut futures = FuturesUnordered::new();
+        for (id, (_, grpc_client)) in self.grpc_clients.iter() {
+            let mut client = grpc_client.clone();
+            let msg = msg.clone();
+            futures.push(async move { (*id, client.send_message(msg_type, msg, timeout).await) });
+        }
+
+        let mut results = Vec::new();
+
+        while let Some((id, reply)) = futures.next().await {
+            let r = handler(reply);
+            results.push((id, r));
+        }
+
+        results
+    }
+
+    /// Join all peers with an **async** handler that processes each reply as it arrives.
+    ///
+    /// Unlike `join_all_with`, the handler returns a `Future` so callers can `.await`
+    /// inside the handler — useful for feeding messages into an async callback.
+    #[inline]
+    pub async fn join_all_with_async<R, Fut, F>(self, handler: F) -> Vec<(NodeId, Result<R>)>
+    where
+        R: Send + Sync + 'static,
+        Fut: Future<Output = Result<R>> + Send + 'static,
+        F: Fn(Result<MessageReply>) -> Fut + Send + Sync + 'static,
+    {
+        let msg = self.msg;
+        let msg_type = self.msg_type;
+        let timeout = self.timeout;
+
+        let handler = Arc::new(handler);
+        let mut futures: JoinAllWithAsyncFut<R> = JoinAllWithAsyncFut::new();
+        for (&id, (_, grpc_client)) in self.grpc_clients.iter() {
+            let mut client = grpc_client.clone();
+            let msg = msg.clone();
+            let handler = Arc::clone(&handler);
+            futures.push(Box::pin(async move {
+                let reply = client.send_message(msg_type, msg, timeout).await;
+                (id, handler(reply).await)
+            }));
+        }
+
+        let mut results = Vec::with_capacity(futures.len());
+        while let Some(result) = futures.next().await {
+            results.push(result);
+        }
+        results
     }
 
     #[inline]

--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -91,6 +91,8 @@ use crate::hook::Hook;
 use crate::inflight::{InInflight, MomentStatus, OutInflight, OutInflightMessage};
 use crate::net::MqttError;
 use crate::queue::{self, Limiter, Policy};
+#[cfg(feature = "msgstore")]
+use crate::shared::MessageLoadCallback;
 use crate::types::*;
 use crate::utils::timestamp_millis;
 use crate::Result;
@@ -1375,8 +1377,13 @@ impl SessionState {
             #[cfg(feature = "msgstore")]
             if self.scx.extends.message_mgr().await.enable() {
                 //Send messages before they expire
-                self.send_storaged_messages(&sub.topic_filter, qos, sub.opts.shared_group(), _excludeds)
-                    .await?;
+                self.send_storaged_messages(
+                    sub.topic_filter.clone(),
+                    qos,
+                    sub.opts.shared_group(),
+                    _excludeds,
+                )
+                .await?;
             }
 
             //hook, session_subscribed
@@ -1413,7 +1420,9 @@ impl SessionState {
 
                 //Send messages before they expire
                 #[cfg(feature = "msgstore")]
-                if let Err(e) = self.send_storaged_messages(tf, opts.qos(), opts.shared_group(), None).await {
+                if let Err(e) =
+                    self.send_storaged_messages(tf.clone(), opts.qos(), opts.shared_group(), None).await
+                {
                     log::warn!("transfer_session_state, router.add, {e:?}");
                 }
             }
@@ -1474,86 +1483,81 @@ impl SessionState {
     #[cfg(feature = "msgstore")]
     async fn send_storaged_messages(
         &self,
-        topic_filter: &str,
+        topic_filter: TopicFilter,
         qos: QoS,
         group: Option<&SharedGroup>,
         excludeds: Option<Vec<(NodeId, MsgID)>>,
     ) -> Result<()> {
-        let storaged_messages =
-            self.scx.extends.shared().await.message_load(&self.id.client_id, topic_filter, group).await?;
-        log::debug!(
-            "{:?} storaged_messages: {:?}, topic_filter: {}, group: {:?}, excludeds: {:?}",
-            self.id,
-            storaged_messages.len(),
-            topic_filter,
-            group,
-            excludeds
-        );
-        self._send_storaged_messages(storaged_messages, qos, excludeds, topic_filter, group).await?;
+        let scx = self.scx.clone();
+        let group = group.cloned();
+        let id = self.id.clone();
+        tokio::spawn(async move {
+            let now = std::time::Instant::now();
+            let handler = SendStoragedMessagesHandler {
+                scx: scx.clone(),
+                id: id.clone(),
+                qos,
+                excludeds,
+                topic_filter: topic_filter.clone(),
+                group: group.clone(),
+            };
+            if let Err(e) = scx
+                .extends
+                .shared()
+                .await
+                .message_load_with(&id.client_id, &topic_filter, group.as_ref(), Arc::new(handler))
+                .await
+            {
+                log::warn!("message_load_with failed, {e:?}");
+            }
+            let elaps = now.elapsed();
+            if elaps.as_secs() > 3 {
+                log::warn!("message_load_with cost time: {:?}", elaps);
+            }
+        });
         Ok(())
     }
 
     #[inline]
     #[cfg(feature = "msgstore")]
-    async fn _send_storaged_messages(
+    #[allow(dead_code)]
+    async fn send_storaged_messages_old(
         &self,
-        storaged_messages: Vec<(MsgID, From, Publish)>,
+        topic_filter: TopicFilter,
         qos: QoS,
-        excludeds: Option<Vec<(NodeId, MsgID)>>,
-        topic_filter: &str,
         group: Option<&SharedGroup>,
+        excludeds: Option<Vec<(NodeId, MsgID)>>,
     ) -> Result<()> {
-        for (msg_id, from, mut publish) in storaged_messages {
-            log::debug!(
-                "{:?} msg_id: {}, from:{:?}, publish:{:?}, excluded: {}",
-                self.id,
-                msg_id,
-                from,
-                publish,
-                excludeds
-                    .as_ref()
-                    .map(|excludeds| excludeds.contains(&(from.node_id, msg_id)))
-                    .unwrap_or_default()
-            );
-            if excludeds
-                .as_ref()
-                .map(|excludeds| excludeds.contains(&(from.node_id, msg_id)))
-                .unwrap_or_default()
-            {
-                continue;
+        let scx = self.scx.clone();
+        let group = group.cloned();
+        let id = self.id.clone();
+        tokio::spawn(async move {
+            let now = std::time::Instant::now();
+            let storaged_messages =
+                scx.extends.shared().await.message_load(&id.client_id, &topic_filter, group.as_ref()).await;
+            let elaps = now.elapsed();
+            if elaps.as_secs() > 3 {
+                log::warn!("message_load cost time: {:?}", elaps);
             }
 
-            let from_node_id = from.node_id;
-
-            publish.dup = false;
-            publish.retain = false;
-            publish.qos = publish.qos.less_value(qos);
-            publish.packet_id = None;
-
-            log::debug!("{:?} persistent.publish: {:?}", self.id, publish);
-
-            if let Err((from, p, reason)) =
-                self.scx.extends.shared().await.entry(self.id.clone()).publish(from, publish).await
-            {
-                self.scx.extends.hook_mgr().message_dropped(Some(self.id.clone()), from, p, reason).await;
-            } else {
-                // Record successful delivery so the message is not
-                // redelivered on next reconnect. The node_id check is
-                // handled inside the shared implementation.
-                let opts = group.map(|g| (TopicFilter::from(topic_filter), g.clone()));
-                if let Err(e) = self
-                    .scx
-                    .extends
-                    .shared()
-                    .await
-                    .message_mark_forwarded(from_node_id, msg_id, vec![(self.id.client_id.clone(), opts)])
-                    .await
-                {
-                    log::warn!("{:?} mark_forwarded error: {e:?}", self.id);
+            let storaged_messages = match storaged_messages {
+                Err(e) => {
+                    log::error!("message_load failed, {e:?}");
+                    return;
                 }
-            }
-        }
-
+                Ok(storaged_messages) => storaged_messages,
+            };
+            _send_storaged_messages(
+                &scx,
+                id,
+                storaged_messages,
+                qos,
+                excludeds,
+                &topic_filter,
+                group.as_ref(),
+            )
+            .await;
+        });
         Ok(())
     }
 
@@ -1829,7 +1833,6 @@ impl SessionState {
             }
             drop(retain);
         }
-
         // Store FIRST (subscriber IDs will be recorded inside forwards()
         // via mark_forwarded), ensuring subscriber tracking is tied
         // to the forwarding result rather than deferred to a later store().
@@ -1919,6 +1922,94 @@ impl fmt::Debug for Session {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Session {:?}", self.id)
+    }
+}
+
+#[inline]
+#[cfg(feature = "msgstore")]
+async fn _send_storaged_messages(
+    scx: &ServerContext,
+    id: Id,
+    storaged_messages: Vec<(MsgID, From, Publish)>,
+    qos: QoS,
+    excludeds: Option<Vec<(NodeId, MsgID)>>,
+    topic_filter: &str,
+    group: Option<&SharedGroup>,
+) {
+    for (msg_id, from, mut publish) in storaged_messages {
+        log::debug!(
+            "{:?} msg_id: {}, from:{:?}, publish:{:?}, excluded: {}",
+            id,
+            msg_id,
+            from,
+            publish,
+            excludeds
+                .as_ref()
+                .map(|excludeds| excludeds.contains(&(from.node_id, msg_id)))
+                .unwrap_or_default()
+        );
+        if excludeds.as_ref().map(|excludeds| excludeds.contains(&(from.node_id, msg_id))).unwrap_or_default()
+        {
+            continue;
+        }
+
+        let from_node_id = from.node_id;
+
+        publish.dup = false;
+        publish.retain = false;
+        publish.qos = publish.qos.less_value(qos);
+        publish.packet_id = None;
+
+        log::debug!("{:?} persistent.publish: {:?}", id, publish);
+
+        if let Err((from, p, reason)) =
+            scx.extends.shared().await.entry(id.clone()).publish(from, publish).await
+        {
+            scx.extends.hook_mgr().message_dropped(Some(id.clone()), from, p, reason).await;
+        } else {
+            // Record successful delivery so the message is not
+            // redelivered on next reconnect. The node_id check is
+            // handled inside the shared implementation.
+            let opts = group.map(|g| (TopicFilter::from(topic_filter), g.clone()));
+            if let Err(e) = scx
+                .extends
+                .shared()
+                .await
+                .message_mark_forwarded(from_node_id, msg_id, vec![(id.client_id.clone(), opts)])
+                .await
+            {
+                log::warn!("{:?} mark_forwarded error: {e:?}", id);
+            }
+        }
+    }
+}
+
+/// Handler for [`MessageLoadCallback`] used by [`send_storaged_messages`].
+#[cfg(feature = "msgstore")]
+struct SendStoragedMessagesHandler {
+    scx: ServerContext,
+    id: Id,
+    qos: QoS,
+    excludeds: Option<Vec<(NodeId, MsgID)>>,
+    topic_filter: TopicFilter,
+    group: Option<SharedGroup>,
+}
+
+#[cfg(feature = "msgstore")]
+#[async_trait]
+impl MessageLoadCallback for SendStoragedMessagesHandler {
+    async fn on_messages(&self, msgs: Vec<(MsgID, From, Publish)>) -> Result<()> {
+        _send_storaged_messages(
+            &self.scx,
+            self.id.clone(),
+            msgs,
+            self.qos,
+            self.excludeds.clone(),
+            &self.topic_filter,
+            self.group.as_ref(),
+        )
+        .await;
+        Ok(())
     }
 }
 

--- a/rmqtt/src/shared.rs
+++ b/rmqtt/src/shared.rs
@@ -139,6 +139,21 @@ pub trait Entry: Sync + Send {
 /// subscription tracking, and publish message forwarding across
 /// cluster nodes. Implementations manage client state storage,
 /// gRPC-based inter-node communication, and message delivery.
+///
+/// Async callback trait for processing messages loaded by `message_load_with`.
+///
+/// Implementations receive batches of loaded messages and can use `await`
+/// internally — unlike the sync `Arc<dyn Fn(...)>` approach.
+#[cfg(feature = "msgstore")]
+#[async_trait]
+pub trait MessageLoadCallback: Send + Sync + 'static {
+    /// Called for each batch of loaded messages.
+    ///
+    /// # Arguments
+    /// * `msgs` - A batch of messages from local storage or a remote peer.
+    async fn on_messages(&self, msgs: Vec<(MsgID, From, Publish)>) -> Result<()>;
+}
+
 #[async_trait]
 pub trait Shared: Sync + Send {
     /// Retrieve the session entry associated with the given client [`Id`].
@@ -251,6 +266,18 @@ pub trait Shared: Sync + Send {
         topic_filter: &str,
         group: Option<&SharedGroup>,
     ) -> Result<Vec<(MsgID, From, Publish)>>;
+
+    #[cfg(feature = "msgstore")]
+    async fn message_load_with(
+        &self,
+        client_id: &str,
+        topic_filter: &str,
+        group: Option<&SharedGroup>,
+        cb: Arc<dyn MessageLoadCallback>,
+    ) -> Result<()> {
+        let msgs = self.message_load(client_id, topic_filter, group).await?;
+        cb.on_messages(msgs).await
+    }
 
     /// Mark a message as successfully forwarded to the given subscribers.
     /// Delegates to [`MessageManager::mark_forwarded`] so that forwarding
@@ -974,6 +1001,20 @@ impl Shared for DefaultShared {
         let scx = self.context();
         let message_mgr = scx.extends.message_mgr().await;
         message_mgr.get(client_id, topic_filter, group).await
+    }
+
+    #[cfg(feature = "msgstore")]
+    async fn message_load_with(
+        &self,
+        client_id: &str,
+        topic_filter: &str,
+        group: Option<&SharedGroup>,
+        cb: Arc<dyn MessageLoadCallback>,
+    ) -> Result<()> {
+        let scx = self.context();
+        let message_mgr = scx.extends.message_mgr().await;
+        let msgs = message_mgr.get(client_id, topic_filter, group).await?;
+        cb.on_messages(msgs).await
     }
 
     #[inline]


### PR DESCRIPTION
**Summary**
Major refactoring of message storage to support async callbacks, configurable back-pressure limits, and improved performance monitoring.

**Key Changes**

Async Callback Support:
- Add `MessageLoadCallback` trait for async message processing
- Add `message_load_with()` to `Shared` trait for callback-based loading
- Move `send_storaged_messages()` to async callback handler
- Prevents blocking the session loop during message delivery

Back-pressure Limits:
- Add `storage.ram.queue_max` config (default: 300_000)
- Reject new store requests when queue is full
- Remove hardcoded channel capacity
- Document in README and example configs

Performance Monitoring:
- Add slow operation warnings (>100ms for matches, >1s for fetch)
- Add yield points in message matching loop (every 1024 iterations)
- Track `msg_queue_count` in attributes
- Remove `exec` stats from RAM storage attributes

Code Cleanup:
- Remove `TaskExecQueue` from RAM storage (unused)
- Add `messages_get_async()` for async message retrieval
- Rename `messages_get()` to `#[allow(dead_code)]`
- Update `max()` to return message count instead of completed count

Cluster Improvements:
- Use `join_all_with()` for parallel message fetching in cluster-raft
- Add `join_all_with_async()` to `MessageBroadcaster` for async handlers
- Reduce `node_grpc_client_timeout` from 60s/15s to 10s in examples
- Add detailed debug logging for message_load operations

Configuration Updates:
- Add `storage.ram.workers` and `storage.ram.queue_max` to README
- Add `storage.ram.queue_max` to all example cluster configs
- Remove `storage.ram.workers` from RAM config (no longer used)

**Benefits**
- Non-blocking session message delivery
- Configurable back-pressure to prevent memory exhaustion
- Better observability with slow operation warnings
- Improved cluster message fetching with async callbacks