### PR TITLE
feat(grpc): add fast-fail for full gRPC request queues

### DIFF
--- a/rmqtt-plugins/rmqtt-cluster-raft/src/config.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/config.rs
@@ -126,7 +126,7 @@ impl PluginConfig {
         128
     }
     fn grpc_client_timeout_default() -> Duration {
-        Duration::from_secs(60)
+        Duration::from_secs(10)
     }
 
     fn grpc_batch_size_default() -> usize {

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -180,6 +180,7 @@ impl GrpcClient {
         );
         let mut c = Client::new(server_addr.into())
             .connect_timeout(client_timeout)
+            .timeout(client_timeout)
             .concurrency_limit(client_concurrency_limit)
             .chunk_size(1024 * 1024 * 2)
             .connect_lazy()?;
@@ -221,6 +222,12 @@ impl GrpcClient {
         msg: Message,
         timeout: Option<Duration>,
     ) -> Result<MessageReply> {
+        // Fast-fail if the duplex request queue is full (peer node may be down).
+        if self.duplex_mailbox.req_queue_is_full() {
+            return Err(anyhow::anyhow!(
+                "send_message failed: duplex request queue is full (peer node may be down)"
+            ));
+        }
         let req = msg.encode(typ)?;
         let reply = if let Some(timeout) = timeout {
             tokio::time::timeout(timeout, self.duplex_mailbox.send(req)).await??
@@ -241,6 +248,13 @@ impl GrpcClient {
     }
     #[inline]
     async fn _notify(&mut self, typ: MessageType, msg: Message, timeout: Option<Duration>) -> Result<()> {
+        // Fast-fail if the transfer queue is full (e.g. the peer node is down).
+        // mailbox.send().await blocks indefinitely when the queue is full because
+        // poll_ready returns Pending until the consumer drains it — and a dead node
+        // never will.  Returning an error immediately prevents worker starvation.
+        if self.mailbox.req_queue_is_full() {
+            return Err(anyhow::anyhow!("notify failed: transfer queue is full (peer node may be down)"));
+        }
         let req = msg.encode(typ)?;
         if let Some(timeout) = timeout {
             tokio::time::timeout(timeout, self.mailbox.send(req)).await??;


### PR DESCRIPTION
**Problem**
When a cluster peer node becomes unresponsive, gRPC request queues can fill up. The `send()` operation blocks indefinitely waiting for queue capacity, causing worker threads to stall and degrading broker performance.

**Solution**
Add `req_queue_is_full()` checks before attempting to send requests:

- `send_message()`: Fast-fail if duplex request queue is full
- `notify()`: Fast-fail if transfer queue is full
- Return immediate error instead of blocking indefinitely

**Additional Changes**
- Reduce default `grpc_client_timeout` from 60s to 10s in cluster-raft config
- Add `timeout(client_timeout)` to gRPC client builder for consistent timeout behavior

**Benefits**
- Prevents worker starvation when a peer node is down
- Fast failure detection and recovery
- Consistent timeout handling across all gRPC operations