### PR TITLE
feat(retain): implement cluster-wide retain synchronization 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ target/
 /code-review-report
 /docs/architecture
 /overview.md
+/DMyWorkspaceMyProjectsrustworkspacermqtt-rsrmqtt.workbuddymemory2026-06-22.md

--- a/examples/cluster-raft-3/1/plugins/rmqtt-retainer.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-retainer.toml
@@ -20,3 +20,7 @@ max_retained_messages = 0
 # The maximum Payload value for retaining messages. After the Payload size exceeds the maximum value, the RMQTT
 # message server will process the received reserved message as a regular message.
 max_payload_size = "1MB"
+
+# TTL for retained messages. Set to 0 for no expiration.
+# If not specified, the message expiration time will be used by default.
+retained_message_ttl = "0m"

--- a/examples/cluster-raft-3/2/plugins/rmqtt-retainer.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-retainer.toml
@@ -20,3 +20,7 @@ max_retained_messages = 0
 # The maximum Payload value for retaining messages. After the Payload size exceeds the maximum value, the RMQTT
 # message server will process the received reserved message as a regular message.
 max_payload_size = "1MB"
+
+# TTL for retained messages. Set to 0 for no expiration.
+# If not specified, the message expiration time will be used by default.
+retained_message_ttl = "0m"

--- a/examples/cluster-raft-3/3/plugins/rmqtt-retainer.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-retainer.toml
@@ -20,3 +20,7 @@ max_retained_messages = 0
 # The maximum Payload value for retaining messages. After the Payload size exceeds the maximum value, the RMQTT
 # message server will process the received reserved message as a regular message.
 max_payload_size = "1MB"
+
+# TTL for retained messages. Set to 0 for no expiration.
+# If not specified, the message expiration time will be used by default.
+retained_message_ttl = "0m"

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/handler.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/handler.rs
@@ -123,6 +123,38 @@ impl Handler for HookHandler {
                         };
                         return (false, Some(new_acc));
                     }
+                    Message::GetAllRetains { offset, limit } => {
+                        let retain_mgr = self.scx.extends.retain().await;
+                        let (items, has_more) =
+                            retain_mgr.get_all_paginated(*offset, *limit).await.unwrap_or_default();
+                        let total_hint = retain_mgr.count().await.max(0) as usize;
+                        let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::GetAllRetainsChunk {
+                            items,
+                            has_more,
+                            total_hint,
+                        }));
+                        return (false, Some(new_acc));
+                    }
+                    Message::SetRetain(topic, retain, expiry_interval) => {
+                        let retain_mgr = self.scx.extends.retain().await;
+                        let current_retains = retain_mgr.get(topic).await.unwrap_or_default();
+                        let should_update = match current_retains.first() {
+                            Some((_, existing)) => {
+                                let incoming_ts = retain.publish.create_time.unwrap_or(0);
+                                let existing_ts = existing.publish.create_time.unwrap_or(0);
+                                incoming_ts > existing_ts
+                            }
+                            None => true,
+                        };
+                        if should_update {
+                            if let Err(e) = retain_mgr.set(topic, retain.clone(), *expiry_interval).await {
+                                log::warn!("Failed to apply remote retain: {e:?}");
+                            }
+                        }
+                        let new_acc =
+                            HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(should_update)));
+                        return (false, Some(new_acc));
+                    }
                     Message::Online(clientid) => {
                         let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::Online(
                             self.scx.extends.router().await.is_online(self.scx.node.id(), clientid).await,

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/lib.rs
@@ -135,6 +135,14 @@ impl Plugin for ClusterPlugin {
         self.register.start().await;
         *self.scx.extends.shared_mut().await = Box::new(self.shared.clone());
         *self.scx.extends.router_mut().await = Box::new(self.router.clone());
+
+        // Async retain sync from peers (fire-and-forget)
+        let shared = self.shared.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            shared.sync_retains_from_peers().await;
+        });
+
         Ok(())
     }
 

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -851,43 +851,40 @@ impl Shared for ClusterShared {
     ) -> Result<Vec<(NodeId, MsgID)>> {
         let retain_mgr = self.scx.extends.retain().await;
         if retain_mgr.merge_on_read() {
-            let retains = retain_mgr.get(topic_filter).await?;
-            let mut excludeds = cb.on_retains(retains).await?;
+            let mut all_retains = retain_mgr.get(topic_filter).await?;
 
             if !self.grpc_clients.is_empty() {
-                let cb2 = cb.clone();
                 let replys = MessageBroadcaster::new(
                     self.grpc_clients.clone(),
                     self.message_type,
                     Message::GetRetains(topic_filter.clone()),
                     Some(self.rw_timeout),
                 )
-                .join_all_with_async(move |reply| {
-                    let retains = match reply {
-                        Ok(MessageReply::GetRetains(retains)) => retains,
+                .join_all_with_async(move |reply| async move {
+                    match reply {
+                        Ok(MessageReply::GetRetains(retains)) => Ok(retains),
                         Ok(other) => {
                             log::warn!("unexpected reply: {other:?}");
-                            vec![]
+                            Ok(vec![])
                         }
                         Err(e) => {
                             log::warn!("Message::GetRetains failed, {e:?}");
-                            vec![]
+                            Ok(vec![])
                         }
-                    };
-                    let cb2 = cb2.clone();
-                    async move { cb2.on_retains(retains).await }
+                    }
                 })
                 .await;
 
                 for (node_id, result) in replys {
                     match result {
-                        Ok(mut ids) => excludeds.append(&mut ids),
+                        Ok(mut remote_retains) => all_retains.append(&mut remote_retains),
                         Err(e) => log::warn!("Message::GetRetains failed, node_id: {node_id}, {e:?}"),
                     }
                 }
             }
 
-            Ok(excludeds)
+            let deduped = rmqtt::shared::dedup_retains_by_topic(all_retains);
+            cb.on_retains(deduped).await
         } else {
             let retains = retain_mgr.get(topic_filter).await?;
             cb.on_retains(retains).await

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -13,7 +13,8 @@ use rust_box::task_exec_queue::{SpawnExt, TaskExecQueue};
 use rmqtt::context::ServerContext;
 use rmqtt::net::MqttError;
 use rmqtt::shared::{DefaultShared, Entry, MessageLoadCallback, Shared};
-use rmqtt::types::{HealthInfo, MsgID, NodeHealthStatus};
+use rmqtt::types::{HealthInfo, MsgID, NodeHealthStatus, Retain, TopicName};
+
 use rmqtt::{
     grpc::{GrpcClient, GrpcClients, Message, MessageBroadcaster, MessageReply, MessageSender, MessageType},
     session::Session,
@@ -891,6 +892,26 @@ impl Shared for ClusterShared {
         }
     }
 
+    async fn retain_set_broadcast(
+        &self,
+        topic: &TopicName,
+        retain: &Retain,
+        expiry_interval: Option<Duration>,
+    ) -> Result<()> {
+        if self.grpc_clients.is_empty() {
+            return Ok(());
+        }
+        let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
+        for (node_id, (_, client)) in self.grpc_clients.iter() {
+            let sender =
+                MessageSender::new(client.clone(), self.message_type, msg.clone(), Some(self.rw_timeout));
+            if let Err(e) = sender.notify().await {
+                log::warn!("retain_set_broadcast to node {node_id} failed, {e:?}");
+            }
+        }
+        Ok(())
+    }
+
     #[inline]
     async fn message_mark_forwarded(
         &self,
@@ -996,5 +1017,68 @@ impl Shared for ClusterShared {
     #[inline]
     fn node_name(&self, id: NodeId) -> String {
         self.node_names.get(&id).cloned().unwrap_or_default()
+    }
+}
+
+impl ClusterShared {
+    /// Pull all retained messages from peer nodes and merge into local storage.
+    ///
+    /// Called once at startup (with a small delay) so a new or restarted node
+    /// catches up on retains that were published while it was offline.
+    pub(crate) async fn sync_retains_from_peers(&self) {
+        if self.grpc_clients.is_empty() {
+            return;
+        }
+        {
+            let retain_mgr = self.scx.extends.retain().await;
+            if !retain_mgr.enable() || !retain_mgr.need_sync() {
+                return;
+            }
+        }
+        const CHUNK: usize = 5000;
+        for (node_id, (_, client)) in self.grpc_clients.iter() {
+            let mut offset = 0;
+            loop {
+                let mut c = client.clone();
+                let result = c
+                    .send_message(
+                        self.message_type,
+                        Message::GetAllRetains { offset, limit: CHUNK },
+                        Some(self.rw_timeout),
+                    )
+                    .await;
+                match result {
+                    Ok(MessageReply::GetAllRetainsChunk { items, has_more, .. }) => {
+                        for (topic, retain, expiry) in items {
+                            let current =
+                                self.scx.extends.retain().await.get(&topic).await.unwrap_or_default();
+                            let should_update = match current.first() {
+                                Some((_, existing)) => {
+                                    retain.publish.create_time.unwrap_or(0)
+                                        > existing.publish.create_time.unwrap_or(0)
+                                }
+                                None => true,
+                            };
+                            if should_update {
+                                let _ = self.scx.extends.retain().await.set(&topic, retain, expiry).await;
+                            }
+                        }
+                        if !has_more {
+                            break;
+                        }
+                        offset += CHUNK;
+                    }
+                    Ok(other) => {
+                        log::warn!("sync_retains_from_peers unexpected reply from {node_id}: {other:?}");
+                        break;
+                    }
+                    Err(e) => {
+                        log::warn!("sync_retains_from_peers failed from {node_id}: {e:?}");
+                        break;
+                    }
+                }
+            }
+            log::info!("sync_retains_from_peers from {node_id}: completed");
+        }
     }
 }

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/handler.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/handler.rs
@@ -190,6 +190,38 @@ impl Handler for HookHandler {
                         };
                         return (false, Some(new_acc));
                     }
+                    GrpcMessage::GetAllRetains { offset, limit } => {
+                        let retain_mgr = self.scx.extends.retain().await;
+                        let (items, has_more) =
+                            retain_mgr.get_all_paginated(*offset, *limit).await.unwrap_or_default();
+                        let total_hint = retain_mgr.count().await.max(0) as usize;
+                        let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::GetAllRetainsChunk {
+                            items,
+                            has_more,
+                            total_hint,
+                        }));
+                        return (false, Some(new_acc));
+                    }
+                    GrpcMessage::SetRetain(topic, retain, expiry_interval) => {
+                        let retain_mgr = self.scx.extends.retain().await;
+                        let current_retains = retain_mgr.get(topic).await.unwrap_or_default();
+                        let should_update = match current_retains.first() {
+                            Some((_, existing)) => {
+                                let incoming_ts = retain.publish.create_time.unwrap_or(0);
+                                let existing_ts = existing.publish.create_time.unwrap_or(0);
+                                incoming_ts > existing_ts
+                            }
+                            None => true,
+                        };
+                        if should_update {
+                            if let Err(e) = retain_mgr.set(topic, retain.clone(), *expiry_interval).await {
+                                log::warn!("Failed to apply remote retain: {e:?}");
+                            }
+                        }
+                        let new_acc =
+                            HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(should_update)));
+                        return (false, Some(new_acc));
+                    }
                     GrpcMessage::SubscriptionsGet(clientid) => {
                         let id = Id::from(self.scx.node.id(), clientid.clone());
                         let entry = self.shared.inner().entry(id);

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
@@ -379,6 +379,14 @@ impl Plugin for ClusterPlugin {
         *self.scx.extends.router_mut().await = Box::new(self.router.clone());
         *self.scx.extends.shared_mut().await = Box::new(self.shared.clone());
         self.register.start().await;
+
+        // Async retain sync from peers (fire-and-forget)
+        let shared = self.shared.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            shared.sync_retains_from_peers().await;
+        });
+
         let status = raft_mailbox.status().await.map_err(anyhow::Error::new)?;
         log::info!("raft status: {status:?}");
         if !status.is_started() {

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -22,7 +22,7 @@ use futures::future::FutureExt;
 use rust_box::task_exec_queue::{SpawnExt, TaskExecQueue};
 
 use rmqtt::context::ServerContext;
-use rmqtt::types::{ClientId, SubscriptionOptions, TopicFilter};
+use rmqtt::types::{ClientId, Retain, SubscriptionOptions, TopicFilter, TopicName};
 use rmqtt::{
     grpc::{GrpcClient, GrpcClients, Message, MessageBroadcaster, MessageReply, MessageSender, MessageType},
     router::Router,
@@ -797,36 +797,32 @@ impl Shared for ClusterShared {
                 self.grpc_clients.len(),
                 self.rw_timeout
             );
-            let retains = retain_mgr.get(topic_filter).await?;
-            let mut excludeds = cb.on_retains(retains).await?;
+            let mut all_retains = retain_mgr.get(topic_filter).await?;
 
             if !self.grpc_clients.is_empty() {
                 let grpc_clients = self.grpc_clients.clone();
                 let message_type = self.message_type;
                 let rw_timeout = self.rw_timeout;
                 let topic_filter = topic_filter.clone();
-                let cb2 = cb.clone();
-                let replys: Vec<(NodeId, Result<Vec<(NodeId, MsgID)>>)> = async move {
+                let replys: Vec<(NodeId, Result<Vec<(TopicName, Retain)>>)> = async move {
                     MessageBroadcaster::new(
                         grpc_clients,
                         message_type,
                         Message::GetRetains(topic_filter),
                         Some(rw_timeout),
                     )
-                    .join_all_with_async(move |reply| {
-                        let retains = match reply {
-                            Ok(MessageReply::GetRetains(retains)) => retains,
+                    .join_all_with_async(move |reply| async move {
+                        match reply {
+                            Ok(MessageReply::GetRetains(retains)) => Ok(retains),
                             Ok(other) => {
                                 log::warn!("unexpected reply: {other:?}");
-                                vec![]
+                                Ok(vec![])
                             }
                             Err(e) => {
                                 log::warn!("Message::GetRetains failed, {e:?}");
-                                vec![]
+                                Ok(vec![])
                             }
-                        };
-                        let cb2 = cb2.clone();
-                        async move { cb2.on_retains(retains).await }
+                        }
                     })
                     .await
                 }
@@ -837,13 +833,14 @@ impl Shared for ClusterShared {
 
                 for (node_id, result) in replys {
                     match result {
-                        Ok(mut ids) => excludeds.append(&mut ids),
+                        Ok(mut remote_retains) => all_retains.append(&mut remote_retains),
                         Err(e) => log::warn!("Message::GetRetains failed, node_id: {node_id}, {e:?}"),
                     }
                 }
             }
 
-            Ok(excludeds)
+            let deduped = rmqtt::shared::dedup_retains_by_topic(all_retains);
+            cb.on_retains(deduped).await
         } else {
             let retains = retain_mgr.get(topic_filter).await?;
             cb.on_retains(retains).await

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -847,6 +847,26 @@ impl Shared for ClusterShared {
         }
     }
 
+    async fn retain_set_broadcast(
+        &self,
+        topic: &TopicName,
+        retain: &Retain,
+        expiry_interval: Option<Duration>,
+    ) -> Result<()> {
+        if self.grpc_clients.is_empty() {
+            return Ok(());
+        }
+        let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
+        for (node_id, (_, client)) in self.grpc_clients.iter() {
+            let sender =
+                MessageSender::new(client.clone(), self.message_type, msg.clone(), Some(self.rw_timeout));
+            if let Err(e) = sender.notify().await {
+                log::warn!("retain_set_broadcast to node {node_id} failed, {e:?}");
+            }
+        }
+        Ok(())
+    }
+
     #[inline]
     async fn message_mark_forwarded(
         &self,
@@ -970,5 +990,68 @@ impl Shared for ClusterShared {
     fn operation_is_busy(&self) -> bool {
         self.exec.active_count() > self.exec_queue_workers_busy_limit
             || self.exec.waiting_count() > self.exec_queue_busy_limit
+    }
+}
+
+impl ClusterShared {
+    /// Pull all retained messages from peer nodes and merge into local storage.
+    ///
+    /// Called once at startup (with a small delay) so a new or restarted node
+    /// catches up on retains that were published while it was offline.
+    pub(crate) async fn sync_retains_from_peers(&self) {
+        if self.grpc_clients.is_empty() {
+            return;
+        }
+        {
+            let retain_mgr = self.scx.extends.retain().await;
+            if !retain_mgr.enable() || !retain_mgr.need_sync() {
+                return;
+            }
+        }
+        const CHUNK: usize = 5000;
+        for (node_id, (_, client)) in self.grpc_clients.iter() {
+            let mut offset = 0;
+            loop {
+                let mut c = client.clone();
+                let result = c
+                    .send_message(
+                        self.message_type,
+                        Message::GetAllRetains { offset, limit: CHUNK },
+                        Some(self.rw_timeout),
+                    )
+                    .await;
+                match result {
+                    Ok(MessageReply::GetAllRetainsChunk { items, has_more, .. }) => {
+                        for (topic, retain, expiry) in items {
+                            let current =
+                                self.scx.extends.retain().await.get(&topic).await.unwrap_or_default();
+                            let should_update = match current.first() {
+                                Some((_, existing)) => {
+                                    retain.publish.create_time.unwrap_or(0)
+                                        > existing.publish.create_time.unwrap_or(0)
+                                }
+                                None => true,
+                            };
+                            if should_update {
+                                let _ = self.scx.extends.retain().await.set(&topic, retain, expiry).await;
+                            }
+                        }
+                        if !has_more {
+                            break;
+                        }
+                        offset += CHUNK;
+                    }
+                    Ok(other) => {
+                        log::warn!("sync_retains_from_peers unexpected reply from {node_id}: {other:?}");
+                        break;
+                    }
+                    Err(e) => {
+                        log::warn!("sync_retains_from_peers failed from {node_id}: {e:?}");
+                        break;
+                    }
+                }
+            }
+            log::info!("sync_retains_from_peers from {node_id}: completed");
+        }
     }
 }

--- a/rmqtt-plugins/rmqtt-retainer/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/lib.rs
@@ -103,6 +103,10 @@ impl RetainerPlugin {
                     support_cluster,
                 )
             }
+            #[allow(unreachable_patterns)]
+            Some(other) => {
+                return Err(anyhow!("Unsupported storage engine: {other:?} (feature not enabled)"))
+            }
             None => return Err(anyhow!("No storage engine specified (ram, sled, or redis)")),
         };
 
@@ -234,6 +238,8 @@ impl Retainer {
             Retainer::Ram(r) => r.remove_expired_messages().await,
             #[cfg(any(feature = "sled", feature = "redis"))]
             Retainer::Storage(_r) => 0,
+            #[allow(unreachable_patterns)]
+            _ => 0,
         }
     }
 
@@ -270,6 +276,8 @@ impl Retainer {
                     },
                 })
             }
+            #[allow(unreachable_patterns)]
+            _ => json!({ "storage_engine": "unknown" }),
         }
     }
 }

--- a/rmqtt-plugins/rmqtt-retainer/src/ram.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/ram.rs
@@ -48,6 +48,11 @@ impl RetainStorage for RamRetainer {
 
     #[inline]
     fn merge_on_read(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn need_sync(&self) -> bool {
         true
     }
 
@@ -92,6 +97,18 @@ impl RetainStorage for RamRetainer {
         }
     }
 
+    async fn get_all_paginated(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
+        if !self.retain_enable.load(Ordering::SeqCst) {
+            log::warn!("{ERR_NOT_SUPPORTED}");
+            return Ok((Vec::new(), false));
+        }
+        self.inner.get_all_paginated(offset, limit).await
+    }
+
     #[inline]
     async fn count(&self) -> isize {
         self.inner.count().await
@@ -104,6 +121,6 @@ impl RetainStorage for RamRetainer {
 
     #[inline]
     fn stats_merge_mode(&self) -> StatsMergeMode {
-        StatsMergeMode::Sum
+        StatsMergeMode::Max
     }
 }

--- a/rmqtt-plugins/rmqtt-retainer/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/storage.rs
@@ -195,6 +195,7 @@ impl RetainerInner {
                     log::warn!("store to db error, insert(..), {e:?}, message: {smsg:?}");
                     continue;
                 };
+
                 if let Some(expiry_interval_millis) = expiry_interval_millis {
                     if let Err(e) =
                         self.storage_db.expire(store_topic_name.as_slice(), expiry_interval_millis).await
@@ -340,6 +341,63 @@ impl RetainerInner {
         }
         Ok(retains)
     }
+
+    #[inline]
+    async fn _get_all_paginated(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
+        let mut db = self.storage_db.clone();
+        let mut iter = match db.scan(RETAIN_MESSAGES_PREFIX.to_vec()).await {
+            Err(e) => {
+                log::error!("get_all_paginated scan error: {e:?}");
+                return Ok((Vec::new(), false));
+            }
+            Ok(iter) => iter,
+        };
+
+        // Collect all matching keys first, then drop the iterator to release
+        // the mutable borrow on `db`, so we can call `db.get` later.
+        let mut matched_keys = Vec::new();
+        while let Some(key) = iter.next().await {
+            match key {
+                Ok(key) if key.starts_with(RETAIN_MESSAGES_PREFIX) => {
+                    matched_keys.push(key);
+                }
+                Ok(_) => {}
+                Err(e) => log::error!("get_all_paginated iter error: {e:?}"),
+            }
+        }
+        drop(iter);
+
+        let total = matched_keys.len();
+        let has_more = offset + limit < total;
+
+        let mut items = Vec::with_capacity(limit);
+        for key in matched_keys.into_iter().skip(offset).take(limit) {
+            match db.get::<_, StoredMsg>(key.as_slice()).await {
+                Ok(Some((retain, expiry_time_at))) => {
+                    let topic_name = TopicName::from(
+                        String::from_utf8_lossy(&key[RETAIN_MESSAGES_PREFIX.len()..]).as_ref(),
+                    );
+                    let remaining = expiry_time_at.and_then(|exp| {
+                        let now = timestamp_millis();
+                        if exp > now {
+                            Some(Duration::from_millis((exp - now) as u64))
+                        } else {
+                            None
+                        }
+                    });
+                    items.push((topic_name, retain, remaining));
+                }
+                Ok(None) => {}
+                Err(e) => log::error!("get_all_paginated get error: {e:?}"),
+            }
+        }
+
+        Ok((items, has_more))
+    }
 }
 
 #[async_trait]
@@ -353,11 +411,21 @@ impl RetainStorage for Retainer {
     fn merge_on_read(&self) -> bool {
         match self.storage_type {
             #[cfg(feature = "sled")]
-            StorageType::Sled => true,
+            StorageType::Sled => false,
             #[cfg(feature = "redis")]
             StorageType::Redis => false,
             #[allow(unreachable_patterns)]
             _ => false,
+        }
+    }
+
+    #[inline]
+    fn need_sync(&self) -> bool {
+        match self.storage_type {
+            #[cfg(feature = "redis")]
+            StorageType::Redis => false,
+            #[allow(unreachable_patterns)]
+            _ => true,
         }
     }
 
@@ -420,12 +488,24 @@ impl RetainStorage for Retainer {
     fn stats_merge_mode(&self) -> StatsMergeMode {
         match self.storage_type {
             #[cfg(feature = "sled")]
-            StorageType::Sled => StatsMergeMode::Sum,
+            StorageType::Sled => StatsMergeMode::Max,
             #[cfg(feature = "redis")]
             StorageType::Redis => StatsMergeMode::Max,
             #[allow(unreachable_patterns)]
             _ => StatsMergeMode::None,
         }
+    }
+
+    async fn get_all_paginated(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
+        if !self.retain_enable.load(Ordering::SeqCst) {
+            log::error!("{ERR_NOT_SUPPORTED}");
+            return Ok((Vec::new(), false));
+        }
+        self._get_all_paginated(offset, limit).await
     }
 }
 

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -180,7 +180,6 @@ impl GrpcClient {
         );
         let mut c = Client::new(server_addr.into())
             .connect_timeout(client_timeout)
-            .timeout(client_timeout)
             .concurrency_limit(client_concurrency_limit)
             .chunk_size(1024 * 1024 * 2)
             .connect_lazy()?;
@@ -281,6 +280,8 @@ pub enum Message {
     ForwardsToAck(MsgID, NodeId, ForwardedRecipients),
     Kick(Id, CleanStart, ClearSubscriptions, IsAdmin),
     GetRetains(TopicFilter),
+    GetAllRetains { offset: usize, limit: usize },
+    SetRetain(TopicName, Retain, Option<Duration>),
     SubscriptionsSearch(SubsSearchParams),
     SubscriptionsGet(ClientId),
     RoutesGet(usize),
@@ -312,6 +313,12 @@ pub enum MessageReply {
     Error(String),
     Kick(OfflineSession),
     GetRetains(Vec<(TopicName, Retain)>),
+    GetAllRetainsChunk {
+        items: Vec<(TopicName, Retain, Option<Duration>)>,
+        has_more: bool,
+        total_hint: usize,
+    },
+    SetRetain(bool),
     SubscriptionsSearch(Vec<SubsSearchResult>),
     SubscriptionsGet(Option<Vec<SubsSearchResult>>),
     RoutesGet(Vec<Route>),

--- a/rmqtt/src/retain.rs
+++ b/rmqtt/src/retain.rs
@@ -97,6 +97,17 @@ pub trait RetainStorage: Sync + Send {
         false
     }
 
+    /// Whether retain storage needs cluster-wide synchronization at startup.
+    ///
+    /// Returns `true` (default) if the storage is local (in-memory, per-node Sled)
+    /// and needs proactive sync of retains from peer nodes when a new node joins.
+    /// Returns `false` if the storage is shared (e.g., Redis) so all nodes already
+    /// see the same data and no startup sync is needed.
+    #[inline]
+    fn need_sync(&self) -> bool {
+        true
+    }
+
     /// Store a retained message for the given topic.
     ///
     /// If the payload is empty, the retained message is cleared.
@@ -104,6 +115,19 @@ pub trait RetainStorage: Sync + Send {
 
     /// Retrieve all retained messages matching the given topic filter.
     async fn get(&self, topic_filter: &TopicFilter) -> Result<Vec<(TopicName, Retain)>>;
+
+    /// Retrieve a paginated snapshot of all non-expired retained messages.
+    ///
+    /// Returns `(items, has_more)`. Used by cluster plugins to synchronize
+    /// the retain store between nodes. Default implementation returns empty.
+    async fn get_all_paginated(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
+        let _ = (offset, limit);
+        Ok((Vec::new(), false))
+    }
 
     /// Current count of retained messages.
     async fn count(&self) -> isize;
@@ -197,6 +221,39 @@ impl DefaultRetainStorage {
             })
             .collect::<Vec<(TopicName, Retain)>>();
         Ok(retains)
+    }
+
+    /// Return a paginated snapshot of all stored (non-expired) messages.
+    ///
+    /// Uses the wildcard `#` filter to match all topics.
+    #[inline]
+    pub async fn get_all_paginated(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
+        let topic = match Topic::from_str("#") {
+            Err(e) => return Err(anyhow::anyhow!(e)),
+            Ok(t) => t,
+        };
+        let messages = self.messages.read().await;
+        let all: Vec<(TopicName, Retain, Option<Duration>)> = messages
+            .matches(&topic)
+            .into_iter()
+            .filter_map(|(t, tv)| {
+                if tv.is_expired() {
+                    return None;
+                }
+                let topic = TopicName::from(t.to_string());
+                let remaining = tv.remaining();
+                let retain = tv.into_value();
+                Some((topic, retain, remaining))
+            })
+            .collect();
+        let total = all.len();
+        let has_more = offset + limit < total;
+        let items = all.into_iter().skip(offset).take(limit).collect();
+        Ok((items, has_more))
     }
 }
 

--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -1727,13 +1727,14 @@ impl SessionState {
         {
             let retain = scx.extends.retain().await;
             if retain.enable() && publish.retain {
-                retain
-                    .set(
-                        &publish.topic,
-                        Retain { msg_id, from: from.clone(), publish: publish.clone() },
-                        message_expiry_interval,
-                    )
-                    .await?;
+                let retain_msg = Retain { msg_id, from: from.clone(), publish: publish.clone() };
+                retain.set(&publish.topic, retain_msg.clone(), message_expiry_interval).await?;
+                let _ = scx
+                    .extends
+                    .shared()
+                    .await
+                    .retain_set_broadcast(&publish.topic, &retain_msg, message_expiry_interval)
+                    .await;
             }
             drop(retain);
         }

--- a/rmqtt/src/shared.rs
+++ b/rmqtt/src/shared.rs
@@ -1083,3 +1083,80 @@ impl Iterator for DefaultIter<'_> {
         }
     }
 }
+
+/// Deduplicate retained messages by topic, keeping the one with the latest `create_time`.
+///
+/// When clustering with node-local retain storage (ram/sled), the same topic may be
+/// present on multiple nodes. This helper collapses those duplicates so a subscriber
+/// receives only the newest retained message per topic.
+#[cfg(feature = "retain")]
+pub fn dedup_retains_by_topic(retains: Vec<(TopicName, Retain)>) -> Vec<(TopicName, Retain)> {
+    let mut latest_idx: HashMap<TopicName, usize> = HashMap::default();
+    for (idx, (topic, retain)) in retains.iter().enumerate() {
+        let incoming_ts = retain.publish.create_time.unwrap_or(0);
+        let keep = match latest_idx.get(topic) {
+            Some(&existing_idx) => {
+                let existing_ts = retains[existing_idx].1.publish.create_time.unwrap_or(0);
+                incoming_ts > existing_ts
+            }
+            None => true,
+        };
+        if keep {
+            latest_idx.insert(topic.clone(), idx);
+        }
+    }
+    let mut indices: Vec<usize> = latest_idx.into_values().collect();
+    indices.sort_unstable();
+    indices.into_iter().map(|idx| retains[idx].clone()).collect()
+}
+
+#[cfg(all(test, feature = "retain"))]
+mod tests {
+    use super::*;
+    use crate::codec::types::{Publish as CodecPublish, QoS};
+    use crate::types::{ClientId, From, Id, Publish, Retain};
+    use bytes::Bytes;
+    use std::collections::HashMap as StdHashMap;
+
+    fn make_retain(topic: &str, payload: &str, create_time: i64) -> (TopicName, Retain) {
+        let topic = TopicName::from(topic);
+        let codec_publish = CodecPublish {
+            dup: false,
+            retain: true,
+            qos: QoS::AtMostOnce,
+            topic: topic.clone(),
+            packet_id: None,
+            payload: Bytes::from(payload.to_string()),
+            properties: None,
+        };
+        let publish = Publish::from(codec_publish).create_time(create_time);
+        let retain =
+            Retain { msg_id: None, from: From::from_custom(Id::from(0, ClientId::from_static(""))), publish };
+        (topic, retain)
+    }
+
+    #[test]
+    fn test_dedup_retains_by_topic_keeps_latest() {
+        let retains = vec![
+            make_retain("a/b", "old", 100),
+            make_retain("a/b", "new", 200),
+            make_retain("a/c", "other", 150),
+        ];
+        let deduped = dedup_retains_by_topic(retains);
+        assert_eq!(deduped.len(), 2);
+        let map: StdHashMap<String, String> = deduped
+            .into_iter()
+            .map(|(t, r)| (t.to_string(), String::from_utf8(r.publish.payload.to_vec()).unwrap()))
+            .collect();
+        assert_eq!(map.get("a/b").unwrap(), "new");
+        assert_eq!(map.get("a/c").unwrap(), "other");
+    }
+
+    #[test]
+    fn test_dedup_retains_by_topic_first_wins_on_equal_time() {
+        let retains = vec![make_retain("a/b", "first", 100), make_retain("a/b", "second", 100)];
+        let deduped = dedup_retains_by_topic(retains);
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].1.publish.payload.as_ref(), b"first");
+    }
+}

--- a/rmqtt/src/shared.rs
+++ b/rmqtt/src/shared.rs
@@ -294,6 +294,22 @@ pub trait Shared: Sync + Send {
         cb: Arc<dyn RetainLoadCallback>,
     ) -> Result<Vec<(NodeId, MsgID)>>;
 
+    /// Broadcast a retained message update to all cluster peers.
+    ///
+    /// Called after the local node has written a retain: propagates the new
+    /// value to remote nodes so they can keep their local stores up to date.
+    /// Default implementation is a no-op (single-node mode).
+    #[cfg(feature = "retain")]
+    async fn retain_set_broadcast(
+        &self,
+        topic: &TopicName,
+        retain: &Retain,
+        expiry_interval: Option<Duration>,
+    ) -> Result<()> {
+        let _ = (topic, retain, expiry_interval);
+        Ok(())
+    }
+
     /// Mark a message as successfully forwarded to the given subscribers.
     /// Delegates to [`MessageManager::mark_forwarded`] so that forwarding
     /// results are persisted and subsequent `get()` calls will not redeliver

--- a/rmqtt/src/types.rs
+++ b/rmqtt/src/types.rs
@@ -2318,6 +2318,23 @@ impl<V> TimedValue<V> {
     pub fn is_expired(&self) -> bool {
         self.1.map(|e| Instant::now() >= e).unwrap_or(false)
     }
+
+    /// Returns the absolute deadline, if set.
+    pub fn deadline(&self) -> Option<Instant> {
+        self.1
+    }
+
+    /// Returns the remaining duration until expiry, if set and not yet expired.
+    pub fn remaining(&self) -> Option<Duration> {
+        self.1.and_then(|d| {
+            let now = Instant::now();
+            if d > now {
+                Some(d.duration_since(now))
+            } else {
+                None
+            }
+        })
+    }
 }
 
 impl<V> PartialEq for TimedValue<V>


### PR DESCRIPTION
**Problem**
Retained messages are stored locally on each cluster node. When a client
publishes a retained message to one node, other nodes do not receive it.
Subsequent subscriptions on other nodes would not see the retained message.

**Solution**
Implement two-phase retain synchronization:

1. **Real-time broadcast**: When a retained message is published, broadcast
   the retain value to all peer nodes immediately via `SetRetain` gRPC.

2. **Startup sync**: When a new node joins, pull all existing retains from
   peers via paginated `GetAllRetains` with last-write-wins merging.

**Key Changes**

gRPC Messages:
- Add `GetAllRetains { offset, limit }` for paginated retain sync
- Add `SetRetain(topic, retain, expiry_interval)` for real-time broadcast

Cluster Plugins (broadcast + raft):
- Handle `GetAllRetains` and `SetRetain` in gRPC handlers
- Implement `sync_retains_from_peers()` called at startup (2s delay)
- Implement `retain_set_broadcast()` for real-time propagation
- Sync chunk size: 5000 retains per request

Retain Storage:
- Add `get_all_paginated()` to `RetainStorage` trait with default impl
- Add `need_sync()`: `true` for local storage (RAM/Sled), `false` for shared (Redis)
- Implement `get_all_paginated` for RAM and storage backends
- Add `remaining()` helper to `TimedValue` for expiry TTL calculation

Merge Semantics:
- On sync: compare `create_time`, keep newest per topic (last-write-wins)
- On real-time broadcast: same LWW check before applying remote retain

Configuration:
- Add `retained_message_ttl` to retainer example configs (default: "0m" = no expiry)

**Benefits**
- Retained messages are consistent across all cluster nodes
- New nodes catch up on startup
- Real-time propagation for new retains
- LWW conflict resolution prevents stale overwrites