### PR TITLE
feat(msgstore): add circuit breaker for Redis storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-utils"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytestring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ rmqtt-codec = "0.2.2"
 rmqtt-net = "0.3.5"
 rmqtt-conf = "0.3.5"
 rmqtt-macros = "0.1.2"
-rmqtt-utils = "0.1"
+rmqtt-utils = "0.1.5"
 rmqtt-storage = { version = "0.8",  default-features = false }
 
 rmqtt-plugins = "0.22.0"

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -824,7 +824,7 @@ impl Shared for ClusterShared {
                     let msgs = match reply {
                         Ok(MessageReply::MessageGet(msgs)) => msgs,
                         Ok(other) => {
-                            log::error!("unexpected reply: {other:?}");
+                            log::warn!("unexpected reply: {other:?}");
                             vec![]
                         }
                         Err(e) => {

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -754,7 +754,7 @@ impl Shared for ClusterShared {
                         let msgs = match reply {
                             Ok(MessageReply::MessageGet(msgs)) => msgs,
                             Ok(other) => {
-                                log::error!("unexpected reply: {other:?}");
+                                log::warn!("unexpected reply: {other:?}");
                                 vec![]
                             }
                             Err(e) => {

--- a/rmqtt-plugins/rmqtt-message-storage.toml
+++ b/rmqtt-plugins/rmqtt-message-storage.toml
@@ -28,3 +28,22 @@ cleanup_count = 5000
 
 ##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
 timeout = "5s"
+
+##─── Circuit breaker ─────────────────────────────────────────────────────────
+##Enable circuit breaker. When Redis fails consecutively beyond the threshold,
+##the broker stops waiting for Redis and returns immediately.
+##Default: true
+#circuit_breaker_enabled = true
+
+##Consecutive storage failures before tripping the circuit to OPEN (fast-fail).
+##Default: 10
+#circuit_failure_threshold = 10
+
+##Duration to wait in OPEN state before allowing a probe (HALF_OPEN).
+##Default: "15s"
+#circuit_reset_timeout = "15s"
+
+##Consecutive probe successes needed to close the circuit.
+##Higher values avoid premature recovery on flaky connections.
+##Default: 3
+#circuit_half_open_success_threshold = 3

--- a/rmqtt-plugins/rmqtt-message-storage/README-CN.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README-CN.md
@@ -59,6 +59,30 @@ rmqtt_message_storage::register(&scx, true, false).await?;
 | `cleanup_count` | integer | `5000` | 每轮清理的过期消息数量 |
 | `timeout` | string | `"5s"` | 存储 I/O 操作超时。`"0s"` = 不超时 |
 
+### 熔断器
+
+保护 Broker 在 Redis 后端不可用时不会被阻塞。电路 OPEN 时，
+store/mark_forwarded/get 会立即返回，不碰 Redis。熔断器会自动探测恢复。
+
+| 选项 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `circuit_breaker_enabled` | boolean | `true` | 启用熔断器 |
+| `circuit_failure_threshold` | integer | `10` | 连续失败次数超过此值后跳闸到 OPEN |
+| `circuit_reset_timeout` | string | `"15s"` | OPEN 状态下等待多久后进入探测（HALF_OPEN） |
+| `circuit_half_open_success_threshold` | integer | `3` | HALF_OPEN 状态下连续成功次数达到此值后关闭电路 |
+
+#### 状态机
+
+```
+CLOSED ── 失败次数 ≥ 阈值 ──► OPEN ── 超时 ──► HALF_OPEN
+  ▲                                                    │
+  └─────────── 成功次数 ≥ 阈值 ◄────────────────────────┘
+```
+
+- **CLOSED**：正常运行，统计失败次数。
+- **OPEN**：所有操作跳过 Redis；worker 直接丢弃积压消息不等待。
+- **HALF_OPEN**：允许探测请求；连续成功达到阈值后关闭，任意失败立即回到 OPEN。
+
 ## 依赖
 
 `rmqtt`（features：`plugin`、`msgstore`）、redis（可选）

--- a/rmqtt-plugins/rmqtt-message-storage/README.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README.md
@@ -59,6 +59,32 @@ File: `rmqtt-message-storage.toml`
 | `cleanup_count` | integer | `5000` | Expired messages cleaned per cycle |
 | `timeout` | string | `"5s"` | Timeout for storage I/O operations. `"0s"` = no timeout |
 
+### Circuit Breaker
+
+Protects the broker from blocking when the Redis backend becomes unreachable.
+When the circuit is OPEN, store/mark_forwarded/get return immediately without
+touching Redis. The circuit automatically probes for recovery.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `circuit_breaker_enabled` | boolean | `true` | Enable circuit breaker |
+| `circuit_failure_threshold` | integer | `10` | Consecutive failures before tripping to OPEN |
+| `circuit_reset_timeout` | string | `"15s"` | Wait duration in OPEN before probing (HALF_OPEN) |
+| `circuit_half_open_success_threshold` | integer | `3` | Consecutive probe successes to close the circuit |
+
+#### State Machine
+
+```
+CLOSED ── failure_count ≥ threshold ──► OPEN ── timeout ──► HALF_OPEN
+  ▲                                                               │
+  └────────────── success × threshold ◄───────────────────────────┘
+```
+
+- **CLOSED**: normal operation, failures are counted.
+- **OPEN**: all operations skip Redis immediately; workers drain backlog without waiting.
+- **HALF_OPEN**: probe requests are allowed; if enough succeed the circuit closes,
+  if any fails it re-opens.
+
 ## Dependencies
 
 `rmqtt` (features: `plugin`, `msgstore`), redis (optional)

--- a/rmqtt-plugins/rmqtt-message-storage/src/config.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/config.rs
@@ -25,6 +25,29 @@ pub struct PluginConfig {
     /// Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
     #[serde(default = "PluginConfig::timeout_default", deserialize_with = "deserialize_duration")]
     pub timeout: Duration,
+
+    // ─── Circuit breaker ─────────────────────────────────────────────────────
+    /// Enable circuit breaker for Redis storage operations.
+    /// When enabled and the circuit is OPEN, store/mark_forwarded/get
+    /// return immediately without touching Redis.
+    #[serde(default = "PluginConfig::circuit_breaker_enabled_default")]
+    pub circuit_breaker_enabled: bool,
+
+    /// Consecutive failures before tripping to OPEN.
+    #[serde(default = "PluginConfig::circuit_failure_threshold_default")]
+    pub circuit_failure_threshold: usize,
+
+    /// Duration in OPEN state before transitioning to HALF_OPEN (probe).
+    /// Example: "30s", "1m".
+    #[serde(
+        default = "PluginConfig::circuit_reset_timeout_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub circuit_reset_timeout: Duration,
+
+    /// Consecutive probe successes in HALF_OPEN before closing the circuit.
+    #[serde(default = "PluginConfig::circuit_half_open_success_threshold_default")]
+    pub circuit_half_open_success_threshold: usize,
 }
 
 impl PluginConfig {
@@ -41,6 +64,22 @@ impl PluginConfig {
 
     fn timeout_default() -> Duration {
         Duration::from_millis(5000)
+    }
+
+    fn circuit_breaker_enabled_default() -> bool {
+        true
+    }
+
+    fn circuit_failure_threshold_default() -> usize {
+        10
+    }
+
+    fn circuit_reset_timeout_default() -> Duration {
+        Duration::from_secs(15)
+    }
+
+    fn circuit_half_open_success_threshold_default() -> usize {
+        3
     }
 
     #[inline]
@@ -113,6 +152,10 @@ impl PluginConfig {
             "storage": storage,
             "cleanup_count": self.cleanup_count,
             "timeout": format!("{:?}", self.timeout),
+            "circuit_breaker_enabled": self.circuit_breaker_enabled,
+            "circuit_failure_threshold": self.circuit_failure_threshold,
+            "circuit_reset_timeout": format!("{:?}", self.circuit_reset_timeout),
+            "circuit_half_open_success_threshold": self.circuit_half_open_success_threshold,
         })
     }
 }

--- a/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
@@ -207,7 +207,7 @@ impl MessageMgr {
                 let receiveds = mgr.topic_tree.read().await.values_size();
                 let exec_active_count = mgr.exec.active_count();
                 let exec_waiting_count = mgr.exec.waiting_count();
-                let storage_info = mgr.storage_db.info().await.unwrap_or_default();
+                let storage_info = mgr.storage_info().await;
                 let cost_time = format!("{:?}", now.elapsed());
                 serde_json::json!({
                     "storage_info": storage_info,
@@ -218,7 +218,11 @@ impl MessageMgr {
                         "cost_time":cost_time,
                     },
                     "exec_active_count": exec_active_count,
-                    "exec_waiting_count": exec_waiting_count
+                    "exec_waiting_count": exec_waiting_count,
+                    "circuit_breaker": {
+                        "enabled": mgr.circuit_breaker.config().enabled,
+                        "state": format!("{:?}", mgr.circuit_breaker.state()),
+                    },
                 })
             }
             #[allow(unreachable_patterns)]

--- a/rmqtt-plugins/rmqtt-message-storage/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/storage.rs
@@ -29,9 +29,10 @@ use rmqtt::{
         ClientId, ForwardedRecipients, From, MsgID, NodeId, Publish, SharedGroup, StoredMessage,
         TimestampMillis, Topic, TopicFilter,
     },
-    utils::timestamp_millis,
+    utils::{timestamp_millis, CircuitBreaker, CircuitBreakerConfig},
     Result,
 };
+use serde_json::{self, json};
 
 use rmqtt::topic::Level;
 use rmqtt_storage::{DefaultStorageDB, Map, StorageMap};
@@ -109,6 +110,14 @@ impl StorageMessageManager {
         let msg_queue_count = Arc::new(AtomicIsize::new(0));
         let timeout = cfg.timeout;
 
+        // Build the circuit breaker from config.
+        let circuit_breaker = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: cfg.circuit_breaker_enabled,
+            failure_threshold: cfg.circuit_failure_threshold,
+            reset_timeout: cfg.circuit_reset_timeout,
+            half_open_success_threshold: cfg.circuit_half_open_success_threshold,
+        });
+
         // Build the shared inner state first, so workers can clone it.
         let inner = Arc::new(StorageMessageManagerInner {
             storage_db,
@@ -118,6 +127,7 @@ impl StorageMessageManager {
             msg_queue_count: msg_queue_count.clone(),
             id_generater,
             timeout,
+            circuit_breaker,
         });
 
         // Spawn N worker tasks — one per routing bucket.
@@ -136,8 +146,23 @@ impl StorageMessageManager {
                 let mut rx = rx;
                 while let Some(msg) = rx.next().await {
                     inner.msg_queue_count.fetch_sub(1, Ordering::Relaxed);
-                    if let Err(e) = inner._process_single(msg).await {
-                        log::warn!("worker {} _process_single error: {:?}", i, e);
+
+                    // When the circuit breaker is OPEN, skip all queued messages
+                    // without touching Redis. This prevents the channel backlog
+                    // (64×5000 = 320K messages) from blocking workers for hours
+                    // while each message waits for a Redis timeout.
+                    // is_blocked() also handles OPEN→HALF_OPEN transitions,
+                    // so when a probe is due, the next message will be processed.
+                    if inner.circuit_breaker.is_blocked() {
+                        continue;
+                    }
+
+                    match inner._process_single(msg).await {
+                        Ok(()) => inner.circuit_breaker.record_success(),
+                        Err(e) => {
+                            log::warn!("worker {} _process_single error: {:?}", i, e);
+                            inner.circuit_breaker.record_failure();
+                        }
                     }
                 }
 
@@ -259,6 +284,9 @@ pub struct StorageMessageManagerInner {
 
     /// Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
     timeout: Duration,
+
+    /// Circuit breaker for Redis failure detection and fast-fall degradation.
+    pub(crate) circuit_breaker: CircuitBreaker,
 }
 
 impl StorageMessageManagerInner {
@@ -375,8 +403,7 @@ impl StorageMessageManagerInner {
                     self.storage_save_msg_id().await
                 };
                 if let Err(e) = result {
-                    log::warn!("save message id error, {e:?}");
-                    return Ok(());
+                    return Err(anyhow!("save message id error: {:?}", e));
                 }
 
                 let mut topic = match Topic::from_str(&publish.topic) {
@@ -407,7 +434,7 @@ impl StorageMessageManagerInner {
                         Ok(map) => map,
                         Err(e) => {
                             log::warn!("store to db error, map_expire(..), {e:?}, message: {smsg:?}");
-                            return Ok(());
+                            return Err(anyhow!("storage_db.map error: {:?}", e));
                         }
                     }
                 };
@@ -422,7 +449,7 @@ impl StorageMessageManagerInner {
                 };
                 if let Err(e) = insert_result {
                     log::warn!("store to db error, {e:?}, message: {smsg:?}");
-                    return Ok(());
+                    return Err(anyhow!("msg_map.insert error: {:?}", e));
                 }
 
                 if let Some(recipients) = recipients {
@@ -435,17 +462,14 @@ impl StorageMessageManagerInner {
                 self.topic_list.write().await.insert((expiry_time_at, topic));
 
                 self.messages_received_count_add(1);
-                let counter_result = if timeout > Duration::ZERO {
+                if timeout > Duration::ZERO {
                     self.storage_messages_counter_add(1)
                         .timeout(futures_time::time::Duration::from(timeout))
                         .await
-                        .map_err(|_e| anyhow!("storage_messages_counter_add timeout"))?
+                        .map_err(|_e| anyhow!("storage_messages_counter_add timeout"))??
                 } else {
-                    self.storage_messages_counter_add(1).await
+                    self.storage_messages_counter_add(1).await?
                 };
-                if let Err(e) = counter_result {
-                    log::warn!("messages_received_counter add error, {e:?}");
-                }
             }
             Msg::MarkForwarded { msg_id, recipients } => {
                 let msg_key = msg_id.to_be_bytes();
@@ -462,8 +486,7 @@ impl StorageMessageManagerInner {
                     match map_result {
                         Ok(map) => map,
                         Err(e) => {
-                            log::warn!("add_forwardeds map error, {e:?}");
-                            return Ok(());
+                            return Err(anyhow!("add_forwardeds map error: {:?}", e));
                         }
                     }
                 };
@@ -472,25 +495,20 @@ impl StorageMessageManagerInner {
                         .contains_key(DATA)
                         .timeout(futures_time::time::Duration::from(timeout))
                         .await
-                        .map_err(|_e| anyhow!("add_forwardeds contains_key timeout"))?
+                        .map_err(|_e| anyhow!("add_forwardeds contains_key timeout"))??
                 } else {
-                    msg_map.contains_key(DATA).await
+                    msg_map.contains_key(DATA).await?
                 };
                 match contains_result {
-                    Ok(true) => {
-                        if let Err(e) = self._forwardeds(&msg_map, recipients).await {
-                            log::warn!("add_forwardeds _forwardeds error, {e:?}");
-                        }
+                    true => {
+                        self._forwardeds(&msg_map, recipients).await?;
                     }
-                    Ok(false) => {
+                    false => {
                         log::warn!(
                             "add_forwardeds: msg_id {:?} not found in storage, recipients: {:?}",
                             msg_id,
                             recipients
                         );
-                    }
-                    Err(e) => {
-                        log::warn!("add_forwardeds: msg_id {:?} contains_key error: {:?}", msg_id, e);
                     }
                 }
             }
@@ -502,23 +520,15 @@ impl StorageMessageManagerInner {
     async fn _forwardeds(&self, msg_map: &StorageMap, forwardeds: ForwardedRecipients) -> Result<()> {
         let timeout = self.timeout;
         for (client_id, opts) in forwardeds {
-            let insert_result = if timeout > Duration::ZERO {
+            if timeout > Duration::ZERO {
                 msg_map
                     .insert(Self::make_forwarded_key(&client_id), &opts)
                     .timeout(futures_time::time::Duration::from(timeout))
                     .await
-                    .map_err(|_e| anyhow!("_forwardeds insert timeout"))?
+                    .map_err(|_e| anyhow!("_forwardeds insert timeout"))??
             } else {
-                msg_map.insert(Self::make_forwarded_key(&client_id), &opts).await
+                msg_map.insert(Self::make_forwarded_key(&client_id), &opts).await?
             };
-            if let Err(e) = insert_result {
-                log::warn!(
-                    "_forwardeds error, client_id: {:?}, msg_map name: {:?}, error: {:?}",
-                    client_id,
-                    String::from_utf8_lossy(msg_map.name()),
-                    e,
-                );
-            }
         }
         Ok(())
     }
@@ -540,34 +550,56 @@ impl StorageMessageManagerInner {
             inner.topic_tree.read().await.matches(&topic).into_iter().map(|(_t, msg_id)| msg_id).collect();
 
         log::debug!("_get matcheds msg_ids: {matcheds:?}");
-        let matcheds = futures::future::join_all(matcheds.into_iter().map(|msg_id| async move {
-            let msg_key = msg_id.to_be_bytes();
-            let msg_map = self.storage_db.map(msg_key, None).await;
-            match msg_map {
-                Ok(mut msg_map) => {
-                    let is_forwarded = self
-                        ._is_forwarded(&mut msg_map, client_id, topic_filter, group)
-                        .await
-                        .unwrap_or_default();
+        let storage_err_count = AtomicUsize::new(0);
+        let matcheds: Vec<_> = futures::future::join_all(matcheds.into_iter().map(|msg_id| {
+            let storage_err = &storage_err_count;
+            async move {
+                let msg_key = msg_id.to_be_bytes();
+                let msg_map = self.storage_db.map(msg_key, None).await;
+                match msg_map {
+                    Ok(mut msg_map) => {
+                        let is_forwarded =
+                            match self._is_forwarded(&mut msg_map, client_id, topic_filter, group).await {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    log::warn!("_get _is_forwarded error, {e:?}");
+                                    storage_err.fetch_add(1, Ordering::Relaxed);
+                                    return None;
+                                }
+                            };
 
-                    if is_forwarded {
-                        None
-                    } else if let Ok(Some(msg)) = inner._get_message(&msg_map).await {
-                        log::debug!("_get msg: {:?}, msg.is_expiry(): {}", msg, msg.is_expiry());
-                        if msg.is_expiry()
-                            || msg.publish.target_clientid.as_ref().is_some_and(|t_cid| t_cid != client_id)
-                        {
+                        if is_forwarded {
                             None
                         } else {
-                            Some((msg_id, msg.from, msg.publish))
+                            match inner._get_message(&msg_map).await {
+                                Ok(Some(msg)) => {
+                                    log::debug!("_get msg: {:?}, msg.is_expiry(): {}", msg, msg.is_expiry());
+                                    if msg.is_expiry()
+                                        || msg
+                                            .publish
+                                            .target_clientid
+                                            .as_ref()
+                                            .is_some_and(|t_cid| t_cid != client_id)
+                                    {
+                                        None
+                                    } else {
+                                        Some((msg_id, msg.from, msg.publish))
+                                    }
+                                }
+                                Ok(None) => None,
+                                Err(e) => {
+                                    log::warn!("_get_message error, {e:?}");
+                                    storage_err.fetch_add(1, Ordering::Relaxed);
+                                    None
+                                }
+                            }
                         }
-                    } else {
+                    }
+                    Err(e) => {
+                        log::warn!("_get new map error, {e:?}");
+                        storage_err.fetch_add(1, Ordering::Relaxed);
                         None
                     }
-                }
-                Err(e) => {
-                    log::warn!("_get new map error, {e:?}");
-                    None
                 }
             }
         }))
@@ -575,6 +607,14 @@ impl StorageMessageManagerInner {
         .into_iter()
         .flatten()
         .collect();
+
+        if storage_err_count.load(Ordering::Relaxed) > 0 {
+            self.circuit_breaker.record_failure();
+        } else if !matcheds.is_empty() {
+            // Only record success if we actually touched Redis.
+            // Zero matcheds = no map() calls = unknown Redis state.
+            self.circuit_breaker.record_success();
+        }
 
         Ok(matcheds)
     }
@@ -618,6 +658,16 @@ impl StorageMessageManagerInner {
     async fn _get_message(&self, msg_map: &StorageMap) -> Result<Option<StoredMessage>> {
         msg_map.get::<_, StoredMessage>(DATA).await
     }
+
+    /// Return storage backend info, with circuit breaker fast-path.
+    /// When the circuit is OPEN, skip the Redis call and return an "unavailable"
+    /// marker instead of waiting for a timeout.
+    pub(crate) async fn storage_info(&self) -> serde_json::Value {
+        if self.circuit_breaker.is_blocked() {
+            return json!({"status": "unavailable"});
+        }
+        self.storage_db.info().await.unwrap_or_default()
+    }
 }
 
 #[async_trait]
@@ -636,6 +686,10 @@ impl MessageManager for StorageMessageManager {
         expiry_interval: Duration,
         recipients: Option<ForwardedRecipients>,
     ) -> Result<()> {
+        if self.circuit_breaker.is_blocked() {
+            log::debug!("circuit breaker OPEN: skip store for msg_id {:?}", msg_id);
+            return Ok(());
+        }
         let msg = Msg::Store { from, publish: p, expiry_interval, msg_id, recipients };
         self.route_msg(msg).await
     }
@@ -647,6 +701,10 @@ impl MessageManager for StorageMessageManager {
         topic_filter: &str,
         group: Option<&SharedGroup>,
     ) -> Result<Vec<(MsgID, From, Publish)>> {
+        if self.circuit_breaker.is_blocked() {
+            log::debug!("circuit breaker OPEN: skip get");
+            return Ok(vec![]);
+        }
         let now = std::time::Instant::now();
         let inner = self.inner.clone();
         let client_id = ClientId::from(client_id);
@@ -673,6 +731,7 @@ impl MessageManager for StorageMessageManager {
             }
             Err(e) => {
                 log::warn!("StorageMessageManager get timeout, {e:?}");
+                self.circuit_breaker.record_failure();
                 vec![]
             }
         };
@@ -688,6 +747,10 @@ impl MessageManager for StorageMessageManager {
 
     #[inline]
     async fn mark_forwarded(&self, msg_id: MsgID, recipients: ForwardedRecipients) -> Result<()> {
+        if self.circuit_breaker.is_blocked() {
+            log::debug!("circuit breaker OPEN: skip mark_forwarded for msg_id {:?}", msg_id);
+            return Ok(());
+        }
         // Route to the worker responsible for this msg_id.
         // Because the worker processes messages sequentially (one batch at a time),
         // the corresponding `Store` for the same `msg_id` is guaranteed

--- a/rmqtt-utils/Cargo.toml
+++ b/rmqtt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-utils"
-version = "0.1.4"
+version = "0.1.5"
 description = "Essential utilities for RMQTT system operations."
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-utils"
 edition.workspace = true

--- a/rmqtt-utils/README-CN.md
+++ b/rmqtt-utils/README-CN.md
@@ -113,6 +113,43 @@ impl Counter {
 pub enum StatsMergeMode { None, Sum, Average, Max, Min }
 ```
 
+## `CircuitBreaker` — 无锁熔断器
+
+```rust
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    pub enabled: bool,                           // 默认: false
+    pub failure_threshold: usize,                // 默认: 10
+    pub reset_timeout: Duration,                 // 默认: 15s
+    pub half_open_success_threshold: usize,      // 默认: 3
+}
+
+pub enum CircuitState { Closed, Open, HalfOpen }
+
+impl CircuitBreaker {
+    pub fn new(config: CircuitBreakerConfig) -> Self;
+
+    /// 返回 true 表示电路 OPEN，调用方应跳过外部操作。
+    /// 副作用：reset_timeout 到期后自动将 OPEN → HALF_OPEN。
+    pub fn is_blocked(&self) -> bool;
+    pub fn record_success(&self);
+    pub fn record_failure(&self);
+    pub fn state(&self) -> CircuitState;
+    pub fn reset(&self);
+    pub fn config(&self) -> &CircuitBreakerConfig;
+}
+```
+
+纯原子操作、零锁的熔断器，用于主动故障检测。
+状态机：`Closed ⇄ Open ⇄ HalfOpen`。通过 `Arc<CircuitBreaker>` 跨线程共享。
+`rmqtt-message-storage` 使用它来避免 Redis 不可用时阻塞 Broker。
+
+| 状态 | 行为 |
+|------|------|
+| **Closed** | 正常放行，统计连续失败次数 |
+| **Open** | `is_blocked()` 返回 `true`，调用方快速跳过外部操作 |
+| **HalfOpen** | 探测阶段，放行请求；连续成功足够次后关闭，任意失败立即回到 Open |
+
 ## 安全性
 
 `#![deny(unsafe_code)]` — 零 unsafe 代码。

--- a/rmqtt-utils/README.md
+++ b/rmqtt-utils/README.md
@@ -113,6 +113,45 @@ impl Counter {
 pub enum StatsMergeMode { None, Sum, Average, Max, Min }
 ```
 
+## `CircuitBreaker` — lock‑free fast‑fail degradation
+
+```rust
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    pub enabled: bool,                           // default: false
+    pub failure_threshold: usize,                // default: 10
+    pub reset_timeout: Duration,                 // default: 15s
+    pub half_open_success_threshold: usize,      // default: 3
+}
+
+pub enum CircuitState { Closed, Open, HalfOpen }
+
+impl CircuitBreaker {
+    pub fn new(config: CircuitBreakerConfig) -> Self;
+
+    /// Returns true if the circuit is OPEN and the caller should skip
+    /// the external operation. Side‑effect: transitions OPEN → HALF_OPEN
+    /// after reset_timeout has elapsed.
+    pub fn is_blocked(&self) -> bool;
+    pub fn record_success(&self);
+    pub fn record_failure(&self);
+    pub fn state(&self) -> CircuitState;
+    pub fn reset(&self);
+    pub fn config(&self) -> &CircuitBreakerConfig;
+}
+```
+
+A pure‑atomics, zero‑lock circuit breaker for proactive failure detection.
+State machine: `Closed ⇄ Open ⇄ HalfOpen`. Shared safely across threads
+via `Arc<CircuitBreaker>`. Used by `rmqtt-message-storage` to avoid
+blocking the broker when Redis is unreachable.
+
+| State | Behaviour |
+|-------|-----------|
+| **Closed** | Normal operation. Counts consecutive failures. |
+| **Open** | `is_blocked()` returns `true`. All callers skip the external op. |
+| **HalfOpen** | Probe phase. Allows requests through; closes after enough consecutive successes or re‑opens on any failure. |
+
 ## Safety
 
 `#![deny(unsafe_code)]` — zero unsafe code.

--- a/rmqtt-utils/src/circuit_breaker.rs
+++ b/rmqtt-utils/src/circuit_breaker.rs
@@ -1,0 +1,431 @@
+//! Thread-safe circuit breaker for proactive failure detection and fast-fail degradation.
+//!
+//! ## State Machine
+//!
+//! ```text
+//!                record_failure() ≥ threshold
+//!     CLOSED ──────────────────────────────────► OPEN
+//!       ▲                                          │
+//!       │                     reset_timeout elapsed │
+//!       │                                          ▼
+//!       │                                  ┌──────────────┐
+//!       │         record_success()         │  HALF_OPEN    │
+//!       ◄──────────────── (≥ threshold) ───│ (probe phase) │
+//!                                          └──────────────┘
+//! ```
+//!
+//! - **CLOSED**: Normal operation. Counts consecutive failures.
+//! - **OPEN**: Fail fast — all callers skip the external operation.
+//! - **HALF_OPEN**: Allow probe requests. If enough consecutive successes occur, transition
+//!   back to CLOSED. If any failure occurs, transition back to OPEN.
+//!
+//! ## Zero-Lock Design
+//!
+//! All state transitions use atomic operations with `SeqCst` ordering for
+//! consistent cross-thread visibility. No `Mutex` or `RwLock` is needed.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use rmqtt_utils::{CircuitBreaker, CircuitBreakerConfig};
+//! use std::time::Duration;
+//!
+//! let cb = CircuitBreaker::new(CircuitBreakerConfig {
+//!     enabled: true,
+//!     failure_threshold: 5,
+//!     reset_timeout: Duration::from_secs(30),
+//!     half_open_success_threshold: 3,
+//! });
+//!
+//! // Before calling an external operation, check if the circuit is blocked:
+//! if !cb.is_blocked() {
+//!     // ... perform operation ...
+//!     let success = true; // replace with actual result
+//!     if success {
+//!         cb.record_success();
+//!     } else {
+//!         cb.record_failure();
+//!     }
+//! }
+//! ```
+
+use std::fmt;
+use std::sync::atomic::{AtomicI64, AtomicU8, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use crate::timestamp_millis;
+
+// ─── State constants ─────────────────────────────────────────────────────────
+
+const CLOSED: u8 = 0;
+const OPEN: u8 = 1;
+const HALF_OPEN: u8 = 2;
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/// Circuit breaker operational states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitState {
+    /// Normal operation — requests are allowed through.
+    Closed,
+    /// Fail-fast — requests are blocked without attempting the external call.
+    Open,
+    /// Probe phase — a limited number of requests are allowed to test recovery.
+    HalfOpen,
+}
+
+/// Configuration for [`CircuitBreaker`].
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [message-storage.circuit_breaker]
+/// enabled = true
+/// failure_threshold = 5
+/// reset_timeout = "30s"
+/// half_open_success_threshold = 3
+/// ```
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    /// Whether the circuit breaker is active. When `false`, all operations pass
+    /// through unchecked.
+    pub enabled: bool,
+
+    /// Number of consecutive failures in CLOSED state before tripping to OPEN.
+    pub failure_threshold: usize,
+
+    /// Duration to wait in OPEN state before transitioning to HALF_OPEN for a probe.
+    pub reset_timeout: Duration,
+
+    /// Number of consecutive successes in HALF_OPEN state before transitioning
+    /// back to CLOSED.
+    ///
+    /// A value of `1` means a single successful probe closes the circuit.
+    /// Higher values provide more confidence before full recovery.
+    pub half_open_success_threshold: usize,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            failure_threshold: 5,
+            reset_timeout: Duration::from_secs(30),
+            half_open_success_threshold: 1,
+        }
+    }
+}
+
+// ─── Circuit breaker ──────────────────────────────────────────────────────────
+
+/// A lock-free, thread-safe circuit breaker for fast-fail degradation.
+///
+/// All state transitions are atomic; no locks or wait mechanisms are used.
+/// See the [module-level documentation](self) for the state machine description
+/// and usage example.
+pub struct CircuitBreaker {
+    state: AtomicU8,
+    failure_count: AtomicUsize,
+    opened_at: AtomicI64,
+    success_count: AtomicUsize,
+    config: CircuitBreakerConfig,
+}
+
+impl fmt::Debug for CircuitBreaker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CircuitBreaker")
+            .field("state", &self.state())
+            .field("failure_count", &self.failure_count.load(Ordering::Relaxed))
+            .field("success_count", &self.success_count.load(Ordering::Relaxed))
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+impl CircuitBreaker {
+    /// Create a new circuit breaker with the given configuration.
+    #[inline]
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            state: AtomicU8::new(CLOSED),
+            failure_count: AtomicUsize::new(0),
+            opened_at: AtomicI64::new(0),
+            success_count: AtomicUsize::new(0),
+            config,
+        }
+    }
+
+    /// Returns `true` **iff** the circuit is OPEN and the caller should **skip**
+    /// the external operation.
+    ///
+    /// Side effects (atomic transitions):
+    /// - OPEN → HALF_OPEN after `reset_timeout` has elapsed (at most one thread
+    ///   will perform the transition; others still see OPEN and are blocked).
+    /// - CLOSED, HALF_OPEN → no transition.
+    #[inline]
+    pub fn is_blocked(&self) -> bool {
+        if !self.config.enabled {
+            return false;
+        }
+
+        let state = self.state.load(Ordering::Acquire);
+
+        match state {
+            CLOSED => false,
+            HALF_OPEN => false,
+            OPEN => {
+                // Check whether it is time to attempt a probe.
+                let elapsed_ms = (crate::timestamp_millis() - self.opened_at.load(Ordering::Relaxed)) as u64;
+                let reset_ms = self.config.reset_timeout.as_millis() as u64;
+
+                if elapsed_ms >= reset_ms {
+                    // Reset success counter before entering HALF_OPEN.
+                    self.success_count.store(0, Ordering::Release);
+                    self.state.store(HALF_OPEN, Ordering::Release);
+                    false
+                } else {
+                    true
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Record a successful call.
+    ///
+    /// - **CLOSED**: reset the `failure_count` to 0.
+    /// - **HALF_OPEN**: increment success count; if it reaches
+    ///   `half_open_success_threshold`, transition to CLOSED and reset all counters.
+    /// - **OPEN**: no-op.
+    #[inline]
+    pub fn record_success(&self) {
+        let state = self.state.load(Ordering::Acquire);
+
+        match state {
+            CLOSED => {
+                self.failure_count.store(0, Ordering::Release);
+            }
+            HALF_OPEN => {
+                let c = self.success_count.fetch_add(1, Ordering::SeqCst) + 1;
+                if c >= self.config.half_open_success_threshold {
+                    self.state.store(CLOSED, Ordering::Release);
+                    self.failure_count.store(0, Ordering::Release);
+                    self.success_count.store(0, Ordering::Release);
+                    log::info!("circuit breaker: CLOSED (recovered)");
+                }
+            }
+            OPEN => {
+                // No-op: failures may still be in-flight after the state
+                // transition; we ignore individual successes while OPEN.
+            }
+            _ => {}
+        }
+    }
+
+    /// Record a failed call.
+    ///
+    /// - **CLOSED**: increment `failure_count`; if it reaches
+    ///   `failure_threshold`, transition to OPEN and record the timestamp.
+    /// - **HALF_OPEN**: transition immediately back to OPEN (probe failed).
+    /// - **OPEN**: no-op (already open).
+    #[inline]
+    pub fn record_failure(&self) {
+        let state = self.state.load(Ordering::Acquire);
+
+        match state {
+            CLOSED => {
+                let c = self.failure_count.fetch_add(1, Ordering::SeqCst) + 1;
+                if c >= self.config.failure_threshold {
+                    self.state.store(OPEN, Ordering::Release);
+                    self.opened_at.store(timestamp_millis(), Ordering::Release);
+                    log::warn!(
+                        "circuit breaker: OPEN ({} consecutive failures, threshold: {})",
+                        c,
+                        self.config.failure_threshold
+                    );
+                }
+            }
+            HALF_OPEN => {
+                self.state.store(OPEN, Ordering::Release);
+                self.opened_at.store(timestamp_millis(), Ordering::Release);
+                log::warn!("circuit breaker: OPEN (half-open probe failed)");
+            }
+            OPEN => {
+                // No-op: already open; no need to update the timestamp.
+            }
+            _ => {}
+        }
+    }
+
+    /// Return the current circuit state (no side effects).
+    #[inline]
+    pub fn state(&self) -> CircuitState {
+        match self.state.load(Ordering::Acquire) {
+            CLOSED => CircuitState::Closed,
+            OPEN => CircuitState::Open,
+            HALF_OPEN => CircuitState::HalfOpen,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Manually reset the circuit breaker to CLOSED state.
+    ///
+    /// This is useful after administrative recovery of the downstream service.
+    #[inline]
+    pub fn reset(&self) {
+        self.state.store(CLOSED, Ordering::Release);
+        self.failure_count.store(0, Ordering::Release);
+        self.success_count.store(0, Ordering::Release);
+        self.opened_at.store(0, Ordering::Release);
+        log::info!("circuit breaker: CLOSED (manual reset)");
+    }
+
+    /// Borrow the configuration (for inspection / logging).
+    #[inline]
+    pub fn config(&self) -> &CircuitBreakerConfig {
+        &self.config
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_disabled_passes_through() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig { enabled: false, ..Default::default() });
+        assert!(!cb.is_blocked());
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_closed_then_open() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 3,
+            reset_timeout: Duration::from_secs(60),
+            half_open_success_threshold: 1,
+        });
+        assert!(!cb.is_blocked());
+
+        // 2 failures — still closed
+        cb.record_failure();
+        cb.record_failure();
+        assert!(!cb.is_blocked());
+
+        // 3rd failure — trip
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+        assert!(cb.is_blocked());
+    }
+
+    #[test]
+    fn test_open_recovers_to_half_open_after_timeout() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 1,
+            reset_timeout: Duration::from_millis(1), // very short
+            half_open_success_threshold: 1,
+        });
+
+        // Trip to OPEN
+        cb.record_failure();
+        assert!(cb.is_blocked());
+
+        // Wait for reset_timeout
+        std::thread::sleep(Duration::from_millis(5));
+
+        // Should now transition to HALF_OPEN
+        assert!(!cb.is_blocked());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn test_half_open_success_closes() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 1,
+            reset_timeout: Duration::from_millis(1),
+            half_open_success_threshold: 2, // need 2 successes
+        });
+
+        // Trip to OPEN
+        cb.record_failure();
+        // Wait for timeout
+        std::thread::sleep(Duration::from_millis(5));
+
+        // Transition to HALF_OPEN
+        assert!(!cb.is_blocked());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        // 1st success — still HALF_OPEN
+        cb.record_success();
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        // 2nd success — CLOSED
+        cb.record_success();
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_half_open_failure_reopens() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 1,
+            reset_timeout: Duration::from_millis(1),
+            half_open_success_threshold: 1,
+        });
+
+        // Trip → wait → HALF_OPEN
+        cb.record_failure();
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(!cb.is_blocked());
+
+        // Probe fails → back to OPEN
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+        assert!(cb.is_blocked());
+    }
+
+    #[test]
+    fn test_reset() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 1,
+            ..Default::default()
+        });
+
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        cb.reset();
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(!cb.is_blocked());
+    }
+
+    #[test]
+    fn test_success_clears_failure_count_in_closed() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 5,
+            ..Default::default()
+        });
+
+        // 2 failures then a success
+        cb.record_failure();
+        cb.record_failure();
+        cb.record_success();
+
+        // Should need 5 more failures to trip
+        cb.record_failure();
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed); // only 3 since reset
+
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+    }
+}

--- a/rmqtt-utils/src/lib.rs
+++ b/rmqtt-utils/src/lib.rs
@@ -6,6 +6,7 @@
 //! - **Timestamp Utilities**: Precise timestamp handling with millisecond resolution
 //! - **Network Addressing**: Cluster node address parsing ([`NodeAddr`]) and socket address handling
 //! - **Counter Implementation**: Thread-safe counter with merge modes ([`Counter`])
+//! - **Circuit Breaker**: Lock-free fast-fail degradation for external service calls ([`CircuitBreaker`])
 //!
 //! ## Key Components:
 //! - `Bytesize`: Handles 2G512M-style conversions with serialization support
@@ -80,8 +81,10 @@ use serde::{
     Deserialize, Serialize,
 };
 
+mod circuit_breaker;
 mod counter;
 
+pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, CircuitState};
 pub use counter::{Counter, StatsMergeMode};
 
 /// Cluster node identifier type (64-bit unsigned integer)


### PR DESCRIPTION
**Problem**
When Redis becomes unavailable, all storage operations time out after the configured `timeout`, causing message store/forward/get operations to block for extended periods. This degrades broker performance and can lead to resource exhaustion under sustained Redis failures.

**Solution**
Add a lock‑free circuit breaker to the message storage plugin. When consecutive storage failures exceed the configured threshold, the circuit trips to OPEN state and all operations return immediately without touching Redis. The circuit automatically probes for recovery after a reset timeout.

**Key Changes**

Circuit Breaker (rmqtt-utils):
- Add `CircuitBreaker` type with pure-atomics, zero-lock implementation
- States: Closed → Open → HalfOpen → Closed
- `is_blocked()` returns true when circuit is OPEN
- `record_success()` / `record_failure()` update state and failure counters
- Configurable: failure_threshold, reset_timeout, half_open_success_threshold

Message Storage Plugin:
- Add circuit breaker configuration options:
  - `circuit_breaker_enabled` (default: true)
  - `circuit_failure_threshold` (default: 10)
  - `circuit_reset_timeout` (default: "15s")
  - `circuit_half_open_success_threshold` (default: 3)
- Apply circuit breaker to storage operations:
  - `store()`: skip when OPEN (return Ok immediately)
  - `mark_forwarded()`: skip when OPEN
  - `get()`: skip when OPEN (return empty list)
  - Worker loop: skip queued messages when OPEN (prevent backlog blocking)
- Record success/failure per worker
- Expose circuit breaker state in plugin attributes (JSON)

Documentation:
- Add circuit breaker section to message-storage README (EN/ZH)
- Include state machine diagram and configuration table
- Update rmqtt-utils README with CircuitBreaker API docs
- Add example config to rmqtt-message-storage.toml
- Bump rmqtt-utils to 0.1.5

**Benefits**
- Fast-fail degradation when Redis is down
- Prevents workers from blocking on queued messages during outages
- Automatic recovery probing without manual intervention
- Full observability via state reporting in plugin attributes
- No locks, pure atomics for minimal overhead