### PR TITLE
feat(grpc): add quick-send path with higher priority and bypass queue-full checks; feat(retainer): add exact topic short-circuit for O(1) lookup; fix(cluster): skip retain sync when retainer indicates no sync needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5267,6 +5267,7 @@ dependencies = [
  "log",
  "rmqtt",
  "rmqtt-storage",
+ "rust-box",
  "serde",
  "serde_json",
  "tokio",

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -901,6 +901,11 @@ impl Shared for ClusterShared {
         if self.grpc_clients.is_empty() {
             return Ok(());
         }
+
+        if !self.scx.extends.retain().await.need_sync() {
+            return Ok(());
+        }
+
         let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
         for (node_id, (_, client)) in self.grpc_clients.iter() {
             let sender =

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -856,6 +856,11 @@ impl Shared for ClusterShared {
         if self.grpc_clients.is_empty() {
             return Ok(());
         }
+
+        if !self.scx.extends.retain().await.need_sync() {
+            return Ok(());
+        }
+
         let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
         for (node_id, (_, client)) in self.grpc_clients.iter() {
             let sender =

--- a/rmqtt-plugins/rmqtt-http-api/src/api.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/api.rs
@@ -477,7 +477,7 @@ async fn _get_broker(
         let grpc_clients = scx.extends.shared().await.get_grpc_clients();
         if let Some((_, c)) = grpc_clients.get(&id) {
             let msg = Message::BrokerInfo.encode()?;
-            let reply = MessageSender::new(
+            let reply = MessageSender::new_quick(
                 c.clone(),
                 message_type,
                 GrpcMessage::Data(msg),
@@ -515,7 +515,7 @@ async fn _get_brokers(scx: &ServerContext, message_type: MessageType) -> Result<
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let msg = Message::BrokerInfo.encode()?;
-        let replys = MessageBroadcaster::new(
+        let replys = MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(msg),
@@ -594,7 +594,7 @@ async fn _get_nodes(scx: &ServerContext, message_type: MessageType) -> Result<Ve
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let msg = Message::NodeInfo.encode()?;
-        let replys = MessageBroadcaster::new(
+        let replys = MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(msg),
@@ -639,7 +639,7 @@ pub(crate) async fn get_node(
         let grpc_clients = scx.extends.shared().await.get_grpc_clients();
         if let Some((_, c)) = grpc_clients.get(&id) {
             let msg = Message::NodeInfo.encode()?;
-            let reply = MessageSender::new(
+            let reply = MessageSender::new_quick(
                 c.clone(),
                 message_type,
                 GrpcMessage::Data(msg),
@@ -679,7 +679,7 @@ pub(crate) async fn get_nodes_all(
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let msg = Message::NodeInfo.encode()?;
-        let replys = MessageBroadcaster::new(
+        let replys = MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(msg),
@@ -755,7 +755,7 @@ async fn check_health_one(
         let grpc_clients = scx.extends.shared().await.get_grpc_clients();
         if let Some((_, c)) = grpc_clients.get(&id) {
             let msg = Message::NodeHealthStatus.encode()?;
-            let reply = MessageSender::new(
+            let reply = MessageSender::new_quick(
                 c.clone(),
                 message_type,
                 GrpcMessage::Data(msg),
@@ -841,7 +841,7 @@ async fn _get_client(
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let q = Message::ClientGet { clientid }.encode()?;
-        let reply = MessageBroadcaster::new(
+        let reply = MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(q),
@@ -928,7 +928,7 @@ async fn _search_clients(
             q._limit -= replys.len();
 
             let q = Message::ClientSearch(Box::new(q.clone())).encode()?;
-            let reply = MessageSender::new(
+            let reply = MessageSender::new_quick(
                 c.clone(),
                 message_type,
                 GrpcMessage::Data(q),
@@ -1352,9 +1352,10 @@ async fn _subscribe_on_other_node(
 ) -> Result<HashMap<TopicFilter, (bool, Option<String>)>> {
     let c = get_grpc_client(scx, node_id).await?;
     let q = Message::Subscribe(params).encode()?;
-    let reply = MessageSender::new(c, message_type, GrpcMessage::Data(q), Some(Duration::from_secs(15)))
-        .send()
-        .await?;
+    let reply =
+        MessageSender::new_quick(c, message_type, GrpcMessage::Data(q), Some(Duration::from_secs(15)))
+            .send()
+            .await?;
     match reply {
         GrpcMessageReply::Data(res) => match MessageReply::decode(&res)? {
             MessageReply::Subscribe(ress) => Ok(ress),
@@ -1423,9 +1424,10 @@ async fn _unsubscribe_on_other_node(
 ) -> Result<()> {
     let c = get_grpc_client(scx, node_id).await?;
     let q = Message::Unsubscribe(params).encode()?;
-    let reply = MessageSender::new(c, message_type, GrpcMessage::Data(q), Some(Duration::from_secs(15)))
-        .send()
-        .await?;
+    let reply =
+        MessageSender::new_quick(c, message_type, GrpcMessage::Data(q), Some(Duration::from_secs(15)))
+            .send()
+            .await?;
     match reply {
         GrpcMessageReply::Data(res) => match MessageReply::decode(&res)? {
             MessageReply::Unsubscribe => Ok(()),
@@ -1467,7 +1469,7 @@ async fn _all_plugins(scx: &ServerContext, message_type: MessageType) -> Result<
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let msg = Message::GetPlugins.encode()?;
-        let replys = MessageBroadcaster::new(
+        let replys = MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(msg),
@@ -1537,7 +1539,7 @@ async fn _node_plugins(
         let c = get_grpc_client(scx, node_id).await?;
         let msg = Message::GetPlugins.encode()?;
         let reply =
-            MessageSender::new(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
+            MessageSender::new_quick(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
                 .send()
                 .await?;
         match reply {
@@ -1598,7 +1600,7 @@ async fn _node_plugin_info(
         let c = get_grpc_client(scx, node_id).await?;
         let msg = Message::GetPlugin { name }.encode()?;
         let reply =
-            MessageSender::new(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
+            MessageSender::new_quick(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
                 .send()
                 .await?;
         match reply {
@@ -1666,7 +1668,7 @@ async fn _node_plugin_config(
         let c = get_grpc_client(scx, node_id).await?;
         let msg = Message::GetPluginConfig { name }.encode()?;
         let reply =
-            MessageSender::new(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
+            MessageSender::new_quick(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
                 .send()
                 .await?;
         match reply {
@@ -1727,7 +1729,7 @@ async fn _node_plugin_config_reload(
         let c = get_grpc_client(scx, node_id).await?;
         let msg = Message::ReloadPluginConfig { name }.encode()?;
         let reply =
-            MessageSender::new(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(15)))
+            MessageSender::new_quick(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(15)))
                 .send()
                 .await?;
         match reply {
@@ -1789,7 +1791,7 @@ async fn _node_plugin_load(
         let c = get_grpc_client(scx, node_id).await?;
         let msg = Message::LoadPlugin { name }.encode()?;
         let reply =
-            MessageSender::new(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
+            MessageSender::new_quick(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
                 .send()
                 .await?;
         match reply {
@@ -1849,7 +1851,7 @@ async fn _node_plugin_unload(
         let c = get_grpc_client(scx, node_id).await?;
         let msg = Message::UnloadPlugin { name }.encode()?;
         let reply =
-            MessageSender::new(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
+            MessageSender::new_quick(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
                 .send()
                 .await?;
         match reply {
@@ -1901,7 +1903,7 @@ async fn _get_stats_sum(
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let msg = Message::StatsInfo.encode()?;
-        for reply in MessageBroadcaster::new(
+        for reply in MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(msg),
@@ -2007,10 +2009,14 @@ pub(crate) async fn get_stats_one(
         let grpc_clients = scx.extends.shared().await.get_grpc_clients();
         if let Some(c) = grpc_clients.get(&id).map(|(_, c)| c.clone()) {
             let msg = Message::StatsInfo.encode()?;
-            let reply =
-                MessageSender::new(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
-                    .send()
-                    .await;
+            let reply = MessageSender::new_quick(
+                c,
+                message_type,
+                GrpcMessage::Data(msg),
+                Some(Duration::from_secs(10)),
+            )
+            .send()
+            .await;
             match reply {
                 Ok(GrpcMessageReply::Data(msg)) => match MessageReply::decode(&msg)? {
                     MessageReply::StatsInfo(node_status, stats) => Ok(Some((node_status, stats))),
@@ -2048,7 +2054,7 @@ pub(crate) async fn get_stats_all(
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let msg = Message::StatsInfo.encode()?;
-        for reply in MessageBroadcaster::new(
+        for reply in MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(msg),
@@ -2213,10 +2219,14 @@ pub(crate) async fn get_metrics_one(
         let grpc_clients = scx.extends.shared().await.get_grpc_clients();
         if let Some(c) = grpc_clients.get(&id).map(|(_, c)| c.clone()) {
             let msg = Message::MetricsInfo.encode()?;
-            let reply =
-                MessageSender::new(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
-                    .send()
-                    .await;
+            let reply = MessageSender::new_quick(
+                c,
+                message_type,
+                GrpcMessage::Data(msg),
+                Some(Duration::from_secs(10)),
+            )
+            .send()
+            .await;
             match reply {
                 Ok(GrpcMessageReply::Data(msg)) => match MessageReply::decode(&msg)? {
                     MessageReply::MetricsInfo(metrics) => Ok(Some(metrics)),
@@ -2251,7 +2261,7 @@ pub(crate) async fn get_metrics_all(
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let msg = Message::MetricsInfo.encode()?;
-        let replys = MessageBroadcaster::new(
+        let replys = MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(msg),
@@ -2300,7 +2310,7 @@ async fn _get_metrics_sum(scx: &ServerContext, message_type: MessageType) -> Res
     let grpc_clients = scx.extends.shared().await.get_grpc_clients();
     if !grpc_clients.is_empty() {
         let msg = Message::MetricsInfo.encode()?;
-        for reply in MessageBroadcaster::new(
+        for reply in MessageBroadcaster::new_quick(
             grpc_clients,
             message_type,
             GrpcMessage::Data(msg),

--- a/rmqtt-plugins/rmqtt-retainer/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-retainer/Cargo.toml
@@ -23,6 +23,7 @@ redis = ["rmqtt-storage/redis"]
 rmqtt = { workspace = true, features = ["plugin", "retain"] }
 rmqtt-storage = { workspace = true, default-features = false, features = ["ttl", "len"], optional = true}
 #rmqtt-storage = { path = "../../../rmqtt-storage", default-features = false, features = ["ttl", "len"], optional = true}
+rust-box = { workspace = true, features = ["task-exec-queue"] }
 futures.workspace = true
 futures-time.workspace = true
 tokio.workspace = true

--- a/rmqtt-plugins/rmqtt-retainer/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/lib.rs
@@ -89,6 +89,7 @@ impl RetainerPlugin {
                     _ => return Err(anyhow::anyhow!("unsupported storage type")),
                 };
                 let storage_db = init_db(s_cfg).await?;
+                let exec = scx.get_exec(("RETAINER_EXEC", 1000, 100_000));
                 (
                     Retainer::Storage(
                         storage::Retainer::new(
@@ -97,6 +98,7 @@ impl RetainerPlugin {
                             storage_db,
                             retain_enable.clone(),
                             s_cfg.typ.clone(),
+                            exec,
                         )
                         .await?,
                     ),

--- a/rmqtt-plugins/rmqtt-retainer/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/storage.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use futures_time::{self, future::FutureExt};
+use rust_box::task_exec_queue::{SpawnExt, TaskExecQueue};
 use tokio::sync::RwLock;
 
 use rmqtt_storage::{DefaultStorageDB, StorageType};
@@ -54,6 +55,7 @@ impl Retainer {
         storage_db: DefaultStorageDB,
         retain_enable: Arc<AtomicBool>,
         storage_type: StorageType,
+        exec: TaskExecQueue,
     ) -> Result<Retainer> {
         let (msg_tx, msg_rx) = mpsc::channel::<Msg>(300_000);
         let msg_queue_count = Arc::new(AtomicIsize::new(0));
@@ -68,6 +70,7 @@ impl Retainer {
             storage_messages_count,
             storage_messages_max,
             storage_type,
+            exec,
         });
         Self { inner }.serve(msg_rx)
     }
@@ -135,6 +138,7 @@ pub struct RetainerInner {
     storage_messages_count: ValueCached<usize>,
     storage_messages_max: ValueCached<isize>,
     storage_type: StorageType,
+    exec: TaskExecQueue,
 }
 
 impl RetainerInner {
@@ -290,6 +294,32 @@ impl RetainerInner {
     #[inline]
     async fn get_message(&self, topic_filter: &TopicFilter) -> Result<Vec<(TopicName, Retain)>> {
         let topic = Topic::from_str(topic_filter)?;
+
+        // Precise topic short circuit - GET directly without wildcard, O (1) single Redis query
+        if !topic_filter.contains(['+', '#']) {
+            let exact_key = [RETAIN_MESSAGES_PREFIX, topic_filter.as_bytes()].concat();
+            return match self.storage_db.get::<_, StoredMsg>(exact_key.as_slice()).await {
+                Ok(Some((retain, expiry_time_at))) => {
+                    let retains = if let Some(expiry_time_at) = expiry_time_at {
+                        if expiry_time_at > timestamp_millis() {
+                            vec![(TopicName::from(topic_filter.as_ref()), retain)]
+                        } else {
+                            Vec::new()
+                        }
+                    } else {
+                        vec![(TopicName::from(topic_filter.as_ref()), retain)]
+                    };
+                    Ok(retains)
+                }
+                Ok(None) => Ok(Vec::new()),
+                Err(e) => {
+                    log::error!("get_message exact get error: {e:?}");
+                    Ok(Vec::new())
+                }
+            };
+        }
+
+        // Wildcard path: Follow SCAN+MATCH unchanged
         let topic_filter_pattern = Self::topic_filter_to_pattern(topic_filter);
         let mut matched_topics = Vec::new();
         let mut db = self.storage_db.clone();
@@ -465,7 +495,13 @@ impl RetainStorage for Retainer {
             log::error!("{ERR_NOT_SUPPORTED}");
             Ok(Vec::new())
         } else {
-            Ok(self.get_message(topic_filter).await?)
+            let this = self.clone();
+            let tf = topic_filter.clone();
+            async move { this.get_message(&tf).await }
+                .spawn(&self.exec)
+                .result()
+                .await
+                .map_err(|e| anyhow!(e.to_string()))?
         }
     }
 

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -211,7 +211,22 @@ impl GrpcClient {
         defer! {
             active_tasks.dec();
         }
-        self._send_message(typ, msg, timeout).await
+        self._send_message(typ, msg, timeout, false).await
+    }
+
+    #[inline]
+    pub async fn quick_send_message(
+        &mut self,
+        typ: MessageType,
+        msg: Message,
+        timeout: Option<Duration>,
+    ) -> Result<MessageReply> {
+        let active_tasks = self.active_tasks.clone();
+        active_tasks.inc();
+        defer! {
+            active_tasks.dec();
+        }
+        self._send_message(typ, msg, timeout, true).await
     }
 
     #[inline]
@@ -220,7 +235,18 @@ impl GrpcClient {
         typ: MessageType,
         msg: Message,
         timeout: Option<Duration>,
+        quick: bool,
     ) -> Result<MessageReply> {
+        if quick {
+            let req = msg.encode(typ)?;
+            let reply = if let Some(timeout) = timeout {
+                tokio::time::timeout(timeout, self.duplex_mailbox.quick_send(req)).await??
+            } else {
+                self.duplex_mailbox.quick_send(req).await?
+            };
+            return MessageReply::decode(&reply);
+        }
+
         // Fast-fail if the duplex request queue is full (peer node may be down).
         if self.duplex_mailbox.req_queue_is_full() {
             return Err(anyhow::anyhow!(
@@ -243,10 +269,42 @@ impl GrpcClient {
         defer! {
             active_tasks.dec();
         }
-        self._notify(typ, msg, timeout).await
+        self._notify(typ, msg, timeout, false).await
     }
+
     #[inline]
-    async fn _notify(&mut self, typ: MessageType, msg: Message, timeout: Option<Duration>) -> Result<()> {
+    pub async fn quick_notify(
+        &mut self,
+        typ: MessageType,
+        msg: Message,
+        timeout: Option<Duration>,
+    ) -> Result<()> {
+        let active_tasks = self.active_tasks.clone();
+        active_tasks.inc();
+        defer! {
+            active_tasks.dec();
+        }
+        self._notify(typ, msg, timeout, true).await
+    }
+
+    #[inline]
+    async fn _notify(
+        &mut self,
+        typ: MessageType,
+        msg: Message,
+        timeout: Option<Duration>,
+        quick: bool,
+    ) -> Result<()> {
+        if quick {
+            let req = msg.encode(typ)?;
+            if let Some(timeout) = timeout {
+                tokio::time::timeout(timeout, self.mailbox.quick_send(req)).await??;
+            } else {
+                self.mailbox.quick_send(req).await?;
+            };
+            return Ok(());
+        }
+
         // Fast-fail if the transfer queue is full (e.g. the peer node is down).
         // mailbox.send().await blocks indefinitely when the queue is full because
         // poll_ready returns Pending until the consumer drains it — and a dead node
@@ -351,17 +409,33 @@ pub struct MessageSender {
     msg_type: MessageType,
     msg: Message,
     timeout: Option<Duration>,
+    quick: bool,
 }
 
 impl MessageSender {
     #[inline]
     pub fn new(client: GrpcClient, msg_type: MessageType, msg: Message, timeout: Option<Duration>) -> Self {
-        Self { client, msg_type, msg, timeout }
+        Self { client, msg_type, msg, timeout, quick: false }
+    }
+
+    #[inline]
+    pub fn new_quick(
+        client: GrpcClient,
+        msg_type: MessageType,
+        msg: Message,
+        timeout: Option<Duration>,
+    ) -> Self {
+        Self { client, msg_type, msg, timeout, quick: true }
     }
 
     #[inline]
     pub async fn send(mut self) -> Result<MessageReply> {
-        match self.client.send_message(self.msg_type, self.msg, self.timeout).await {
+        let reply = if self.quick {
+            self.client.quick_send_message(self.msg_type, self.msg, self.timeout).await
+        } else {
+            self.client.send_message(self.msg_type, self.msg, self.timeout).await
+        };
+        match reply {
             Ok(reply) => Ok(reply),
             Err(e) => {
                 log::warn!("error sending message, {e:?}");
@@ -372,7 +446,13 @@ impl MessageSender {
 
     #[inline]
     pub async fn notify(mut self) -> Result<()> {
-        match self.client.notify(self.msg_type, self.msg, self.timeout).await {
+        let reply = if self.quick {
+            self.client.quick_notify(self.msg_type, self.msg, self.timeout).await
+        } else {
+            self.client.notify(self.msg_type, self.msg, self.timeout).await
+        };
+
+        match reply {
             Ok(()) => Ok(()),
             Err(e) => {
                 log::warn!("error notify message, {e:?}");
@@ -392,6 +472,7 @@ pub struct MessageBroadcaster {
     msg_type: MessageType,
     msg: Message,
     timeout: Option<Duration>,
+    quick: bool,
 }
 
 impl MessageBroadcaster {
@@ -403,18 +484,36 @@ impl MessageBroadcaster {
         timeout: Option<Duration>,
     ) -> Self {
         assert!(!grpc_clients.is_empty(), "gRPC clients is empty!");
-        Self { grpc_clients, msg_type, msg, timeout }
+        Self { grpc_clients, msg_type, msg, timeout, quick: false }
+    }
+
+    #[inline]
+    pub fn new_quick(
+        grpc_clients: GrpcClients,
+        msg_type: MessageType,
+        msg: Message,
+        timeout: Option<Duration>,
+    ) -> Self {
+        assert!(!grpc_clients.is_empty(), "gRPC clients is empty!");
+        Self { grpc_clients, msg_type, msg, timeout, quick: true }
     }
 
     #[inline]
     pub async fn join_all(self) -> Vec<(NodeId, Result<MessageReply>)> {
         let msg = self.msg;
+        let quick = self.quick;
         let mut senders = Vec::new();
         for (id, (_, grpc_client)) in self.grpc_clients.iter() {
             let msg_type = self.msg_type;
             let msg = msg.clone();
-            let fut =
-                async move { (*id, grpc_client.clone().send_message(msg_type, msg, self.timeout).await) };
+            let fut = async move {
+                let reply = if quick {
+                    grpc_client.clone().quick_send_message(msg_type, msg, self.timeout).await
+                } else {
+                    grpc_client.clone().send_message(msg_type, msg, self.timeout).await
+                };
+                (*id, reply)
+            };
             senders.push(fut.boxed());
         }
         futures::future::join_all(senders).await
@@ -423,11 +522,19 @@ impl MessageBroadcaster {
     #[inline]
     pub async fn notify_all(self) -> Vec<(NodeId, Result<()>)> {
         let msg = self.msg;
+        let quick = self.quick;
         let mut senders = Vec::new();
         for (id, (_, grpc_client)) in self.grpc_clients.iter() {
             let msg_type = self.msg_type;
             let msg = msg.clone();
-            let fut = async move { (*id, grpc_client.clone().notify(msg_type, msg, self.timeout).await) };
+            let fut = async move {
+                let reply = if quick {
+                    grpc_client.clone().quick_notify(msg_type, msg, self.timeout).await
+                } else {
+                    grpc_client.clone().notify(msg_type, msg, self.timeout).await
+                };
+                (*id, reply)
+            };
             senders.push(fut.boxed());
         }
         futures::future::join_all(senders).await
@@ -440,6 +547,7 @@ impl MessageBroadcaster {
         F: Fn(Result<MessageReply>) -> Result<R> + Send + Sync,
     {
         let msg = self.msg;
+        let quick = self.quick;
         let msg_type = self.msg_type;
         let timeout = self.timeout;
 
@@ -447,7 +555,14 @@ impl MessageBroadcaster {
         for (id, (_, grpc_client)) in self.grpc_clients.iter() {
             let mut client = grpc_client.clone();
             let msg = msg.clone();
-            futures.push(async move { (*id, client.send_message(msg_type, msg, timeout).await) });
+            futures.push(async move {
+                let reply = if quick {
+                    client.quick_send_message(msg_type, msg, timeout).await
+                } else {
+                    client.send_message(msg_type, msg, timeout).await
+                };
+                (*id, reply)
+            });
         }
 
         let mut results = Vec::new();
@@ -473,6 +588,7 @@ impl MessageBroadcaster {
     {
         let msg = self.msg;
         let msg_type = self.msg_type;
+        let quick = self.quick;
         let timeout = self.timeout;
 
         let handler = Arc::new(handler);
@@ -482,7 +598,11 @@ impl MessageBroadcaster {
             let msg = msg.clone();
             let handler = Arc::clone(&handler);
             futures.push(Box::pin(async move {
-                let reply = client.send_message(msg_type, msg, timeout).await;
+                let reply = if quick {
+                    client.quick_send_message(msg_type, msg, timeout).await
+                } else {
+                    client.send_message(msg_type, msg, timeout).await
+                };
                 (id, handler(reply).await)
             }));
         }
@@ -501,15 +621,19 @@ impl MessageBroadcaster {
         F: Fn(MessageReply) -> Result<R> + Send + Sync,
     {
         let msg = self.msg;
+        let quick = self.quick;
         let mut senders = Vec::new();
         let max_idx = self.grpc_clients.len() - 1;
         for (i, (_, (_, grpc_client))) in self.grpc_clients.iter().enumerate() {
             if i == max_idx {
-                senders.push(Self::send(grpc_client, self.msg_type, msg, self.timeout, &check_fn).boxed());
+                senders.push(
+                    Self::send(grpc_client, self.msg_type, msg, self.timeout, quick, &check_fn).boxed(),
+                );
                 break;
             } else {
                 senders.push(
-                    Self::send(grpc_client, self.msg_type, msg.clone(), self.timeout, &check_fn).boxed(),
+                    Self::send(grpc_client, self.msg_type, msg.clone(), self.timeout, quick, &check_fn)
+                        .boxed(),
                 );
             }
         }
@@ -523,13 +647,20 @@ impl MessageBroadcaster {
         typ: MessageType,
         msg: Message,
         timeout: Option<Duration>,
+        quick: bool,
         check_fn: &F,
     ) -> Result<R>
     where
         R: std::any::Any + Send + Sync,
         F: Fn(MessageReply) -> Result<R> + Send + Sync,
     {
-        match grpc_client.clone().send_message(typ, msg, timeout).await {
+        let reply = if quick {
+            grpc_client.clone().quick_send_message(typ, msg, timeout).await
+        } else {
+            grpc_client.clone().send_message(typ, msg, timeout).await
+        };
+
+        match reply {
             Ok(r) => {
                 log::debug!("OK reply: {r:?}");
                 check_fn(r)


### PR DESCRIPTION
feat(grpc): add quick-send path with higher priority and bypass queue-full checks
feat(retainer): add exact topic short-circuit for O(1) lookup
fix(cluster): skip retain sync when retainer indicates no sync needed

### Changes

**grpc core (`rmqtt/src/grpc.rs`)**
- Introduce `quick_send_message()` and `quick_notify()` methods that send messages through the higher-priority `DuplexMailbox::quick_send` / `Mailbox::quick_send` channel, and skip the request queue capacity check entirely
- Add `new_quick()` constructors to both `MessageSender` and `MessageBroadcaster`, supporting quick paths across all send modes: `send`, `notify`, `join_all`, `notify_all`, `send_all`, `send_and_check`

**HTTP API (`rmqtt-plugins/rmqtt-http-api/src/api.rs`)**
- Switch all cross-node gRPC calls (20+ call sites) from `new` to `new_quick`, covering BrokerInfo, NodeInfo, Client, Stats, Metrics, Plugins, Subscribe/Unsubscribe, and other admin endpoints

**Cluster retain sync (`rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs`, `rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs`)**
- Add `need_sync()` guard at the top of `sync_retain_message()` to skip gRPC broadcast when the retainer reports no sync is needed

**Retainer storage (`rmqtt-plugins/rmqtt-retainer/src/storage.rs`)**
- Add exact-topic short-circuit path in `get_message()`: for topic filters without `+`/`#` wildcards, perform a single O(1) Redis GET instead of SCAN+MATCH — drastically reducing latency for precise retained-message lookups
- Offload `messages_get()` to `TaskExecQueue.spawn()` for async execution with backpressure