### PR TITLE
refactor(msgstore): remove merge_on_read and TaskExecQueue, add with_…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ target/
 /CODEBUDDY.md
 /code-review-report
 /docs/architecture
+/overview.md

--- a/README-CN.md
+++ b/README-CN.md
@@ -2,6 +2,7 @@
 
 [![GitHub Release](https://img.shields.io/github/release/rmqtt/rmqtt?color=brightgreen)](https://github.com/rmqtt/rmqtt/releases)
 [![Rust Version](https://img.shields.io/badge/rust-1.89.0%2B-blue)](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rmqtt/rmqtt)
 [![crates.io](https://img.shields.io/crates/v/rmqtt.svg)](https://crates.io/crates/rmqtt)
 [![docs.rs](https://docs.rs/rmqtt/badge.svg)](https://docs.rs/rmqtt/latest/rmqtt/)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub Release](https://img.shields.io/github/release/rmqtt/rmqtt?color=brightgreen)](https://github.com/rmqtt/rmqtt/releases)
 [![Rust Version](https://img.shields.io/badge/rust-1.89.0%2B-blue)](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rmqtt/rmqtt)
 [![crates.io](https://img.shields.io/crates/v/rmqtt.svg)](https://crates.io/crates/rmqtt)
 [![docs.rs](https://docs.rs/rmqtt/badge.svg)](https://docs.rs/rmqtt/latest/rmqtt/)
 

--- a/rmqtt-plugins/rmqtt-cluster-broadcast.toml
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast.toml
@@ -15,4 +15,10 @@ node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
 node_grpc_client_timeout = "15s"
 
+##Task execution queue workers
+task_exec_queue_workers = 500
+
+##Task execution queue max capacity
+task_exec_queue_max = 100_000
+
 

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/README-CN.md
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/README-CN.md
@@ -28,6 +28,8 @@ rmqtt_cluster_broadcast::register(&scx, true, false).await?;
 | `node_grpc_batch_size` | integer | `128` | 批量发送的最大消息数 |
 | `node_grpc_client_concurrency_limit` | integer | `128` | 客户端并发请求限制 |
 | `node_grpc_client_timeout` | string | `"60s"` | 连接和发送超时 |
+| `task_exec_queue_workers` | integer | `500` | 任务执行队列工作线程数 |
+| `task_exec_queue_max` | integer | `100_000` | 任务执行队列最大容量 |
 
 ## 依赖
 

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/README.md
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/README.md
@@ -28,6 +28,8 @@ File: `rmqtt-cluster-broadcast.toml`
 | `node_grpc_batch_size` | integer | `128` | Maximum messages sent in batch |
 | `node_grpc_client_concurrency_limit` | integer | `128` | Client concurrent request limit |
 | `node_grpc_client_timeout` | string | `"60s"` | Connect and send timeout |
+| `task_exec_queue_workers` | integer | `500` | Task execution queue workers |
+| `task_exec_queue_max` | integer | `100_000` | Task execution queue max capacity |
 
 ## Dependencies
 

--- a/rmqtt-plugins/rmqtt-message-storage.toml
+++ b/rmqtt-plugins/rmqtt-message-storage.toml
@@ -8,7 +8,7 @@ storage.type = "ram"
 ##ram
 storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
-storage.ram.encode = true
+storage.ram.encode = false
 
 ##Maximum pending messages in the in-memory channel (back-pressure limit).
 ##Beyond this, new store requests are rejected.

--- a/rmqtt-plugins/rmqtt-message-storage/README-CN.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README-CN.md
@@ -33,9 +33,8 @@ rmqtt_message_storage::register(&scx, true, false).await?;
 | 选项 | 类型 | 默认值 | 描述 |
 |------|------|--------|------|
 | `storage.ram.cache_capacity` | string | `"3G"` | 内存缓存容量 |
-| `storage.ram.cache_max_count` | integer | `1_000_000` | 最大缓存条目数 |
-| `storage.ram.encode` | boolean | `true` | 启用消息编码 |
-| `storage.ram.workers` | integer | `1000` | 任务执行队列的工作线程数 |
+| `storage.ram.cache_max_count` | integer | `1_000_000` | 最大缓存条目数（无限制） |
+| `storage.ram.encode` | boolean | `false` | 启用消息编码 |
 | `storage.ram.queue_max` | integer | `300000` | 任务队列最大积压量（背压保护） |
 
 ### Redis 后端

--- a/rmqtt-plugins/rmqtt-message-storage/README.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README.md
@@ -33,9 +33,8 @@ File: `rmqtt-message-storage.toml`
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `storage.ram.cache_capacity` | string | `"3G"` | In-memory cache capacity |
-| `storage.ram.cache_max_count` | integer | `1_000_000` | Maximum cache entry count |
-| `storage.ram.encode` | boolean | `true` | Enable message encoding |
-| `storage.ram.workers` | integer | `1000` | Task execution queue worker threads |
+| `storage.ram.cache_max_count` | integer | `1_000_000` | Maximum cache entry count (unlimited) |
+| `storage.ram.encode` | boolean | `false` | Enable message encoding |
 | `storage.ram.queue_max` | integer | `300000` | Maximum task queue backlog (back-pressure limit) |
 
 ### Redis Backend

--- a/rmqtt-plugins/rmqtt-message-storage/src/config.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/config.rs
@@ -59,7 +59,7 @@ impl PluginConfig {
     }
 
     fn cleanup_count_default() -> usize {
-        2000
+        5000
     }
 
     fn timeout_default() -> Duration {
@@ -105,19 +105,9 @@ impl PluginConfig {
             }
             #[cfg(any(feature = "redis", feature = "redis-cluster"))]
             Some("redis") | Some("redis-cluster") => {
-                let backend_key = match typ {
-                    Some("redis") => "redis",
-                    _ => "redis-cluster",
-                };
-                let merge_on_read = storage
-                    .as_object()
-                    .and_then(|obj| obj.get(backend_key))
-                    .and_then(|v| v.get("merge_on_read"))
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(true);
                 match serde_json::from_value::<rmqtt_storage::Config>(storage) {
                     Err(e) => Err(de::Error::custom(e.to_string())),
-                    Ok(s_cfg) => Ok(Some(Config::Storage(s_cfg, merge_on_read))),
+                    Ok(s_cfg) => Ok(Some(Config::Storage(s_cfg))),
                 }
             }
             _ => Err(de::Error::custom(format!("Unsupported storage type, {typ:?}"))),
@@ -134,16 +124,7 @@ impl PluginConfig {
                 "ram": ram,
             }),
             #[cfg(any(feature = "redis", feature = "redis-cluster"))]
-            Some(Config::Storage(s_cfg, merge_on_read)) => {
-                let mut map = serde_json::to_value(s_cfg).unwrap_or_default();
-                if let Some(obj) = map.as_object_mut() {
-                    let backend_key = if obj.contains_key("redis") { "redis" } else { "redis-cluster" };
-                    if let Some(backend) = obj.get_mut(backend_key).and_then(|v| v.as_object_mut()) {
-                        backend.insert("merge_on_read".to_string(), serde_json::json!(*merge_on_read));
-                    }
-                }
-                map
-            }
+            Some(Config::Storage(s_cfg)) => serde_json::to_value(s_cfg).unwrap_or_default(),
             None => serde_json::Value::Null,
             #[allow(unreachable_patterns)]
             _ => serde_json::Value::Null,
@@ -166,7 +147,7 @@ pub enum Config {
     #[cfg(feature = "ram")]
     Ram(RamConfig),
     #[cfg(any(feature = "redis", feature = "redis-cluster"))]
-    Storage(rmqtt_storage::Config, bool),
+    Storage(rmqtt_storage::Config),
 }
 
 /// In-memory (RAM) storage configuration.
@@ -175,8 +156,6 @@ pub struct RamConfig {
     pub cache_capacity: Bytesize,
     pub cache_max_count: usize,
     pub encode: bool,
-    #[serde(default = "RamConfig::merge_on_read_default")]
-    pub merge_on_read: bool,
 
     /// Maximum number of pending tasks in the TaskExecQueue.
     /// Beyond this, new tasks are rejected.
@@ -189,20 +168,15 @@ impl Default for RamConfig {
     #[inline]
     fn default() -> Self {
         RamConfig {
-            cache_capacity: Bytesize::from(1024 * 1024 * 1024 * 2),
+            cache_capacity: Bytesize::from(1024 * 1024 * 1024 * 3),
             cache_max_count: usize::MAX,
             encode: false,
-            merge_on_read: true,
             queue_max: Self::queue_max_default(),
         }
     }
 }
 
 impl RamConfig {
-    fn merge_on_read_default() -> bool {
-        true
-    }
-
     fn queue_max_default() -> usize {
         300_000
     }

--- a/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
@@ -65,18 +65,12 @@ impl StoragePlugin {
         let result: Result<(MessageMgr, Arc<PluginConfig>)> = match cfg.storage.clone() {
             #[cfg(feature = "ram")]
             Some(config::Config::Ram(ram_cfg)) => {
-                if !ram_cfg.merge_on_read {
-                    log::warn!(
-                        "merge_on_read=false is not recommended when storage.type='ram', merge_on_read: {}",
-                        ram_cfg.merge_on_read
-                    );
-                }
                 let message_mgr =
                     RamMessageManager::new(ram_cfg.clone(), cfg.cleanup_count, cfg.timeout).await?;
                 Ok((MessageMgr::Ram(message_mgr), Arc::new(cfg)))
             }
             #[cfg(any(feature = "redis", feature = "redis-cluster"))]
-            Some(config::Config::Storage(mut s_cfg, _)) => {
+            Some(config::Config::Storage(mut s_cfg)) => {
                 let node_id = scx.node.id();
                 #[cfg(feature = "redis")]
                 {
@@ -93,8 +87,7 @@ impl StoragePlugin {
                 })?;
 
                 let cfg = Arc::new(cfg);
-                let message_mgr =
-                    StorageMessageManager::new(node_id, cfg.clone(), storage_db.clone()).await?;
+                let message_mgr = StorageMessageManager::new(cfg.clone(), storage_db.clone()).await?;
                 Ok((MessageMgr::Storage(message_mgr), cfg))
             }
             None => Err(anyhow!("No storage engine specified (ram, redis, or redis-cluster)")),
@@ -205,8 +198,6 @@ impl MessageMgr {
                 let msg_queue_count = mgr.msg_queue_count.load(std::sync::atomic::Ordering::Relaxed);
                 let topic_nodes = mgr.topic_tree.read().await.nodes_size();
                 let receiveds = mgr.topic_tree.read().await.values_size();
-                let exec_active_count = mgr.exec.active_count();
-                let exec_waiting_count = mgr.exec.waiting_count();
                 let storage_info = mgr.storage_info().await;
                 let cost_time = format!("{:?}", now.elapsed());
                 serde_json::json!({
@@ -217,8 +208,6 @@ impl MessageMgr {
                         "receiveds": receiveds,
                         "cost_time":cost_time,
                     },
-                    "exec_active_count": exec_active_count,
-                    "exec_waiting_count": exec_waiting_count,
                     "circuit_breaker": {
                         "enabled": mgr.circuit_breaker.config().enabled,
                         "state": format!("{:?}", mgr.circuit_breaker.state()),

--- a/rmqtt-plugins/rmqtt-message-storage/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/storage.rs
@@ -5,7 +5,6 @@
 //! with batch writes, topic-tree restoration, and expiry cleanup.
 
 use std::collections::BTreeSet;
-use std::convert::From as _;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
@@ -19,15 +18,14 @@ use futures::{
     {SinkExt, StreamExt},
 };
 use futures_time::{self, future::FutureExt};
-use rust_box::task_exec_queue::{Builder, SpawnExt, TaskExecQueue};
 use tokio::{runtime::Handle, sync::RwLock, task::spawn_blocking, time::sleep};
 
 use rmqtt::{
     message::MessageManager,
     retain::RetainTree,
     types::{
-        ClientId, ForwardedRecipients, From, MsgID, NodeId, Publish, SharedGroup, StoredMessage,
-        TimestampMillis, Topic, TopicFilter,
+        ForwardedRecipients, From, MsgID, Publish, SharedGroup, StoredMessage, TimestampMillis, Topic,
+        TopicFilter,
     },
     utils::{timestamp_millis, CircuitBreaker, CircuitBreakerConfig},
     Result,
@@ -73,7 +71,6 @@ enum Msg {
 #[derive(Clone)]
 pub struct StorageMessageManager {
     inner: Arc<StorageMessageManagerInner>,
-    pub(crate) exec: TaskExecQueue,
     /// One sender per worker.  Index = `msg_id % WORKER_COUNT`.
     worker_txs: Arc<Vec<mpsc::Sender<Msg>>>,
     /// Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
@@ -90,7 +87,6 @@ impl StorageMessageManager {
     /// corresponding `Store` message for the same `msg_id`.
     #[inline]
     pub(crate) async fn new(
-        _node_id: NodeId,
         cfg: Arc<PluginConfig>,
         storage_db: DefaultStorageDB,
     ) -> Result<StorageMessageManager> {
@@ -99,13 +95,6 @@ impl StorageMessageManager {
         let messages_received_max =
             StorageMessageManagerInner::storage_new_messages_counter(&storage_db).await?;
         log::info!("messages_received_max: {}", messages_received_max.load(Ordering::SeqCst));
-
-        let queue_max = 300_000;
-        let (exec, task_runner) = Builder::default().workers(1000).queue_max(queue_max).build();
-
-        tokio::spawn(async move {
-            task_runner.await;
-        });
 
         let msg_queue_count = Arc::new(AtomicIsize::new(0));
         let timeout = cfg.timeout;
@@ -222,7 +211,7 @@ impl StorageMessageManager {
             }
         });
 
-        Ok(Self { inner, exec, worker_txs: Arc::new(worker_txs), timeout })
+        Ok(Self { inner, worker_txs: Arc::new(worker_txs), timeout })
     }
 
     /// Route a message to the worker responsible for its `msg_id`.
@@ -290,6 +279,29 @@ pub struct StorageMessageManagerInner {
 }
 
 impl StorageMessageManagerInner {
+    /// Execute an async operation with an optional timeout.
+    ///
+    /// * When `timeout > Duration::ZERO`, wraps the future with the given timeout,
+    ///   converting timeout errors to `anyhow::Error`.
+    /// * When `timeout == Duration::ZERO`, runs the future directly.
+    ///
+    /// The inner error type `E` is converted to `anyhow::Error` via `Into<anyhow::Error>`.
+    #[inline]
+    async fn with_timeout<F, T, E>(fut: F, timeout: Duration, err_msg: &'static str) -> Result<T>
+    where
+        F: std::future::Future<Output = std::result::Result<T, E>>,
+        E: Into<anyhow::Error>,
+    {
+        if timeout > Duration::ZERO {
+            fut.timeout(futures_time::time::Duration::from(timeout))
+                .await
+                .map_err(|_e| anyhow!("{} timeout", err_msg))?
+                .map_err(Into::into)
+        } else {
+            fut.await.map_err(Into::into)
+        }
+    }
+
     #[inline]
     pub(crate) async fn restore_topic_tree(&self) -> Result<()> {
         let mut topic_tree = self.topic_tree.write().await;
@@ -394,17 +406,9 @@ impl StorageMessageManagerInner {
         match msg {
             Msg::Store { from, publish, expiry_interval, msg_id, recipients } => {
                 // Persist the msg_id counter so a restart can resume without reuse.
-                let result = if timeout > Duration::ZERO {
-                    self.storage_save_msg_id()
-                        .timeout(futures_time::time::Duration::from(timeout))
-                        .await
-                        .map_err(|_e| anyhow!("storage_save_msg_id timeout"))?
-                } else {
-                    self.storage_save_msg_id().await
-                };
-                if let Err(e) = result {
-                    return Err(anyhow!("save message id error: {:?}", e));
-                }
+                Self::with_timeout(self.storage_save_msg_id(), timeout, "storage_save_msg_id")
+                    .await
+                    .map_err(|e| anyhow!("save message id error: {:?}", e))?;
 
                 let mut topic = match Topic::from_str(&publish.topic) {
                     Err(e) => {
@@ -419,38 +423,23 @@ impl StorageMessageManagerInner {
 
                 // received messages
                 let msg_key = msg_id.to_be_bytes();
-                let msg_map = {
-                    let map_fut =
-                        self.storage_db.map(msg_key, Some(expiry_interval.as_millis() as TimestampMillis));
-                    let map_result = if timeout > Duration::ZERO {
-                        map_fut
-                            .timeout(futures_time::time::Duration::from(timeout))
-                            .await
-                            .map_err(|_e| anyhow!("storage_db.map timeout"))?
-                    } else {
-                        map_fut.await
-                    };
-                    match map_result {
-                        Ok(map) => map,
-                        Err(e) => {
-                            log::warn!("store to db error, map_expire(..), {e:?}, message: {smsg:?}");
-                            return Err(anyhow!("storage_db.map error: {:?}", e));
-                        }
-                    }
-                };
-                let insert_result = if timeout > Duration::ZERO {
-                    msg_map
-                        .insert(DATA, &smsg)
-                        .timeout(futures_time::time::Duration::from(timeout))
-                        .await
-                        .map_err(|_e| anyhow!("map.insert timeout"))?
-                } else {
-                    msg_map.insert(DATA, &smsg).await
-                };
-                if let Err(e) = insert_result {
-                    log::warn!("store to db error, {e:?}, message: {smsg:?}");
-                    return Err(anyhow!("msg_map.insert error: {:?}", e));
-                }
+                let msg_map = Self::with_timeout(
+                    self.storage_db.map(msg_key, Some(expiry_interval.as_millis() as TimestampMillis)),
+                    timeout,
+                    "storage_db.map",
+                )
+                .await
+                .map_err(|e| {
+                    log::warn!("store to db error, map_expire(..), {e:?}, message: {smsg:?}");
+                    anyhow!("storage_db.map error: {:?}", e)
+                })?;
+
+                Self::with_timeout(msg_map.insert(DATA, &smsg), timeout, "map.insert").await.map_err(
+                    |e| {
+                        log::warn!("store to db error, {e:?}, message: {smsg:?}");
+                        anyhow!("msg_map.insert error: {:?}", e)
+                    },
+                )?;
 
                 if let Some(recipients) = recipients {
                     self._forwardeds(&msg_map, recipients).await?;
@@ -462,54 +451,27 @@ impl StorageMessageManagerInner {
                 self.topic_list.write().await.insert((expiry_time_at, topic));
 
                 self.messages_received_count_add(1);
-                if timeout > Duration::ZERO {
-                    self.storage_messages_counter_add(1)
-                        .timeout(futures_time::time::Duration::from(timeout))
-                        .await
-                        .map_err(|_e| anyhow!("storage_messages_counter_add timeout"))??
-                } else {
-                    self.storage_messages_counter_add(1).await?
-                };
+                Self::with_timeout(self.storage_messages_counter_add(1), timeout, "messages_counter_add")
+                    .await?;
             }
             Msg::MarkForwarded { msg_id, recipients } => {
                 let msg_key = msg_id.to_be_bytes();
-                let msg_map = {
-                    let map_fut = self.storage_db.map(msg_key, None);
-                    let map_result = if timeout > Duration::ZERO {
-                        map_fut
-                            .timeout(futures_time::time::Duration::from(timeout))
-                            .await
-                            .map_err(|_e| anyhow!("add_forwardeds map timeout"))?
-                    } else {
-                        map_fut.await
-                    };
-                    match map_result {
-                        Ok(map) => map,
-                        Err(e) => {
-                            return Err(anyhow!("add_forwardeds map error: {:?}", e));
-                        }
-                    }
-                };
-                let contains_result = if timeout > Duration::ZERO {
-                    msg_map
-                        .contains_key(DATA)
-                        .timeout(futures_time::time::Duration::from(timeout))
+                let msg_map =
+                    Self::with_timeout(self.storage_db.map(msg_key, None), timeout, "add_forwardeds map")
                         .await
-                        .map_err(|_e| anyhow!("add_forwardeds contains_key timeout"))??
+                        .map_err(|e| anyhow!("add_forwardeds map error: {:?}", e))?;
+
+                let found =
+                    Self::with_timeout(msg_map.contains_key(DATA), timeout, "add_forwardeds contains_key")
+                        .await?;
+                if found {
+                    self._forwardeds(&msg_map, recipients).await?;
                 } else {
-                    msg_map.contains_key(DATA).await?
-                };
-                match contains_result {
-                    true => {
-                        self._forwardeds(&msg_map, recipients).await?;
-                    }
-                    false => {
-                        log::warn!(
-                            "add_forwardeds: msg_id {:?} not found in storage, recipients: {:?}",
-                            msg_id,
-                            recipients
-                        );
-                    }
+                    log::warn!(
+                        "add_forwardeds: msg_id {:?} not found in storage, recipients: {:?}",
+                        msg_id,
+                        recipients
+                    );
                 }
             }
         }
@@ -520,15 +482,12 @@ impl StorageMessageManagerInner {
     async fn _forwardeds(&self, msg_map: &StorageMap, forwardeds: ForwardedRecipients) -> Result<()> {
         let timeout = self.timeout;
         for (client_id, opts) in forwardeds {
-            if timeout > Duration::ZERO {
-                msg_map
-                    .insert(Self::make_forwarded_key(&client_id), &opts)
-                    .timeout(futures_time::time::Duration::from(timeout))
-                    .await
-                    .map_err(|_e| anyhow!("_forwardeds insert timeout"))??
-            } else {
-                msg_map.insert(Self::make_forwarded_key(&client_id), &opts).await?
-            };
+            Self::with_timeout(
+                msg_map.insert(Self::make_forwarded_key(&client_id), &opts),
+                timeout,
+                "forwardeds insert",
+            )
+            .await?;
         }
         Ok(())
     }
@@ -706,28 +665,24 @@ impl MessageManager for StorageMessageManager {
             return Ok(vec![]);
         }
         let now = std::time::Instant::now();
-        let inner = self.inner.clone();
-        let client_id = ClientId::from(client_id);
-        let topic_filter = TopicFilter::from(topic_filter);
-        let group = group.cloned();
         let timeout = self.timeout;
-        let matcheds = async move { inner._get(&client_id, &topic_filter, group.as_ref()).await }
-            .spawn(&self.exec)
-            .result();
-        let matcheds = if timeout > Duration::ZERO {
-            matcheds.timeout(futures_time::time::Duration::from(timeout)).await
-        } else {
-            Ok(matcheds.await)
-        };
-        let matcheds = match matcheds {
-            Ok(Ok(Ok(res))) => res,
-            Ok(Ok(Err(e))) => {
-                log::error!("StorageMessageManager get error, {:?}", e.to_string());
-                return Err(e);
+
+        // Run _get directly — no exec queue indirection needed,
+        // since _get is fully async (no blocking I/O).
+        let result = {
+            let fut = self._get(client_id, topic_filter, group);
+            if timeout > Duration::ZERO {
+                fut.timeout(futures_time::time::Duration::from(timeout)).await
+            } else {
+                Ok(fut.await)
             }
+        };
+
+        let matcheds = match result {
+            Ok(Ok(res)) => res,
             Ok(Err(e)) => {
-                log::error!("StorageMessageManager get error, {:?}", e.to_string());
-                return Err(anyhow!(e.to_string()));
+                log::error!("StorageMessageManager get error, {:?}", e);
+                return Err(e);
             }
             Err(e) => {
                 log::warn!("StorageMessageManager get timeout, {e:?}");
@@ -735,12 +690,9 @@ impl MessageManager for StorageMessageManager {
                 vec![]
             }
         };
+
         if now.elapsed().as_millis() > 900 {
-            log::info!(
-                "StorageMessageManager::get cost time: {:?}, waiting_count: {:?}",
-                now.elapsed(),
-                self.exec.waiting_count()
-            );
+            log::info!("StorageMessageManager::get cost time: {:?}", now.elapsed());
         }
         Ok(matcheds)
     }


### PR DESCRIPTION
…timeout

**Summary**
Simplify the message storage backend by removing `merge_on_read` from config, removing TaskExecQueue indirection, and introducing a reusable timeout helper.

**Key Changes**

Remove `merge_on_read`:
- Remove from `RamConfig` and `Config::Storage` variant
- Simplify storage type deserialization
- Always merge on read (default behavior for clustered deployments)

Remove TaskExecQueue:
- Remove `exec` field from `StorageMessageManager`
- Remove `Builder` and `SpawnExt` imports
- Remove `NodeId` parameter from `StorageMessageManager::new()`
- Run `_get()` directly instead of spawning via exec queue
- Remove exec-related stats from attributes output

Add `with_timeout` helper:
- Generic async timeout wrapper with consistent error handling
- Converts timeout errors to `anyhow::Error` with context message
- Unified error mapping via `Into<anyhow::Error>`
- Applied to all storage I/O operations

**Configuration Updates**
- `storage.ram.cache_capacity` default: 2G → 3G
- `storage.ram.encode` default: true → false
- `cleanup_count` default: 2000 → 5000 (already updated earlier)
- Remove `storage.ram.merge_on_read` (no longer used)
- Update README: remove `workers`, clarify `encode` default

**Benefits**
- Simplified codebase (removed redundant indirection)
- Consistent timeout handling across all I/O operations
- Better performance with `encode=false` default
- Cleaner config with fewer options