### PR TITLE
feat(cluster): implement cluster-aware retain message synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5109,7 +5109,6 @@ dependencies = [
  "log",
  "rmqtt",
  "rmqtt-storage",
- "rust-box",
  "scc",
  "serde",
  "serde_json",

--- a/examples/cluster-broadcast/1/rmqtt.toml
+++ b/examples/cluster-broadcast/1/rmqtt.toml
@@ -39,7 +39,7 @@ log.file = "rmqtt_1.log"
 plugins.dir = "./plugins"
 #Plug in started by default, when the mqtt server is started
 plugins.default_startups = [
-    #"rmqtt-retainer",
+    "rmqtt-retainer",
     "rmqtt-cluster-broadcast",
     #"rmqtt-auth-http",
     "rmqtt-message-storage",

--- a/examples/cluster-broadcast/2/rmqtt.toml
+++ b/examples/cluster-broadcast/2/rmqtt.toml
@@ -39,7 +39,7 @@ log.file = "rmqtt_2.log"
 plugins.dir = "./plugins"
 #Plug in started by default, when the mqtt server is started
 plugins.default_startups = [
-    #"rmqtt-retainer",
+    "rmqtt-retainer",
     "rmqtt-cluster-broadcast",
     #"rmqtt-auth-http",
     "rmqtt-message-storage",

--- a/examples/cluster-broadcast/3/rmqtt.toml
+++ b/examples/cluster-broadcast/3/rmqtt.toml
@@ -39,7 +39,7 @@ log.file = "rmqtt_3.log"
 plugins.dir = "./plugins"
 #Plug in started by default, when the mqtt server is started
 plugins.default_startups = [
-    #"rmqtt-retainer",
+    "rmqtt-retainer",
     "rmqtt-cluster-broadcast",
     #"rmqtt-auth-http",
     "rmqtt-message-storage",

--- a/examples/cluster-raft-3/1/rmqtt.toml
+++ b/examples/cluster-raft-3/1/rmqtt.toml
@@ -32,7 +32,7 @@ log.file = "rmqtt_1.log"
 plugins.dir = "./plugins/"
 #Plug in started by default, when the mqtt server is started
 plugins.default_startups = [
-    #"rmqtt-retainer",
+    "rmqtt-retainer",
     "rmqtt-cluster-raft",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",

--- a/examples/cluster-raft-3/2/rmqtt.toml
+++ b/examples/cluster-raft-3/2/rmqtt.toml
@@ -33,7 +33,7 @@ log.file = "rmqtt_2.log"
 plugins.dir = "./plugins/"
 #Plug in started by default, when the mqtt server is started
 plugins.default_startups = [
-    #"rmqtt-retainer",
+    "rmqtt-retainer",
     "rmqtt-cluster-raft",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",

--- a/examples/cluster-raft-3/3/rmqtt.toml
+++ b/examples/cluster-raft-3/3/rmqtt.toml
@@ -33,7 +33,7 @@ log.file = "rmqtt_3.log"
 plugins.dir = "./plugins/"
 #Plug in started by default, when the mqtt server is started
 plugins.default_startups = [
-    #"rmqtt-retainer",
+    "rmqtt-retainer",
     "rmqtt-cluster-raft",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-rmqtt = { workspace = true, features = ["plugin", "grpc", "stats", "msgstore", "shared-subscription"] }
+rmqtt = { workspace = true, features = ["plugin", "grpc", "stats", "msgstore", "retain", "shared-subscription"] }
 tokio = { workspace = true, features = ["sync"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/handler.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/handler.rs
@@ -114,7 +114,14 @@ impl Handler for HookHandler {
                         return (false, Some(new_acc));
                     }
                     Message::GetRetains(topic_filter) => {
-                        log::error!("unreachable!(), Message::GetRetains({topic_filter})");
+                        let retains = self.scx.extends.retain().await.get(topic_filter).await;
+                        let new_acc = match retains {
+                            Err(e) => HookResult::GrpcMessageReply(Err(e)),
+                            Ok(retains) => {
+                                HookResult::GrpcMessageReply(Ok(MessageReply::GetRetains(retains)))
+                            }
+                        };
+                        return (false, Some(new_acc));
                     }
                     Message::Online(clientid) => {
                         let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::Online(

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -844,6 +844,56 @@ impl Shared for ClusterShared {
         }
     }
 
+    async fn retain_load_with(
+        &self,
+        topic_filter: &TopicFilter,
+        cb: Arc<dyn rmqtt::shared::RetainLoadCallback>,
+    ) -> Result<Vec<(NodeId, MsgID)>> {
+        let retain_mgr = self.scx.extends.retain().await;
+        if retain_mgr.merge_on_read() {
+            let retains = retain_mgr.get(topic_filter).await?;
+            let mut excludeds = cb.on_retains(retains).await?;
+
+            if !self.grpc_clients.is_empty() {
+                let cb2 = cb.clone();
+                let replys = MessageBroadcaster::new(
+                    self.grpc_clients.clone(),
+                    self.message_type,
+                    Message::GetRetains(topic_filter.clone()),
+                    Some(self.rw_timeout),
+                )
+                .join_all_with_async(move |reply| {
+                    let retains = match reply {
+                        Ok(MessageReply::GetRetains(retains)) => retains,
+                        Ok(other) => {
+                            log::warn!("unexpected reply: {other:?}");
+                            vec![]
+                        }
+                        Err(e) => {
+                            log::warn!("Message::GetRetains failed, {e:?}");
+                            vec![]
+                        }
+                    };
+                    let cb2 = cb2.clone();
+                    async move { cb2.on_retains(retains).await }
+                })
+                .await;
+
+                for (node_id, result) in replys {
+                    match result {
+                        Ok(mut ids) => excludeds.append(&mut ids),
+                        Err(e) => log::warn!("Message::GetRetains failed, node_id: {node_id}, {e:?}"),
+                    }
+                }
+            }
+
+            Ok(excludeds)
+        } else {
+            let retains = retain_mgr.get(topic_filter).await?;
+            cb.on_retains(retains).await
+        }
+    }
+
     #[inline]
     async fn message_mark_forwarded(
         &self,

--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-rmqtt = { workspace = true, features = ["plugin", "grpc", "stats", "msgstore"] }
+rmqtt = { workspace = true, features = ["plugin", "grpc", "stats", "msgstore", "retain", "shared-subscription"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["sync"] }
 rmqtt-raft = { version = "0.7.2", features = ["reuse"] }

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/handler.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/handler.rs
@@ -181,7 +181,14 @@ impl Handler for HookHandler {
                         return (false, Some(new_acc));
                     }
                     GrpcMessage::GetRetains(topic_filter) => {
-                        log::error!("unreachable!(), GrpcMessage::GetRetains({topic_filter})");
+                        let retains = self.scx.extends.retain().await.get(topic_filter).await;
+                        let new_acc = match retains {
+                            Err(e) => HookResult::GrpcMessageReply(Err(e)),
+                            Ok(retains) => {
+                                HookResult::GrpcMessageReply(Ok(MessageReply::GetRetains(retains)))
+                            }
+                        };
+                        return (false, Some(new_acc));
                     }
                     GrpcMessage::SubscriptionsGet(clientid) => {
                         let id = Id::from(self.scx.node.id(), clientid.clone());

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -785,6 +785,71 @@ impl Shared for ClusterShared {
         }
     }
 
+    async fn retain_load_with(
+        &self,
+        topic_filter: &TopicFilter,
+        cb: Arc<dyn rmqtt::shared::RetainLoadCallback>,
+    ) -> Result<Vec<(NodeId, MsgID)>> {
+        let retain_mgr = self.scx.extends.retain().await;
+        if retain_mgr.merge_on_read() {
+            log::debug!(
+                "retain_load_with start, topic_filter: {topic_filter}, grpc_clients: {}, rw_timeout: {:?}",
+                self.grpc_clients.len(),
+                self.rw_timeout
+            );
+            let retains = retain_mgr.get(topic_filter).await?;
+            let mut excludeds = cb.on_retains(retains).await?;
+
+            if !self.grpc_clients.is_empty() {
+                let grpc_clients = self.grpc_clients.clone();
+                let message_type = self.message_type;
+                let rw_timeout = self.rw_timeout;
+                let topic_filter = topic_filter.clone();
+                let cb2 = cb.clone();
+                let replys: Vec<(NodeId, Result<Vec<(NodeId, MsgID)>>)> = async move {
+                    MessageBroadcaster::new(
+                        grpc_clients,
+                        message_type,
+                        Message::GetRetains(topic_filter),
+                        Some(rw_timeout),
+                    )
+                    .join_all_with_async(move |reply| {
+                        let retains = match reply {
+                            Ok(MessageReply::GetRetains(retains)) => retains,
+                            Ok(other) => {
+                                log::warn!("unexpected reply: {other:?}");
+                                vec![]
+                            }
+                            Err(e) => {
+                                log::warn!("Message::GetRetains failed, {e:?}");
+                                vec![]
+                            }
+                        };
+                        let cb2 = cb2.clone();
+                        async move { cb2.on_retains(retains).await }
+                    })
+                    .await
+                }
+                .spawn(&self.exec)
+                .result()
+                .await
+                .map_err(|_| anyhow!("ClusterShared::retain_load_with task execution failure"))?;
+
+                for (node_id, result) in replys {
+                    match result {
+                        Ok(mut ids) => excludeds.append(&mut ids),
+                        Err(e) => log::warn!("Message::GetRetains failed, node_id: {node_id}, {e:?}"),
+                    }
+                }
+            }
+
+            Ok(excludeds)
+        } else {
+            let retains = retain_mgr.get(topic_filter).await?;
+            cb.on_retains(retains).await
+        }
+    }
+
     #[inline]
     async fn message_mark_forwarded(
         &self,

--- a/rmqtt-plugins/rmqtt-message-storage/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-message-storage/Cargo.toml
@@ -23,7 +23,6 @@ serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["sync", "time"] }
 rmqtt-storage = { workspace = true, default-features = false, features = ["ttl"], optional = true}
 #rmqtt-storage = { path = "../../../rmqtt-storage", default-features = false, features = ["ttl"], optional = true}
-rust-box = { workspace = true, features = ["task-exec-queue", "task-exec-queue-rate"] }
 futures.workspace = true
 futures-time.workspace = true
 async-trait.workspace = true

--- a/rmqtt-plugins/rmqtt-retainer/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/lib.rs
@@ -70,7 +70,7 @@ impl RetainerPlugin {
 
         let (retainer, support_cluster) = match &mut cfg.write().await.storage {
             #[cfg(feature = "ram")]
-            Some(Config::Ram) => (Retainer::Ram(RamRetainer::new(cfg.clone(), retain_enable.clone())), false),
+            Some(Config::Ram) => (Retainer::Ram(RamRetainer::new(cfg.clone(), retain_enable.clone())), true),
             #[cfg(any(feature = "sled", feature = "redis"))]
             Some(Config::Storage(s_cfg)) => {
                 let node_id = scx.node.id();
@@ -78,7 +78,7 @@ impl RetainerPlugin {
                     #[cfg(feature = "sled")]
                     StorageType::Sled => {
                         s_cfg.sled.path = s_cfg.sled.path.replace("{node}", &format!("{node_id}"));
-                        false
+                        true
                     }
                     #[cfg(feature = "redis")]
                     StorageType::Redis => {
@@ -91,8 +91,14 @@ impl RetainerPlugin {
                 let storage_db = init_db(s_cfg).await?;
                 (
                     Retainer::Storage(
-                        storage::Retainer::new(node_id, cfg.clone(), storage_db, retain_enable.clone())
-                            .await?,
+                        storage::Retainer::new(
+                            node_id,
+                            cfg.clone(),
+                            storage_db,
+                            retain_enable.clone(),
+                            s_cfg.typ.clone(),
+                        )
+                        .await?,
                     ),
                     support_cluster,
                 )

--- a/rmqtt-plugins/rmqtt-retainer/src/ram.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/ram.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 
+use rmqtt::utils::StatsMergeMode;
 use rmqtt::{
     retain::DefaultRetainStorage,
     retain::RetainStorage,
@@ -42,6 +43,11 @@ impl RamRetainer {
 impl RetainStorage for RamRetainer {
     #[inline]
     fn enable(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn merge_on_read(&self) -> bool {
         true
     }
 
@@ -94,5 +100,10 @@ impl RetainStorage for RamRetainer {
     #[inline]
     async fn max(&self) -> isize {
         self.inner.max().await
+    }
+
+    #[inline]
+    fn stats_merge_mode(&self) -> StatsMergeMode {
+        StatsMergeMode::Sum
     }
 }

--- a/rmqtt-plugins/rmqtt-retainer/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/storage.rs
@@ -20,7 +20,7 @@ use futures::{SinkExt, StreamExt};
 use futures_time::{self, future::FutureExt};
 use tokio::sync::RwLock;
 
-use rmqtt_storage::DefaultStorageDB;
+use rmqtt_storage::{DefaultStorageDB, StorageType};
 
 use rmqtt::{
     retain::RetainStorage,
@@ -53,6 +53,7 @@ impl Retainer {
         cfg: Arc<RwLock<PluginConfig>>,
         storage_db: DefaultStorageDB,
         retain_enable: Arc<AtomicBool>,
+        storage_type: StorageType,
     ) -> Result<Retainer> {
         let (msg_tx, msg_rx) = mpsc::channel::<Msg>(300_000);
         let msg_queue_count = Arc::new(AtomicIsize::new(0));
@@ -66,6 +67,7 @@ impl Retainer {
             retain_enable,
             storage_messages_count,
             storage_messages_max,
+            storage_type,
         });
         Self { inner }.serve(msg_rx)
     }
@@ -130,10 +132,9 @@ pub struct RetainerInner {
     msg_tx: mpsc::Sender<Msg>,
     pub(crate) msg_queue_count: Arc<AtomicIsize>,
     retain_enable: Arc<AtomicBool>,
-    // retain_count: Arc<AtomicUsize>,
-    // retain_count_utime: Arc<AtomicI64>,
     storage_messages_count: ValueCached<usize>,
     storage_messages_max: ValueCached<isize>,
+    storage_type: StorageType,
 }
 
 impl RetainerInner {
@@ -348,6 +349,18 @@ impl RetainStorage for Retainer {
         true
     }
 
+    #[inline]
+    fn merge_on_read(&self) -> bool {
+        match self.storage_type {
+            #[cfg(feature = "sled")]
+            StorageType::Sled => true,
+            #[cfg(feature = "redis")]
+            StorageType::Redis => false,
+            #[allow(unreachable_patterns)]
+            _ => false,
+        }
+    }
+
     ///topic - concrete topic
     async fn set(&self, topic: &TopicName, retain: Retain, expiry_interval: Option<Duration>) -> Result<()> {
         if !self.retain_enable.load(Ordering::SeqCst) {
@@ -405,7 +418,14 @@ impl RetainStorage for Retainer {
 
     #[inline]
     fn stats_merge_mode(&self) -> StatsMergeMode {
-        StatsMergeMode::Max
+        match self.storage_type {
+            #[cfg(feature = "sled")]
+            StorageType::Sled => StatsMergeMode::Sum,
+            #[cfg(feature = "redis")]
+            StorageType::Redis => StatsMergeMode::Max,
+            #[allow(unreachable_patterns)]
+            _ => StatsMergeMode::None,
+        }
     }
 }
 

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -256,9 +256,6 @@ impl GrpcClient {
 /// Values below 1000 are reserved for internal broker messages.
 pub type MessageType = u64;
 
-/// Identifier for the `MessageGet` operation (value: 22).
-pub const MESSAGE_TYPE_MESSAGE_GET: u64 = 22;
-
 /// Cluster message payloads for inter-node operations.
 ///
 /// Each variant represents a specific cluster operation:

--- a/rmqtt/src/retain.rs
+++ b/rmqtt/src/retain.rs
@@ -91,6 +91,12 @@ pub trait RetainStorage: Sync + Send {
         false
     }
 
+    /// Whether merging retentions from remote cluster nodes is needed during retrieval.
+    #[inline]
+    fn merge_on_read(&self) -> bool {
+        false
+    }
+
     /// Store a retained message for the given topic.
     ///
     /// If the payload is empty, the retained message is cleared.

--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -82,6 +82,7 @@ use tokio::sync::RwLock;
 use tokio::time::{Duration, Instant};
 
 use crate::acl::AuthInfo;
+use crate::codec::v5::RetainHandling;
 use crate::codec::{
     v3,
     v5::{self, Auth, PublishAck2, PublishAck2Reason, SubscribeAckReason, ToReasonCode, UserProperties},
@@ -93,6 +94,8 @@ use crate::net::MqttError;
 use crate::queue::{self, Limiter, Policy};
 #[cfg(feature = "msgstore")]
 use crate::shared::MessageLoadCallback;
+#[cfg(feature = "retain")]
+use crate::shared::RetainLoadCallback;
 use crate::types::*;
 use crate::utils::timestamp_millis;
 use crate::Result;
@@ -1338,54 +1341,28 @@ impl SessionState {
 
         #[allow(unused_variables)]
         if let Some(qos) = sub_ret.success() {
-            //send retain messages
-            #[cfg(feature = "retain")]
-            let _excludeds = if self.scx.extends.retain().await.enable() {
-                use crate::codec::v5::RetainHandling;
-                //MQTT V5: Retain Handling
-                let send_retain_enable = match sub.opts.retain_handling() {
-                    Some(RetainHandling::AtSubscribe) => true,
-                    Some(RetainHandling::AtSubscribeNew) => sub_ret.prev_opts.is_none(),
-                    Some(RetainHandling::NoAtSubscribe) => false,
-                    None => true, //MQTT V3
-                };
-                log::debug!(
-                    "send_retain_enable: {}, sub_ret.prev_opts: {:?}",
-                    send_retain_enable,
-                    sub_ret.prev_opts
-                );
-                let excludeds = if send_retain_enable {
-                    let retain_messages = self.scx.extends.retain().await.get(&sub.topic_filter).await?;
-                    let excludeds = retain_messages
-                        .iter()
-                        .filter_map(|(_, r)| r.msg_id.map(|msg_id| (r.from.node_id, msg_id)))
-                        .collect::<Vec<_>>();
-                    self.send_retain_messages(retain_messages, qos).await?;
-                    excludeds
-                } else {
-                    Vec::new()
-                };
-
-                log::debug!("{:?} excludeds: {:?}", self.id, excludeds);
-                Some(excludeds)
-            } else {
-                None
-            };
-            #[cfg(not(feature = "retain"))]
-            let _excludeds: Option<Vec<(NodeId, MsgID)>> = None;
-
-            #[cfg(feature = "msgstore")]
-            if self.scx.extends.message_mgr().await.enable() {
-                //Send messages before they expire
-                self.send_storaged_messages(
-                    sub.topic_filter.clone(),
-                    qos,
-                    sub.opts.shared_group(),
-                    _excludeds,
-                )
-                .await?;
+            #[cfg(any(feature = "retain", feature = "msgstore"))]
+            {
+                //send retain messages + sent storaged messages (fire-and-forget)
+                let scx = self.scx.clone();
+                let id = self.id.clone();
+                let sub_topic_filter = sub.topic_filter.clone();
+                let sub_shared_group = sub.opts.shared_group().cloned();
+                let retain_handling = sub.opts.retain_handling();
+                let prev_opts_is_none = sub_ret.prev_opts.is_none();
+                tokio::spawn(async move {
+                    _send_subscribe_messages(
+                        scx,
+                        id,
+                        sub_topic_filter,
+                        sub_shared_group,
+                        retain_handling,
+                        prev_opts_is_none,
+                        qos,
+                    )
+                    .await;
+                });
             }
-
             //hook, session_subscribed
             self.hook.session_subscribed(sub).await;
         }
@@ -1450,36 +1427,6 @@ impl SessionState {
     }
 
     #[inline]
-    #[cfg(feature = "retain")]
-    async fn send_retain_messages(&self, retains: Vec<(TopicName, Retain)>, qos: QoS) -> Result<()> {
-        for (topic, mut retain) in retains {
-            log::debug!("{:?} topic:{:?}, retain:{:?}", self.id, topic, retain);
-
-            retain.publish.dup = false;
-            retain.publish.retain = true;
-            retain.publish.qos = retain.publish.qos.less_value(qos);
-            retain.publish.topic = topic;
-            retain.publish.packet_id = None;
-            retain.publish.create_time = Some(timestamp_millis());
-
-            log::debug!("{:?} retain.publish: {:?}", self.id, retain.publish);
-
-            if let Err((from, p, reason)) = self
-                .scx
-                .extends
-                .shared()
-                .await
-                .entry(self.id.clone())
-                .publish(retain.from, retain.publish)
-                .await
-            {
-                self.scx.extends.hook_mgr().message_dropped(Some(self.id.clone()), from, p, reason).await;
-            }
-        }
-        Ok(())
-    }
-
-    #[inline]
     #[cfg(feature = "msgstore")]
     async fn send_storaged_messages(
         &self,
@@ -1514,49 +1461,6 @@ impl SessionState {
             if elaps.as_secs() > 3 {
                 log::warn!("message_load_with cost time: {:?}", elaps);
             }
-        });
-        Ok(())
-    }
-
-    #[inline]
-    #[cfg(feature = "msgstore")]
-    #[allow(dead_code)]
-    async fn send_storaged_messages_old(
-        &self,
-        topic_filter: TopicFilter,
-        qos: QoS,
-        group: Option<&SharedGroup>,
-        excludeds: Option<Vec<(NodeId, MsgID)>>,
-    ) -> Result<()> {
-        let scx = self.scx.clone();
-        let group = group.cloned();
-        let id = self.id.clone();
-        tokio::spawn(async move {
-            let now = std::time::Instant::now();
-            let storaged_messages =
-                scx.extends.shared().await.message_load(&id.client_id, &topic_filter, group.as_ref()).await;
-            let elaps = now.elapsed();
-            if elaps.as_secs() > 3 {
-                log::warn!("message_load cost time: {:?}", elaps);
-            }
-
-            let storaged_messages = match storaged_messages {
-                Err(e) => {
-                    log::error!("message_load failed, {e:?}");
-                    return;
-                }
-                Ok(storaged_messages) => storaged_messages,
-            };
-            _send_storaged_messages(
-                &scx,
-                id,
-                storaged_messages,
-                qos,
-                excludeds,
-                &topic_filter,
-                group.as_ref(),
-            )
-            .await;
         });
         Ok(())
     }
@@ -2010,6 +1914,157 @@ impl MessageLoadCallback for SendStoragedMessagesHandler {
         )
         .await;
         Ok(())
+    }
+}
+
+/// Sends retain messages to a subscriber, adjusting fields as needed.
+///
+/// # Arguments
+/// * `scx` - The server context.
+/// * `id` - The subscriber's session ID.
+/// * `retains` - The retain messages to send.
+/// * `qos` - The maximum QoS to use.
+#[cfg(feature = "retain")]
+#[inline]
+async fn _send_retain_messages(
+    scx: &ServerContext,
+    id: &Id,
+    retains: Vec<(TopicName, Retain)>,
+    qos: QoS,
+) -> Result<()> {
+    for (topic, mut retain) in retains {
+        log::debug!("{:?} topic:{:?}, retain:{:?}", id, topic, retain);
+
+        retain.publish.dup = false;
+        retain.publish.retain = true;
+        retain.publish.qos = retain.publish.qos.less_value(qos);
+        retain.publish.topic = topic;
+        retain.publish.packet_id = None;
+        retain.publish.create_time = Some(timestamp_millis());
+
+        log::debug!("{:?} retain.publish: {:?}", id, retain.publish);
+
+        if let Err((from, p, reason)) =
+            scx.extends.shared().await.entry(id.clone()).publish(retain.from, retain.publish).await
+        {
+            scx.extends.hook_mgr().message_dropped(Some(id.clone()), from, p, reason).await;
+        }
+    }
+    Ok(())
+}
+
+/// Standalone retain excludeds loader — does not require `SessionState` reference.
+#[cfg(feature = "retain")]
+#[inline]
+async fn _send_retain_excludeds(
+    scx: &ServerContext,
+    id: &Id,
+    topic_filter: &TopicFilter,
+    retain_handling: Option<RetainHandling>,
+    prev_opts_is_none: bool,
+    qos: QoS,
+) -> Result<Option<Vec<(NodeId, MsgID)>>> {
+    if !scx.extends.retain().await.enable() {
+        return Ok(None);
+    }
+
+    //MQTT V5: Retain Handling
+    let send_retain_enable = match retain_handling {
+        Some(RetainHandling::AtSubscribe) => true,
+        Some(RetainHandling::AtSubscribeNew) => prev_opts_is_none,
+        Some(RetainHandling::NoAtSubscribe) => false,
+        None => true, //MQTT V3
+    };
+    log::debug!("send_retain_enable: {}, prev_opts.is_none: {}", send_retain_enable, prev_opts_is_none,);
+
+    let excludeds = if send_retain_enable {
+        let handler = SendRetainMessagesHandler { scx: scx.clone(), id: id.clone(), qos };
+        scx.extends.shared().await.retain_load_with(topic_filter, Arc::new(handler)).await?
+    } else {
+        Vec::new()
+    };
+
+    log::debug!("{:?} excludeds: {:?}", id, excludeds);
+    Ok(Some(excludeds))
+}
+
+/// Handler for [`RetainLoadCallback`] used to load and send retain messages on subscribe.
+#[cfg(feature = "retain")]
+struct SendRetainMessagesHandler {
+    scx: ServerContext,
+    id: Id,
+    qos: QoS,
+}
+
+#[cfg(feature = "retain")]
+#[async_trait]
+impl RetainLoadCallback for SendRetainMessagesHandler {
+    async fn on_retains(&self, retains: Vec<(TopicName, Retain)>) -> Result<Vec<(NodeId, MsgID)>> {
+        let excludeds = retains
+            .iter()
+            .filter_map(|(_, r)| r.msg_id.map(|msg_id| (r.from.node_id, msg_id)))
+            .collect::<Vec<_>>();
+
+        _send_retain_messages(&self.scx, &self.id, retains, self.qos).await?;
+
+        Ok(excludeds)
+    }
+}
+
+/// Fire-and-forget handler for sending retain + storaged messages on subscribe.
+///
+/// Runs inside a `tokio::spawn` so the subscribe response is not blocked.
+/// Logs errors internally — no error propagation to the caller.
+#[inline]
+#[allow(unused_variables)]
+#[cfg(any(feature = "retain", feature = "msgstore"))]
+async fn _send_subscribe_messages(
+    scx: ServerContext,
+    id: Id,
+    topic_filter: TopicFilter,
+    shared_group: Option<SharedGroup>,
+    retain_handling: Option<RetainHandling>,
+    prev_opts_is_none: bool,
+    qos: QoS,
+) {
+    #[cfg(feature = "retain")]
+    let excludeds =
+        match _send_retain_excludeds(&scx, &id, &topic_filter, retain_handling, prev_opts_is_none, qos).await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("{:?} retain excludeds error: {:?}", id, e);
+                None
+            }
+        };
+
+    #[cfg(not(feature = "retain"))]
+    let excludeds: Option<Vec<(NodeId, MsgID)>> = None;
+
+    #[cfg(feature = "msgstore")]
+    if scx.extends.message_mgr().await.enable() {
+        let now = std::time::Instant::now();
+        let handler = SendStoragedMessagesHandler {
+            scx: scx.clone(),
+            id: id.clone(),
+            qos,
+            excludeds,
+            topic_filter: topic_filter.clone(),
+            group: shared_group.clone(),
+        };
+        if let Err(e) = scx
+            .extends
+            .shared()
+            .await
+            .message_load_with(&id.client_id, &topic_filter, shared_group.as_ref(), Arc::new(handler))
+            .await
+        {
+            log::warn!("message_load_with failed, {e:?}");
+        }
+        let elaps = now.elapsed();
+        if elaps.as_secs() > 3 {
+            log::warn!("message_load_with cost time: {:?}", elaps);
+        }
     }
 }
 

--- a/rmqtt/src/shared.rs
+++ b/rmqtt/src/shared.rs
@@ -154,6 +154,14 @@ pub trait MessageLoadCallback: Send + Sync + 'static {
     async fn on_messages(&self, msgs: Vec<(MsgID, From, Publish)>) -> Result<()>;
 }
 
+#[cfg(feature = "retain")]
+#[async_trait]
+pub trait RetainLoadCallback: Send + Sync + 'static {
+    /// Called with the loaded batch of retain messages (topic + retain data).
+    /// Returns the extracted (NodeId, MsgID) pairs for caller-side tracking.
+    async fn on_retains(&self, retains: Vec<(TopicName, Retain)>) -> Result<Vec<(NodeId, MsgID)>>;
+}
+
 #[async_trait]
 pub trait Shared: Sync + Send {
     /// Retrieve the session entry associated with the given client [`Id`].
@@ -278,6 +286,13 @@ pub trait Shared: Sync + Send {
         let msgs = self.message_load(client_id, topic_filter, group).await?;
         cb.on_messages(msgs).await
     }
+
+    #[cfg(feature = "retain")]
+    async fn retain_load_with(
+        &self,
+        topic_filter: &TopicFilter,
+        cb: Arc<dyn RetainLoadCallback>,
+    ) -> Result<Vec<(NodeId, MsgID)>>;
 
     /// Mark a message as successfully forwarded to the given subscribers.
     /// Delegates to [`MessageManager::mark_forwarded`] so that forwarding
@@ -1015,6 +1030,18 @@ impl Shared for DefaultShared {
         let message_mgr = scx.extends.message_mgr().await;
         let msgs = message_mgr.get(client_id, topic_filter, group).await?;
         cb.on_messages(msgs).await
+    }
+
+    #[cfg(feature = "retain")]
+    async fn retain_load_with(
+        &self,
+        topic_filter: &TopicFilter,
+        cb: Arc<dyn RetainLoadCallback>,
+    ) -> Result<Vec<(NodeId, MsgID)>> {
+        let scx = self.context();
+        let retain_mgr = scx.extends.retain().await;
+        let retains = retain_mgr.get(topic_filter).await?;
+        cb.on_retains(retains).await
     }
 
     #[inline]


### PR DESCRIPTION
**Problem**
Retained messages were not synchronized across cluster nodes. When a client subscribed to a topic on one node, it would only receive retained messages from that node's local retain storage, missing retained messages stored on other cluster nodes.

**Solution**
Extend the cluster broadcast/raft plugins to support cross-node retain message retrieval. Subscribe flow now aggregates retained messages from all cluster nodes before sending them to the client.

**Key Changes**

Retain Storage:
- Add `merge_on_read()` to `RetainStorage` trait
- Add `stats_merge_mode()` for per-backend statistics merging
- RamRetainer: `merge_on_read = true`, `stats_merge_mode = Sum`
- Storage retainer: per-backend configuration
  - Sled: `merge_on_read = true`, `stats_merge_mode = Sum`
  - Redis: `merge_on_read = false`, `stats_merge_mode = Max`

Cluster Plugins:
- Implement `retain_load_with()` in both cluster-broadcast and cluster-raft
- Add `GetRetains` gRPC message handler for cross-node retain requests
- Use `RetainLoadCallback` trait for async retain processing

Session Subscribe Flow:
- Refactor retain + storaged message sending to fire-and-forget
- Extract `_send_subscribe_messages()` async handler
- Add `SendRetainMessagesHandler` and `SendStoragedMessagesHandler` callbacks
- Use `retain_load_with()` + `message_load_with()` for cross-node aggregation
- Remove blocking `send_retain_messages()` and `send_storaged_messages()` from session loop

Shared Trait:
- Add `RetainLoadCallback` trait for async retain processing
- Add `retain_load_with()` method to `Shared` trait
- Default implementation: local retain only

Configuration Updates:
- Enable `rmqtt-retainer` plugin in all example cluster configs
- Add `retain` feature to cluster-broadcast and cluster-raft Cargo.toml
- Remove `rust-box` dependency from message-storage (no longer used)

**Benefits**
- Retained messages are visible across all cluster nodes
- Non-blocking subscribe flow (fire-and-forget)
- Configurable per-backend merge behavior
- Consistent with message storage merge-on-read pattern