### PR TITLE
feat(retainer): batch storage, topic trie, circuit breaker & rate counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "handy-grpc"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3f5fcb27468550a33fa3dccbb7300906906bc1b362534f9b8124a3c2b0e070"
+checksum = "fb91361ecff6baecebbf478190025c5094f0308af741be37b06b2b288db5b7c0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4185,9 +4185,9 @@ dependencies = [
 
 [[package]]
 name = "queue-ext"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120b0b73691c04d1b3895c9c1131b1e553f0f93f09ffe2ba594992db585624c8"
+checksum = "9921bcd7fb7b6f7ecec0cb47399d6c0e0f41a8eb1a1514ddaece943f3e9c45e3"
 dependencies = [
  "futures",
  "log",
@@ -4714,6 +4714,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "strum",
  "systemstat",
  "thiserror 1.0.69",
  "tokio",
@@ -5379,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-utils"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "bytestring",
@@ -5481,9 +5482,9 @@ dependencies = [
 
 [[package]]
 name = "rust-box"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebcad8abcd40b368b6d1fc9cf6105faa380a965bf0ff2bb3703aa6cd6425a3"
+checksum = "a7b78e9d7746dd59d7a11c80544ae7789f0f943bf45c915f9cccf79d6c908014"
 dependencies = [
  "dequemap",
  "handy-grpc",
@@ -6384,6 +6385,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6474,9 +6497,9 @@ dependencies = [
 
 [[package]]
 name = "task-exec-queue"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3dcac8481d475b2d71d5072b2abe429681f827be6c54fa258754164486629a9"
+checksum = "e24624639a5626a1db333bd3f29a339f42c098389ef6dd34040bd4dfb67f8a0a"
 dependencies = [
  "ahash",
  "box-counter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ rmqtt-codec = "0.2.2"
 rmqtt-net = "0.3.5"
 rmqtt-conf = "0.3.5"
 rmqtt-macros = "0.1.2"
-rmqtt-utils = "0.1.5"
+rmqtt-utils = "0.1.6"
 rmqtt-storage = { version = "0.8",  default-features = false }
 
 rmqtt-plugins = "0.22.0"
@@ -150,7 +150,7 @@ regex = "1.11.1"
 backoff = "0.4"
 webpki-roots = "0.26"
 toml = "0.9"
-rust-box = "0.16"
+rust-box = "0.18"
 scopeguard = "1"
 rayon = "1.11.0"
 parking_lot = "0.12.4"
@@ -158,6 +158,7 @@ proxy-protocol = "0.5"
 jsonwebtoken = "9.3.1"
 quinn = "0.11.6"
 time = "0.3"
+strum = "0.26"
 
 [profile.dev]
 opt-level = 0

--- a/docs/en_US/retainer.md
+++ b/docs/en_US/retainer.md
@@ -11,6 +11,7 @@ Starting from **RMQTT 0.4.0**, the **Retain Message** feature will be disabled b
 Enabling the **Retain Message** feature requires activating the **rmqtt-retainer** plugin and configuring the **listener.tcp.\<xxxx\>.retain_available** option.
 
 **Note:** Starting from **RMQTT 0.11.0**, the configuration item **listener.tcp.\<xxxx\>.retain_available** has been **removed**.
+
 #### Plugins:
 
 ```bash
@@ -31,7 +32,7 @@ plugins/rmqtt-retainer.toml
 ##--------------------------------------------------------------------
 #
 # Single node mode         - ram, sled, redis
-# Multi-node cluster mode  - redis
+# Multi-node cluster mode  - ram, sled, redis
 #
 
 ##ram, sled, redis
@@ -56,25 +57,74 @@ max_payload_size = "1MB"
 # TTL for retained messages. Set to 0 for no expiration.
 # If not specified, the message expiration time will be used by default.
 #retained_message_ttl = "0m"
+
+# Maximum number of messages per batch (default: 500).
+#batch_messages_limit = 500
+
+##─── Circuit breaker ──────────────────────────────────────────────
+##Enable circuit breaker. When storage fails consecutively beyond the threshold,
+##all retain operations fast-fail without touching the storage backend.
+#circuit_breaker_enabled = true
+
+##Consecutive storage failures before tripping the circuit to OPEN (fast-fail).
+#circuit_failure_threshold = 10
+
+##Duration in OPEN state before transitioning to HALF_OPEN (probe).
+#circuit_reset_timeout = "15s"
+
+##Consecutive probe successes needed to close the circuit.
+#circuit_half_open_success_threshold = 3
 ```
 
 Currently, three storage modes are supported: "ram", "sled", and "redis".
 "ram" storage mode stores data in memory. "sled" storage mode stores data on the local disk and requires configuration of 
-the storage location and cache capacity in memory. A suitable size can improve read/write efficiency. "redis" storage mode 
-currently supports only single node. {node} will be replaced with the current node identifier.
+the storage location and cache capacity in memory. A suitable size can improve read/write efficiency. "redis" storage 
+mode currently supports only single node. {node} will be replaced with the current node identifier.
 
 
 Additionally, "max_retained_messages" can be configured to set the maximum number of retained messages, where `0` indicates 
 no limit; "max_payload_size" limits the size of message payloads; "retained_message_ttl" configures the expiration 
 time for retained messages. A value of `"0m"` means no expiration. If not specified, the message expiration time will be used by default.
 
+"batch_messages_limit" limits the maximum number of messages processed in a single batch store operation (default: 500).
+When a large number of retained messages arrive at once, they are grouped into batches of this size for efficient processing.
 
-If RMQTT is deployed in single-node mode, then "ram", "sled", and "redis" are all supported storage modes. However, 
-if RMQTT is deployed in cluster mode, only "redis" is supported.
+The **Circuit Breaker** prevents cascading failures when the storage backend becomes unavailable. When the number of consecutive storage failures exceeds `circuit_failure_threshold` (default: 10), the circuit trips to **OPEN** state and all retain operations (set/get) fast-fail without touching the storage. After `circuit_reset_timeout` (default: `"15s"`), the circuit transitions to **HALF_OPEN** and allows a probe request. If the probe succeeds, the circuit closes; otherwise it re-opens. `circuit_half_open_success_threshold` (default: 3) controls how many consecutive probe successes are needed to close the circuit.
+
+If RMQTT is deployed in single-node mode, then "ram", "sled", and "redis" are all supported storage modes. 
+In cluster mode, all three storage modes are also supported; for "redis" mode, a lightweight topic-only 
+synchronization mechanism is used to reduce inter-node traffic.
+
+### Architecture (v0.22.0+)
+
+Starting from RMQTT **0.22.0**, the retainer plugin uses the following key optimizations:
+
+- **In-Memory Topic Trie Index**: A `RetainTree` is built in memory on startup by scanning all stored retain messages. 
+  This index enables fast wildcard matching when clients subscribe, replacing the previous SCAN+MATCH approach.
+  The trie is updated incrementally as messages are set or removed.
+
+- **Batch Storage**: Messages are collected into a channel and processed in batches using `batch_insert` / `batch_remove` 
+  operations (controlled by `batch_messages_limit`), significantly improving throughput under high load.
+
+- **Rate Counter**: When built with the `rate-counter` feature (enabled by default), the plugin tracks message 
+  processing throughput for monitoring and debugging.
+
+- **RetainSyncMode**: The storage backend reports whether it requires full retain message synchronization across 
+  cluster nodes (`Full`) or only lightweight topic-name synchronization (`TopicOnly`).
+  - `Full`: Used by local-only backends (ram, sled) — the full retain payload is broadcast to all nodes.
+  - `TopicOnly`: Used by shared backends (redis) — only the topic name is broadcast; each node reads the 
+    retain data directly from the shared storage and updates its in-memory topic index.
+
+- **Circuit Breaker**: Integrated into the Retainer storage layer to detect storage backend failures and fast-fail
+  retain operations without touching the backend, preventing cascading node failures. See configuration below.
+
+- **Retain Engine API**: Added `retain_sync_mode()` and `sync_retain_topic()` to the `RetainStorage` trait,
+  enabling storage backends to declare their cluster synchronization strategy and handle topic-only sync
+  notifications from peers.
 
 
-By default, this plugin is not enabled. To activate it, you must add the `rmqtt-retainer` entry to the
-`plugins.default_startups` configuration in the main configuration file `rmqtt.toml`, as shown below:
+The plugin is now **enabled by default** in the main configuration. To verify or change this setting, check the
+`plugins.default_startups` configuration in `rmqtt.toml`:
 ```bash
 ##--------------------------------------------------------------------
 ## Plugins
@@ -94,10 +144,6 @@ plugins.default_startups = [
     "rmqtt-http-api"
 ]
 ```
-
-
-
-
 
 
 

--- a/docs/zh_CN/retainer.md
+++ b/docs/zh_CN/retainer.md
@@ -28,7 +28,7 @@ plugins/rmqtt-retainer.toml
 ##--------------------------------------------------------------------
 #
 # Single node mode         - ram, sled, redis
-# Multi-node cluster mode  - redis
+# Multi-node cluster mode  - ram, sled, redis
 #
 
 ##ram, sled, redis
@@ -53,18 +53,60 @@ max_payload_size = "1MB"
 # TTL for retained messages. Set to 0 for no expiration.
 # If not specified, the message expiration time will be used by default.
 #retained_message_ttl = "0m"
+
+# Maximum number of messages per batch (default: 500).
+#batch_messages_limit = 500
+
+##─── Circuit breaker ──────────────────────────────────────────────
+##Enable circuit breaker. When storage fails consecutively beyond the threshold,
+##all retain operations fast-fail without touching the storage backend.
+#circuit_breaker_enabled = true
+
+##Consecutive storage failures before tripping the circuit to OPEN (fast-fail).
+#circuit_failure_threshold = 10
+
+##Duration in OPEN state before transitioning to HALF_OPEN (probe).
+#circuit_reset_timeout = "15s"
+
+##Consecutive probe successes needed to close the circuit.
+#circuit_half_open_success_threshold = 3
 ```
 
-当前支持“ram”、“sled”和“redis”三种存储模式。“ram”是存储在内存。“sled”是存储在本地磁盘，需要配置存储位置和在内存中的缓存容量，适当大小可以提高读写效率。
-“redis”存储当前仅支持单节点。{node}将被替换为当前节点标识。
+当前支持 "ram"、"sled" 和 "redis" 三种存储模式。"ram" 是存储在内存。"sled" 是存储在本地磁盘，需要配置存储位置和在内存中的缓存容量，适当大小可以提高读写效率。
+"redis" 存储当前仅支持单节点。{node} 将被替换为当前节点标识。
 
-另外，“max_retained_messages”：可以配置最大保留消息数量，`0` 表示无限制；“max_payload_size”：限制消息负载大小；“retained_message_ttl” 
-配置保留消息过期时间，`"0m"`表示不过期，如果未指定，则默认情况下将使用消息过期时间。
+另外，"max_retained_messages"：可以配置最大保留消息数量，`0` 表示无限制；"max_payload_size"：限制消息负载大小；"retained_message_ttl"
+配置保留消息过期时间，`"0m"` 表示不过期，如果未指定，则默认情况下将使用消息过期时间。
 
-如果RMQTT部署为单机模式，那么“ram”、“sled”和“redis”都是支持的。如果RMQTT部署为集群模式，就只支持“redis”。
+"batch_messages_limit" 限制单次批量存储操作处理的最大消息数（默认值：500）。当大量保留消息同时到达时，会按此大小分组进行批量处理以提高效率。
+
+**熔断器（Circuit Breaker）** 防止存储后端不可用时发生级联故障。当连续存储失败次数超过 `circuit_failure_threshold`（默认值：10）时，熔断器进入 **OPEN** 状态，所有保留消息操作（set/get）快速失败，不再访问存储后端。经过 `circuit_reset_timeout`（默认值：`"15s"`）后，熔断器进入 **HALF_OPEN** 状态并允许探针请求。如果探针成功，熔断器关闭；否则重新打开。`circuit_half_open_success_threshold`（默认值：3）控制关闭熔断器所需的连续探针成功次数。
+
+如果 RMQTT 部署为单机模式，"ram"、"sled" 和 "redis" 都是支持的。集群模式下同样支持所有三种存储模式；
+对于 "redis" 模式，使用轻量级的仅主题同步机制来减少节点间流量。
+
+### 架构说明（v0.22.0+）
+
+从 RMQTT **0.22.0** 版本开始，保留消息插件采用了以下关键优化：
+
+- **内存主题 Trie 索引**：启动时通过扫描所有已存储的保留消息，在内存中构建 `RetainTree`。该索引在客户端订阅时提供快速的通配符匹配，
+  替代了之前的 SCAN+MATCH 方式。随着消息的设置或移除，该 Trie 索引会增量更新。
+
+- **批量存储**：消息收集到通道后，通过 `batch_insert` / `batch_remove` 操作进行批量处理（由 `batch_messages_limit` 控制），
+  在高负载下显著提高吞吐量。
+
+- **速率计数器**：当使用 `rate-counter` 特性（默认启用）构建时，插件会跟踪消息处理吞吐量，用于监控和调试。
+
+- **RetainSyncMode**：存储后端上报集群同步所需的模式，决定重同步的方式：
+  - `Full`（完整同步）：用于本地存储后端（ram、sled）—— 将完整保留消息广播到所有节点。
+  - `TopicOnly`（仅主题同步）：用于共享存储后端（redis）—— 仅广播主题名称，每个节点直接从共享存储读取保留数据并更新其本地内存主题索引。
+
+- **熔断器（Circuit Breaker）**：集成到 Retainer 存储层，检测存储后端故障并快速失败保留操作，防止级联节点故障。参见下方配置说明。
+
+- **Retain 引擎 API**：向 `RetainStorage` trait 添加了 `retain_sync_mode()` 和 `sync_retain_topic()` 方法，使存储后端能够声明其集群同步策略并处理来自对等节点的仅主题同步通知。
 
 
-默认情况下并没有启动此插件，如果要开启此插件，必须在主配置文件“rmqtt.toml”中的“plugins.default_startups”配置中添加“rmqtt-retainer”项，如：
+该插件现在默认已**启用**。要验证或更改此设置，请检查主配置文件 `rmqtt.toml` 中的 `plugins.default_startups` 配置：
 ```bash
 ##--------------------------------------------------------------------
 ## Plugins
@@ -84,13 +126,3 @@ plugins.default_startups = [
     "rmqtt-http-api"
 ]
 ```
-
-
-
-
-
-
-
-
-
-

--- a/rmqtt-plugins/rmqtt-bridge-ingress-nats/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-nats/src/bridge.rs
@@ -271,7 +271,8 @@ impl Consumer {
         }
 
         if let (Some(jwt), Some(seed)) = (cfg.auth.jwt.as_ref(), cfg.auth.jwt_seed.as_ref()) {
-            let key_pair = Arc::new(nkeys::KeyPair::from_seed(seed).map_err(|e: nkeys::error::Error| anyhow!(e))?);
+            let key_pair =
+                Arc::new(nkeys::KeyPair::from_seed(seed).map_err(|e: nkeys::error::Error| anyhow!(e))?);
             opts = opts.jwt(jwt.into(), move |nonce| {
                 let key_pair = key_pair.clone();
                 async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }

--- a/rmqtt-plugins/rmqtt-bridge-ingress-nats/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-nats/src/bridge.rs
@@ -271,7 +271,7 @@ impl Consumer {
         }
 
         if let (Some(jwt), Some(seed)) = (cfg.auth.jwt.as_ref(), cfg.auth.jwt_seed.as_ref()) {
-            let key_pair = Arc::new(nkeys::KeyPair::from_seed(seed).map_err(|e| anyhow!(e))?);
+            let key_pair = Arc::new(nkeys::KeyPair::from_seed(seed).map_err(|e: nkeys::error::Error| anyhow!(e))?);
             opts = opts.jwt(jwt.into(), move |nonce| {
                 let key_pair = key_pair.clone();
                 async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }

--- a/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/bridge.rs
@@ -15,7 +15,10 @@ use bytestring::ByteString;
 use event_notify::Event;
 use futures::StreamExt;
 use itertools::Itertools;
-use pulsar::{authentication::oauth2::OAuth2Authentication, authentication::oauth2::OAuth2Params, consumer, Authentication, Pulsar, TokioExecutor};
+use pulsar::{
+    authentication::oauth2::OAuth2Authentication, authentication::oauth2::OAuth2Params, consumer,
+    Authentication, Pulsar, TokioExecutor,
+};
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 

--- a/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/bridge.rs
@@ -15,7 +15,7 @@ use bytestring::ByteString;
 use event_notify::Event;
 use futures::StreamExt;
 use itertools::Itertools;
-use pulsar::{authentication::oauth2::OAuth2Authentication, consumer, Authentication, Pulsar, TokioExecutor};
+use pulsar::{authentication::oauth2::OAuth2Authentication, authentication::oauth2::OAuth2Params, consumer, Authentication, Pulsar, TokioExecutor};
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 
@@ -290,9 +290,9 @@ impl Consumer {
             .with_options(cfg_entry.remote.options)
             .build::<Vec<u8>>()
             .await
-            .map_err(|e| anyhow!(e))?;
+            .map_err(|e: pulsar::Error| anyhow!(e))?;
 
-        consumer.check_connection().await.map_err(|e| anyhow!(e))?;
+        consumer.check_connection().await.map_err(|e: pulsar::Error| anyhow!(e))?;
         log::info!("connection ok");
 
         let (cmd_tx, cmd_rx) = mpsc::channel(100_000);
@@ -456,7 +456,7 @@ impl BridgeManager {
             }
             Some(AuthName::OAuth2) => {
                 let oauth2_cfg = cfg.auth.data.clone().ok_or(anyhow!("oauth2 config is not exist"))?;
-                let oauth2_json = serde_json::from_str(oauth2_cfg.as_str()).map_err(|e| {
+                let oauth2_json = serde_json::from_str::<OAuth2Params>(oauth2_cfg.as_str()).map_err(|e| {
                     anyhow!(format!("invalid oauth2 config [{}], {:?}", oauth2_cfg.as_str(), e))
                 })?;
                 builder = builder.with_auth_provider(OAuth2Authentication::client_credentials(oauth2_json));
@@ -470,7 +470,7 @@ impl BridgeManager {
         builder = builder.with_tls_hostname_verification_enabled(cfg.tls_hostname_verification_enabled);
         builder = builder.with_allow_insecure_connection(cfg.allow_insecure_connection);
 
-        let pulsar: Pulsar<_> = builder.build().await.map_err(|e| anyhow!(e))?;
+        let pulsar: Pulsar<_> = builder.build().await.map_err(|e: pulsar::Error| anyhow!(e))?;
         Ok(pulsar)
     }
 

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/handler.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/handler.rs
@@ -137,22 +137,26 @@ impl Handler for HookHandler {
                     }
                     Message::SetRetain(topic, retain, expiry_interval) => {
                         let retain_mgr = self.scx.extends.retain().await;
-                        let current_retains = retain_mgr.get(topic).await.unwrap_or_default();
-                        let should_update = match current_retains.first() {
-                            Some((_, existing)) => {
-                                let incoming_ts = retain.publish.create_time.unwrap_or(0);
-                                let existing_ts = existing.publish.create_time.unwrap_or(0);
-                                incoming_ts > existing_ts
-                            }
-                            None => true,
-                        };
-                        if should_update {
-                            if let Err(e) = retain_mgr.set(topic, retain.clone(), *expiry_interval).await {
-                                log::warn!("Failed to apply remote retain: {e:?}");
-                            }
+                        if let Err(e) = retain_mgr.set(topic, retain.clone(), *expiry_interval).await {
+                            log::warn!("Failed to apply remote retain: {e:?}");
                         }
-                        let new_acc =
-                            HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(should_update)));
+                        let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(true)));
+                        return (false, Some(new_acc));
+                    }
+                    Message::SetRetainTopicAdd(topic, expiry_interval) => {
+                        let retain_mgr = self.scx.extends.retain().await;
+                        if let Err(e) = retain_mgr.sync_retain_topic(topic, *expiry_interval, true).await {
+                            log::warn!("Failed to sync retain topic (add): {e:?}");
+                        }
+                        let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(true)));
+                        return (false, Some(new_acc));
+                    }
+                    Message::SetRetainTopicRemove(topic) => {
+                        let retain_mgr = self.scx.extends.retain().await;
+                        if let Err(e) = retain_mgr.sync_retain_topic(topic, None, false).await {
+                            log::warn!("Failed to sync retain topic (remove): {e:?}");
+                        }
+                        let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(true)));
                         return (false, Some(new_acc));
                     }
                     Message::Online(clientid) => {

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -12,6 +12,7 @@ use rust_box::task_exec_queue::{SpawnExt, TaskExecQueue};
 
 use rmqtt::context::ServerContext;
 use rmqtt::net::MqttError;
+use rmqtt::retain::RetainSyncMode;
 use rmqtt::shared::{DefaultShared, Entry, MessageLoadCallback, Shared};
 use rmqtt::types::{HealthInfo, MsgID, NodeHealthStatus, Retain, TopicName};
 
@@ -902,16 +903,39 @@ impl Shared for ClusterShared {
             return Ok(());
         }
 
-        if !self.scx.extends.retain().await.need_sync() {
-            return Ok(());
-        }
-
-        let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
-        for (node_id, (_, client)) in self.grpc_clients.iter() {
-            let sender =
-                MessageSender::new(client.clone(), self.message_type, msg.clone(), Some(self.rw_timeout));
-            if let Err(e) = sender.notify().await {
-                log::warn!("retain_set_broadcast to node {node_id} failed, {e:?}");
+        match self.scx.extends.retain().await.retain_sync_mode() {
+            RetainSyncMode::Full => {
+                let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
+                for (node_id, (_, client)) in self.grpc_clients.iter() {
+                    let sender = MessageSender::new(
+                        client.clone(),
+                        self.message_type,
+                        msg.clone(),
+                        Some(self.rw_timeout),
+                    );
+                    if let Err(e) = sender.notify().await {
+                        log::warn!("retain_set_broadcast to node {node_id} failed, {e:?}");
+                    }
+                }
+            }
+            RetainSyncMode::TopicOnly => {
+                let is_set = !retain.publish.payload.is_empty();
+                let msg = if is_set {
+                    Message::SetRetainTopicAdd(topic.clone(), expiry_interval)
+                } else {
+                    Message::SetRetainTopicRemove(topic.clone())
+                };
+                for (node_id, (_, client)) in self.grpc_clients.iter() {
+                    let sender = MessageSender::new(
+                        client.clone(),
+                        self.message_type,
+                        msg.clone(),
+                        Some(self.rw_timeout),
+                    );
+                    if let Err(e) = sender.notify().await {
+                        log::warn!("retain_set_broadcast(topic) to node {node_id} failed, {e:?}");
+                    }
+                }
             }
         }
         Ok(())

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/handler.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/handler.rs
@@ -203,23 +203,35 @@ impl Handler for HookHandler {
                         return (false, Some(new_acc));
                     }
                     GrpcMessage::SetRetain(topic, retain, expiry_interval) => {
-                        let retain_mgr = self.scx.extends.retain().await;
-                        let current_retains = retain_mgr.get(topic).await.unwrap_or_default();
-                        let should_update = match current_retains.first() {
-                            Some((_, existing)) => {
-                                let incoming_ts = retain.publish.create_time.unwrap_or(0);
-                                let existing_ts = existing.publish.create_time.unwrap_or(0);
-                                incoming_ts > existing_ts
-                            }
-                            None => true,
-                        };
-                        if should_update {
-                            if let Err(e) = retain_mgr.set(topic, retain.clone(), *expiry_interval).await {
-                                log::warn!("Failed to apply remote retain: {e:?}");
-                            }
+                        if let Err(e) =
+                            self.scx.extends.retain().await.set(topic, retain.clone(), *expiry_interval).await
+                        {
+                            log::warn!("Failed to apply remote retain: {e:?}");
                         }
-                        let new_acc =
-                            HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(should_update)));
+                        let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(true)));
+                        return (false, Some(new_acc));
+                    }
+                    GrpcMessage::SetRetainTopicAdd(topic, expiry_interval) => {
+                        if let Err(e) = self
+                            .scx
+                            .extends
+                            .retain()
+                            .await
+                            .sync_retain_topic(topic, *expiry_interval, true)
+                            .await
+                        {
+                            log::warn!("Failed to sync retain topic (add): {e:?}");
+                        }
+                        let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(true)));
+                        return (false, Some(new_acc));
+                    }
+                    GrpcMessage::SetRetainTopicRemove(topic) => {
+                        if let Err(e) =
+                            self.scx.extends.retain().await.sync_retain_topic(topic, None, false).await
+                        {
+                            log::warn!("Failed to sync retain topic (remove): {e:?}");
+                        }
+                        let new_acc = HookResult::GrpcMessageReply(Ok(MessageReply::SetRetain(true)));
                         return (false, Some(new_acc));
                     }
                     GrpcMessage::SubscriptionsGet(clientid) => {

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -22,6 +22,7 @@ use futures::future::FutureExt;
 use rust_box::task_exec_queue::{SpawnExt, TaskExecQueue};
 
 use rmqtt::context::ServerContext;
+use rmqtt::retain::RetainSyncMode;
 use rmqtt::types::{ClientId, Retain, SubscriptionOptions, TopicFilter, TopicName};
 use rmqtt::{
     grpc::{GrpcClient, GrpcClients, Message, MessageBroadcaster, MessageReply, MessageSender, MessageType},
@@ -306,6 +307,7 @@ pub struct ClusterShared {
     scx: ServerContext,
     exec: TaskExecQueue,
     forwards_exec: TaskExecQueue,
+    retainer_exec: TaskExecQueue,
     inner: DefaultShared,
     router: ClusterRouter,
     grpc_clients: GrpcClients,
@@ -332,10 +334,12 @@ impl ClusterShared {
     ) -> ClusterShared {
         let scx1 = scx.clone();
         let forwards_exec = scx.get_exec("RAFT_FORWARDS_EXEC");
+        let retainer_exec = scx.get_exec("RAFT_RETAINER_EXEC");
         Self {
             scx,
             exec,
             forwards_exec,
+            retainer_exec,
             inner: DefaultShared::new(Some(scx1)),
             router,
             grpc_clients,
@@ -826,7 +830,7 @@ impl Shared for ClusterShared {
                     })
                     .await
                 }
-                .spawn(&self.exec)
+                .spawn(&self.retainer_exec)
                 .result()
                 .await
                 .map_err(|_| anyhow!("ClusterShared::retain_load_with task execution failure"))?;
@@ -857,16 +861,39 @@ impl Shared for ClusterShared {
             return Ok(());
         }
 
-        if !self.scx.extends.retain().await.need_sync() {
-            return Ok(());
-        }
-
-        let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
-        for (node_id, (_, client)) in self.grpc_clients.iter() {
-            let sender =
-                MessageSender::new(client.clone(), self.message_type, msg.clone(), Some(self.rw_timeout));
-            if let Err(e) = sender.notify().await {
-                log::warn!("retain_set_broadcast to node {node_id} failed, {e:?}");
+        match self.scx.extends.retain().await.retain_sync_mode() {
+            RetainSyncMode::Full => {
+                let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
+                for (node_id, (_, client)) in self.grpc_clients.iter() {
+                    let sender = MessageSender::new(
+                        client.clone(),
+                        self.message_type,
+                        msg.clone(),
+                        Some(self.rw_timeout),
+                    );
+                    if let Err(e) = sender.notify().spawn(&self.retainer_exec).await {
+                        log::warn!("retain_set_broadcast to node {node_id} failed, {}", e);
+                    }
+                }
+            }
+            RetainSyncMode::TopicOnly => {
+                let is_set = !retain.publish.payload.is_empty();
+                let msg = if is_set {
+                    Message::SetRetainTopicAdd(topic.clone(), expiry_interval)
+                } else {
+                    Message::SetRetainTopicRemove(topic.clone())
+                };
+                for (node_id, (_, client)) in self.grpc_clients.iter() {
+                    let sender = MessageSender::new(
+                        client.clone(),
+                        self.message_type,
+                        msg.clone(),
+                        Some(self.rw_timeout),
+                    );
+                    if let Err(e) = sender.notify().spawn(&self.retainer_exec).await {
+                        log::warn!("retain_set_broadcast(topic) to node {node_id} failed, {}", e);
+                    }
+                }
             }
         }
         Ok(())

--- a/rmqtt-plugins/rmqtt-retainer.toml
+++ b/rmqtt-plugins/rmqtt-retainer.toml
@@ -3,7 +3,7 @@
 ##--------------------------------------------------------------------
 #
 # Single node mode         - ram, sled, redis
-# Multi-node cluster mode  - redis
+# Multi-node cluster mode  - ram, sled, redis
 #
 
 ##ram, sled, redis
@@ -28,3 +28,20 @@ max_payload_size = "1MB"
 # TTL for retained messages. Set to 0 for no expiration.
 # If not specified, the message expiration time will be used by default.
 retained_message_ttl = "0m"
+
+# Maximum number of messages per batch (default: 500).
+batch_messages_limit = 500
+
+##─── Circuit breaker ──────────────────────────────────────────────
+##Enable circuit breaker. When storage fails consecutively beyond the threshold,
+##all retain operations fast-fail without touching the storage backend.
+#circuit_breaker_enabled = true
+
+##Consecutive storage failures before tripping the circuit to OPEN (fast-fail).
+#circuit_failure_threshold = 10
+
+##Duration in OPEN state before transitioning to HALF_OPEN (probe).
+#circuit_reset_timeout = "15s"
+
+##Consecutive probe successes needed to close the circuit.
+#circuit_half_open_success_threshold = 3

--- a/rmqtt-plugins/rmqtt-retainer/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-retainer/Cargo.toml
@@ -14,10 +14,11 @@ license.workspace = true
 all-features = true
 
 [features]
-default = []
+default = ["rate-counter"]
 ram = []
 sled = ["rmqtt-storage/sled"]
 redis = ["rmqtt-storage/redis"]
+rate-counter = []
 
 [dependencies]
 rmqtt = { workspace = true, features = ["plugin", "retain"] }

--- a/rmqtt-plugins/rmqtt-retainer/README-CN.md
+++ b/rmqtt-plugins/rmqtt-retainer/README-CN.md
@@ -6,9 +6,20 @@
 
 保留消息存储插件。支持 RAM、Sled（嵌入式）和 Redis 三种后端。替换 Broker 默认的 retain 引擎，提供重启后持久化能力。
 
+所有后端均支持单机和集群模式。集群模式下，本地存储后端（ram、sled）使用完整保留同步，Redis 使用轻量级仅主题同步。
+
 ## 概述
 
-在 `BeforeStartup` Hook 中注入持久化 retain 存储。后台任务每 10 秒定期清理过期的保留消息。仅 Redis 后端支持集群模式。
+在 `BeforeStartup` Hook 中注入持久化 retain 存储。后台任务每 10 秒定期清理过期的保留消息。
+
+### 架构说明（v0.22.0+）
+
+- **内存主题 Trie 索引**：启动时通过扫描已存储的保留消息构建。为订阅查询提供快速通配符匹配，替代了之前的 SCAN+MATCH 方式。
+- **批量存储**：消息收集后通过 `batch_insert` / `batch_remove` 批量处理，由 `batch_messages_limit` 控制。
+- **速率计数器**：跟踪处理吞吐量（通过 `rate-counter` 特性默认启用）。
+- **RetainSyncMode**：
+  - `Full`：完整保留消息广播（ram、sled）。
+  - `TopicOnly`：仅主题名称同步（共享存储的 Redis）。
 
 ## 使用方法
 
@@ -18,19 +29,25 @@
 
 ```toml
 # 直接依赖
-rmqtt-retainer = { version = "0.21", features = ["ram"] }
+rmqtt-retainer = { version = "0.22", features = ["ram"] }
 
 # 或通过元 crate
-rmqtt-plugins = { version = "0.21", features = ["retainer-ram"] }
+rmqtt-plugins = { version = "0.22", features = ["retainer-ram"] }
 ```
 
 可用的存储后端 Feature 标志：
 
 | Feature | 后端 | 持久化 | 集群支持 |
 |---------|------|--------|----------|
-| `ram` | 内存 HashMap | 否（重启丢失） | 否 |
-| `sled` | Sled 嵌入式数据库（磁盘） | 是 | 否 |
+| `ram` | 内存 HashMap | 否（重启丢失） | 是 |
+| `sled` | Sled 嵌入式数据库（磁盘） | 是 | 是 |
 | `redis` | Redis 远程存储 | 是 | 是 |
+
+其他特性：
+
+| Feature | 说明 |
+|---------|------|
+| `rate-counter` | 启用吞吐量速率计数器（默认启用） |
 
 ### 注册
 
@@ -56,6 +73,11 @@ rmqtt_retainer::register_named(&scx, "rmqtt-retainer", true, false).await?;
 | `max_retained_messages` | `u64` | `0`（无限制） | 最大保留消息数。超出后现有消息可被替换，但无法为新主题存储保留消息。 |
 | `max_payload_size` | `string` | `"1MB"` | 保留消息的最大 Payload 大小。超出后该消息将被视为普通消息处理。 |
 | `retained_message_ttl` | `string` | `"0m"`（不过期） | 保留消息的 TTL。未设置时默认使用消息过期时间。 |
+| `batch_messages_limit` | `usize` | `500` | 单次批量存储操作的最大消息数 |
+| `circuit_breaker_enabled` | `bool` | `true` | 启用熔断器，检测存储后端故障 |
+| `circuit_failure_threshold` | `usize` | `10` | 触发熔断器 OPEN 所需的连续失败次数 |
+| `circuit_reset_timeout` | `string` | `"15s"` | OPEN 状态持续时间，之后进入 HALF_OPEN 状态探针 |
+| `circuit_half_open_success_threshold` | `usize` | `3` | 关闭熔断器所需的连续探针成功次数 |
 
 ### 配置来源
 
@@ -71,7 +93,7 @@ rmqtt_retainer::register_named(&scx, "rmqtt-retainer", true, false).await?;
 # RAM 模式（默认）
 storage.type = "ram"
 
-# Sled 模式（持久化，单节点）
+# Sled 模式（持久化）
 storage.type = "sled"
 storage.sled.path = "/var/log/rmqtt/.cache/retain/{node}"
 storage.sled.cache_capacity = "3G"
@@ -85,6 +107,13 @@ storage.redis.prefix = "retain"
 max_retained_messages = 10000
 max_payload_size = "1MB"
 retained_message_ttl = "24h"
+batch_messages_limit = 500
+
+# 熔断器（默认启用）
+#circuit_breaker_enabled = true
+#circuit_failure_threshold = 10
+#circuit_reset_timeout = "15s"
+#circuit_half_open_success_threshold = 3
 ```
 
 ## 依赖

--- a/rmqtt-plugins/rmqtt-retainer/README.md
+++ b/rmqtt-plugins/rmqtt-retainer/README.md
@@ -6,9 +6,22 @@
 
 Retained message storage plugin. Supports RAM, Sled (embedded), and Redis backends. Replaces the default retain engine with persistent storage.
 
+All backends support both single-node and cluster mode. In cluster mode, local backends (ram, sled) use full retain synchronization, while Redis uses lightweight topic-only synchronization.
+
 ## Overview
 
-Intercepts the `BeforeStartup` hook to inject a persistent retain store. A background task periodically (every 10s) cleans expired retained messages. Only the Redis backend supports cluster mode.
+Intercepts the `BeforeStartup` hook to inject a persistent retain store. A background task periodically (every 10s) cleans expired retained messages.
+
+### Architecture (v0.22.0+)
+
+- **In-Memory Topic Trie Index**: Built on startup by scanning stored retain messages. Provides fast wildcard matching for subscription queries, replacing the previous SCAN+MATCH approach.
+- **Batch Storage**: Messages are collected and processed in batches (`batch_insert` / `batch_remove`), controlled by `batch_messages_limit`.
+- **Rate Counter**: Tracks processing throughput (enabled by default via the `rate-counter` feature).
+- **RetainSyncMode**:
+  - `Full`: Full retain payload broadcast (ram, sled).
+  - `TopicOnly`: Lightweight topic-name sync only (Redis with shared storage).
+- **Circuit Breaker**: Built-in storage failure detection with automatic fast-fail degradation and recovery.
+  See configuration below.
 
 ## Usage
 
@@ -18,19 +31,25 @@ Add the dependency in `rmqttd/Cargo.toml` or enable via the `rmqtt-plugins` meta
 
 ```toml
 # Direct dependency
-rmqtt-retainer = { version = "0.21", features = ["ram"] }
+rmqtt-retainer = { version = "0.22", features = ["ram"] }
 
 # Or via meta-crate
-rmqtt-plugins = { version = "0.21", features = ["retainer-ram"] }
+rmqtt-plugins = { version = "0.22", features = ["retainer-ram"] }
 ```
 
 Available feature flags for storage backends:
 
 | Feature | Backend | Persistence | Cluster Support |
 |---------|---------|-------------|-----------------|
-| `ram` | In-memory HashMap | No (lost on restart) | No |
-| `sled` | Sled embedded DB (disk) | Yes | No |
+| `ram` | In-memory HashMap | No (lost on restart) | Yes |
+| `sled` | Sled embedded DB (disk) | Yes | Yes |
 | `redis` | Redis remote store | Yes | Yes |
+
+Additional features:
+
+| Feature | Description |
+|---------|-------------|
+| `rate-counter` | Enable throughput rate counter (enabled by default) |
 
 ### Register
 
@@ -56,6 +75,11 @@ File: `rmqtt-retainer.toml` (in the plugin config directory). Loaded via `scx.pl
 | `max_retained_messages` | `u64` | `0` (unlimited) | Maximum retained messages. After exceeding, existing messages can be replaced but new topics cannot be stored. |
 | `max_payload_size` | `string` | `"1MB"` | Maximum payload size for retained messages. Exceeding this causes the message to be treated as a regular message. |
 | `retained_message_ttl` | `string` | `"0m"` (no expiry) | TTL for retained messages. If not set, defaults to the message expiry interval. |
+| `batch_messages_limit` | `usize` | `500` | Maximum number of messages per batch store operation |
+| `circuit_breaker_enabled` | `bool` | `true` | Enable circuit breaker for storage failure detection |
+| `circuit_failure_threshold` | `usize` | `10` | Consecutive failures before tripping the circuit to OPEN |
+| `circuit_reset_timeout` | `string` | `"15s"` | Duration in OPEN state before transitioning to HALF_OPEN |
+| `circuit_half_open_success_threshold` | `usize` | `3` | Consecutive probe successes needed to close the circuit |
 
 ### Configuration Source
 
@@ -71,7 +95,7 @@ The plugin loads configuration via `scx.plugins.load_config_default::<PluginConf
 # RAM mode (default)
 storage.type = "ram"
 
-# Sled mode (persistent, single-node)
+# Sled mode (persistent)
 storage.type = "sled"
 storage.sled.path = "/var/log/rmqtt/.cache/retain/{node}"
 storage.sled.cache_capacity = "3G"
@@ -85,6 +109,13 @@ storage.redis.prefix = "retain"
 max_retained_messages = 10000
 max_payload_size = "1MB"
 retained_message_ttl = "24h"
+batch_messages_limit = 500
+
+# Circuit breaker (enabled by default)
+#circuit_breaker_enabled = true
+#circuit_failure_threshold = 10
+#circuit_reset_timeout = "15s"
+#circuit_half_open_success_threshold = 3
 ```
 
 ## Dependencies

--- a/rmqtt-plugins/rmqtt-retainer/src/config.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/config.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 
-use rmqtt::utils::{deserialize_duration_option, Bytesize};
+use rmqtt::utils::{deserialize_duration, deserialize_duration_option, Bytesize};
 use rmqtt::Result;
 
 /// Top-level configuration for the retained messages plugin.
@@ -35,6 +35,33 @@ pub struct PluginConfig {
     // If not specified, the message expiration time will be used by default.
     #[serde(default, deserialize_with = "deserialize_duration_option")]
     pub retained_message_ttl: Option<Duration>,
+
+    // Maximum number of messages per batch (default: 500).
+    #[serde(default = "PluginConfig::batch_messages_limit_default")]
+    pub batch_messages_limit: usize,
+
+    // ─── Circuit breaker ─────────────────────────────────────────────────
+    /// Enable circuit breaker for storage operations. When enabled and the
+    /// circuit is OPEN, all retain store/get operations fast-fail without
+    /// touching the storage backend.
+    #[serde(default = "PluginConfig::circuit_breaker_enabled_default")]
+    pub circuit_breaker_enabled: bool,
+
+    /// Consecutive storage failures before tripping the circuit to OPEN.
+    #[serde(default = "PluginConfig::circuit_failure_threshold_default")]
+    pub circuit_failure_threshold: usize,
+
+    /// Duration in OPEN state before transitioning to HALF_OPEN (probe).
+    /// Example: "15s", "1m".
+    #[serde(
+        default = "PluginConfig::circuit_reset_timeout_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub circuit_reset_timeout: Duration,
+
+    /// Consecutive probe successes in HALF_OPEN before closing the circuit.
+    #[serde(default = "PluginConfig::circuit_half_open_success_threshold_default")]
+    pub circuit_half_open_success_threshold: usize,
 }
 
 impl PluginConfig {
@@ -51,6 +78,26 @@ impl PluginConfig {
 
     fn max_payload_size_default() -> Bytesize {
         Bytesize::from(1024 * 1024)
+    }
+
+    fn batch_messages_limit_default() -> usize {
+        500
+    }
+
+    fn circuit_breaker_enabled_default() -> bool {
+        true
+    }
+
+    fn circuit_failure_threshold_default() -> usize {
+        10
+    }
+
+    fn circuit_reset_timeout_default() -> Duration {
+        Duration::from_secs(15)
+    }
+
+    fn circuit_half_open_success_threshold_default() -> usize {
+        3
     }
 
     #[inline]

--- a/rmqtt-plugins/rmqtt-retainer/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/lib.rs
@@ -13,7 +13,6 @@
 //!
 #![deny(unsafe_code)]
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -24,10 +23,12 @@ use tokio::sync::RwLock;
 
 use rmqtt::{
     context::ServerContext,
-    hook::{Handler, HookResult, Parameter, Register, ReturnType, Type},
+    hook::Register,
     macros::Plugin,
     plugin::Plugin,
-    register, Result,
+    register,
+    utils::{CircuitBreaker, CircuitBreakerConfig},
+    Result,
 };
 
 #[cfg(feature = "ram")]
@@ -35,6 +36,7 @@ use ram::RamRetainer;
 #[cfg(any(feature = "sled", feature = "redis"))]
 use rmqtt_storage::{init_db, StorageType};
 
+#[cfg_attr(not(any(feature = "ram", feature = "sled", feature = "redis")), allow(unused_imports))]
 use config::{Config, PluginConfig};
 use rmqtt::plugin::PackageInfo;
 use rmqtt::retain::RetainStorage;
@@ -44,6 +46,8 @@ mod config;
 mod ram;
 #[cfg(any(feature = "sled", feature = "redis"))]
 mod storage;
+#[cfg_attr(not(any(feature = "sled", feature = "redis")), allow(dead_code))]
+mod value_cached;
 
 register!(RetainerPlugin::new);
 
@@ -53,12 +57,14 @@ struct RetainerPlugin {
     register: Box<dyn Register>,
     cfg: Arc<RwLock<PluginConfig>>,
     retainer: Retainer,
-    support_cluster: bool,
-    retain_enable: Arc<AtomicBool>,
 }
 
 impl RetainerPlugin {
     #[inline]
+    #[cfg_attr(
+        not(any(feature = "ram", feature = "sled", feature = "redis")),
+        allow(unused, unreachable_code)
+    )]
     async fn new<N: Into<String>>(scx: ServerContext, name: N) -> Result<Self> {
         let name = name.into();
 
@@ -66,53 +72,63 @@ impl RetainerPlugin {
         log::info!("{name} RetainerPlugin cfg: {cfg:?}");
         let register = scx.extends.hook_mgr().register();
         let cfg = Arc::new(RwLock::new(cfg));
-        let retain_enable = Arc::new(AtomicBool::new(false));
 
-        let (retainer, support_cluster) = match &mut cfg.write().await.storage {
-            #[cfg(feature = "ram")]
-            Some(Config::Ram) => (Retainer::Ram(RamRetainer::new(cfg.clone(), retain_enable.clone())), true),
-            #[cfg(any(feature = "sled", feature = "redis"))]
-            Some(Config::Storage(s_cfg)) => {
-                let node_id = scx.node.id();
-                let support_cluster = match s_cfg.typ {
-                    #[cfg(feature = "sled")]
-                    StorageType::Sled => {
-                        s_cfg.sled.path = s_cfg.sled.path.replace("{node}", &format!("{node_id}"));
-                        true
-                    }
-                    #[cfg(feature = "redis")]
-                    StorageType::Redis => {
-                        s_cfg.redis.prefix = s_cfg.redis.prefix.replace("{node}", &format!("{node_id}"));
-                        true
-                    }
-                    #[allow(unreachable_patterns)]
-                    _ => return Err(anyhow::anyhow!("unsupported storage type")),
-                };
-                let storage_db = init_db(s_cfg).await?;
-                let exec = scx.get_exec(("RETAINER_EXEC", 1000, 100_000));
-                (
+        let retainer = {
+            let cfg_guard = cfg.read().await;
+            let batch_messages_limit = cfg_guard.batch_messages_limit;
+            // Build the circuit breaker here (before cfg.write() below) to
+            // avoid deadlock: tokio::sync::RwLock is NOT reentrant, and
+            // cfg.write() is held inside the match block.
+            let circuit_breaker = CircuitBreaker::new(CircuitBreakerConfig {
+                enabled: cfg_guard.circuit_breaker_enabled,
+                failure_threshold: cfg_guard.circuit_failure_threshold,
+                reset_timeout: cfg_guard.circuit_reset_timeout,
+                half_open_success_threshold: cfg_guard.circuit_half_open_success_threshold,
+            });
+            drop(cfg_guard);
+
+            match &mut cfg.write().await.storage {
+                #[cfg(feature = "ram")]
+                Some(Config::Ram) => Retainer::Ram(RamRetainer::new(cfg.clone())),
+                #[cfg(any(feature = "sled", feature = "redis"))]
+                Some(Config::Storage(s_cfg)) => {
+                    let node_id = scx.node.id();
+                    match s_cfg.typ {
+                        #[cfg(feature = "sled")]
+                        StorageType::Sled => {
+                            s_cfg.sled.path = s_cfg.sled.path.replace("{node}", &format!("{node_id}"));
+                        }
+                        #[cfg(feature = "redis")]
+                        StorageType::Redis => {
+                            s_cfg.redis.prefix = s_cfg.redis.prefix.replace("{node}", &format!("{node_id}"));
+                        }
+                        #[allow(unreachable_patterns)]
+                        _ => return Err(anyhow::anyhow!("unsupported storage type")),
+                    };
+                    let storage_db = init_db(s_cfg).await?;
+                    let exec = scx.get_exec(("RETAINER_EXEC", 1000, 10_000));
                     Retainer::Storage(
                         storage::Retainer::new(
                             node_id,
                             cfg.clone(),
                             storage_db,
-                            retain_enable.clone(),
                             s_cfg.typ.clone(),
                             exec,
+                            batch_messages_limit,
+                            circuit_breaker,
                         )
                         .await?,
-                    ),
-                    support_cluster,
-                )
+                    )
+                }
+                #[allow(unreachable_patterns)]
+                Some(other) => {
+                    return Err(anyhow!("Unsupported storage engine: {other:?} (feature not enabled)"))
+                }
+                None => return Err(anyhow!("No storage engine specified (ram, sled, or redis)")),
             }
-            #[allow(unreachable_patterns)]
-            Some(other) => {
-                return Err(anyhow!("Unsupported storage engine: {other:?} (feature not enabled)"))
-            }
-            None => return Err(anyhow!("No storage engine specified (ram, sled, or redis)")),
         };
 
-        Ok(Self { scx, register, cfg, retainer, support_cluster, retain_enable })
+        Ok(Self { scx, register, cfg, retainer })
     }
 }
 
@@ -121,23 +137,13 @@ impl Plugin for RetainerPlugin {
     #[inline]
     async fn init(&mut self) -> Result<()> {
         log::info!("{} init", self.name());
-        self.register
-            .add(
-                Type::BeforeStartup,
-                Box::new(RetainHandler::new(
-                    self.scx.clone(),
-                    self.support_cluster,
-                    self.retain_enable.clone(),
-                )),
-            )
-            .await;
 
-        let retainer = self.retainer.clone();
+        let _retainer = self.retainer.clone();
         //I run every 10 seconds
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(10)).await;
-                let removeds = retainer.remove_expired_messages().await;
+                let removeds = _retainer.remove_expired_messages().await;
                 if removeds > 0 {
                     log::debug!(
                         "{:?} remove_expired_messages, removed count: {}",
@@ -165,6 +171,10 @@ impl Plugin for RetainerPlugin {
     }
 
     #[inline]
+    #[cfg_attr(
+        not(any(feature = "ram", feature = "sled", feature = "redis")),
+        allow(unused, unreachable_code)
+    )]
     async fn start(&mut self) -> Result<()> {
         log::info!("{} start", self.name());
         let r: Box<dyn RetainStorage> = match self.retainer.clone() {
@@ -192,39 +202,6 @@ impl Plugin for RetainerPlugin {
     }
 }
 
-struct RetainHandler {
-    scx: ServerContext,
-    support_cluster: bool,
-    retain_enable: Arc<AtomicBool>,
-}
-
-impl RetainHandler {
-    fn new(scx: ServerContext, support_cluster: bool, retain_enable: Arc<AtomicBool>) -> Self {
-        Self { scx, support_cluster, retain_enable }
-    }
-}
-
-#[async_trait]
-impl Handler for RetainHandler {
-    async fn hook(&self, param: &Parameter, acc: Option<HookResult>) -> ReturnType {
-        match param {
-            Parameter::BeforeStartup => {
-                let grpc_enable = self.scx.extends.shared().await.grpc_enable();
-                if grpc_enable && !self.support_cluster {
-                    log::warn!("{ERR_NOT_SUPPORTED}");
-                    self.retain_enable.store(false, Ordering::SeqCst);
-                } else {
-                    self.retain_enable.store(true, Ordering::SeqCst);
-                }
-            }
-            _ => {
-                log::error!("unimplemented, {param:?}")
-            }
-        }
-        (true, acc)
-    }
-}
-
 #[derive(Clone)]
 enum Retainer {
     #[cfg(feature = "ram")]
@@ -245,6 +222,7 @@ impl Retainer {
         }
     }
 
+    #[allow(unused_mut)]
     async fn info(&self) -> serde_json::Value {
         match self {
             #[cfg(feature = "ram")]
@@ -267,22 +245,37 @@ impl Retainer {
             Retainer::Storage(r) => {
                 let msg_max = r.max().await;
                 let msg_count = r.count().await;
-                let msg_queue_count = r.msg_queue_count.load(Ordering::Relaxed);
-                let storage_info = r.storage_db.info().await.unwrap_or_default();
-                json!({
+                let storage_info = r.info().await;
+                let topics_size = r.topics.read().await.values_size();
+                let cb_state = format!("{:?}", r.circuit_breaker.state());
+                let cb_enabled = r.circuit_breaker.config().enabled;
+                let cb_failure_count = r.circuit_breaker.failure_count();
+                let cb_success_count = r.circuit_breaker.success_count();
+                let mut info = json!({
                     "storage_info": storage_info,
-                    "msg_queue_count": msg_queue_count,
+                    "topics_size": topics_size,
+                    "circuit_breaker": {
+                        "success_count": cb_success_count,
+                        "failure_count": cb_failure_count,
+                        "state": cb_state,
+                        "enabled": cb_enabled,
+                    },
                     "message": {
                         "max": msg_max,
                         "count": msg_count,
                     },
-                })
+                });
+
+                #[cfg(feature = "rate-counter")]
+                {
+                    info.as_object_mut().unwrap().insert("set_rate".into(), r.set_rate_counter.to_json());
+                    info.as_object_mut().unwrap().insert("sync_rate".into(), r.sync_rate_counter.to_json());
+                }
+
+                info
             }
             #[allow(unreachable_patterns)]
             _ => json!({ "storage_engine": "unknown" }),
         }
     }
 }
-
-pub(crate) const ERR_NOT_SUPPORTED: &str =
-    "The storage engine of the 'rmqtt-retainer' plugin does not support cluster mode!";

--- a/rmqtt-plugins/rmqtt-retainer/src/ram.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/ram.rs
@@ -3,7 +3,6 @@
 //! Wraps [`DefaultRetainStorage`] to provide a [`RetainStorage`] that
 //! enforces configurable message count and payload size limits.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,19 +17,18 @@ use rmqtt::{
     Result,
 };
 
-use crate::{PluginConfig, ERR_NOT_SUPPORTED};
+use crate::PluginConfig;
 
 #[derive(Clone)]
 pub(crate) struct RamRetainer {
     pub(crate) inner: Arc<DefaultRetainStorage>,
     cfg: Arc<RwLock<PluginConfig>>,
-    retain_enable: Arc<AtomicBool>,
 }
 
 impl RamRetainer {
     #[inline]
-    pub(crate) fn new(cfg: Arc<RwLock<PluginConfig>>, retain_enable: Arc<AtomicBool>) -> RamRetainer {
-        Self { inner: Arc::new(DefaultRetainStorage::new()), cfg, retain_enable }
+    pub(crate) fn new(cfg: Arc<RwLock<PluginConfig>>) -> RamRetainer {
+        Self { inner: Arc::new(DefaultRetainStorage::new()), cfg }
     }
 
     #[inline]
@@ -58,11 +56,6 @@ impl RetainStorage for RamRetainer {
 
     ///topic - concrete topic
     async fn set(&self, topic: &TopicName, retain: Retain, expiry_interval: Option<Duration>) -> Result<()> {
-        if !self.retain_enable.load(Ordering::SeqCst) {
-            log::warn!("{ERR_NOT_SUPPORTED}");
-            return Ok(());
-        }
-
         let (max_retained_messages, max_payload_size, retained_message_ttl) = {
             let cfg = self.cfg.read().await;
             (cfg.max_retained_messages, *cfg.max_payload_size, cfg.retained_message_ttl)
@@ -89,12 +82,7 @@ impl RetainStorage for RamRetainer {
 
     ///topic_filter - Topic filter
     async fn get(&self, topic_filter: &TopicFilter) -> Result<Vec<(TopicName, Retain)>> {
-        if !self.retain_enable.load(Ordering::SeqCst) {
-            log::warn!("{ERR_NOT_SUPPORTED}");
-            Ok(Vec::new())
-        } else {
-            Ok(self.inner.get_message(topic_filter).await?)
-        }
+        Ok(self.inner.get_message(topic_filter).await?)
     }
 
     async fn get_all_paginated(
@@ -102,10 +90,6 @@ impl RetainStorage for RamRetainer {
         offset: usize,
         limit: usize,
     ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
-        if !self.retain_enable.load(Ordering::SeqCst) {
-            log::warn!("{ERR_NOT_SUPPORTED}");
-            return Ok((Vec::new(), false));
-        }
         self.inner.get_all_paginated(offset, limit).await
     }
 

--- a/rmqtt-plugins/rmqtt-retainer/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/storage.rs
@@ -6,10 +6,8 @@
 
 use std::borrow::Cow;
 use std::convert::From as _;
-use std::future::Future;
 use std::ops::Deref;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -23,18 +21,27 @@ use tokio::sync::RwLock;
 
 use rmqtt_storage::{DefaultStorageDB, StorageType};
 
+#[cfg(feature = "rate-counter")]
+use rmqtt::utils::RateCounter;
 use rmqtt::{
     retain::RetainStorage,
-    types::{NodeId, Retain, TimestampMillis, Topic, TopicFilter, TopicName},
-    utils::timestamp_millis,
-    utils::StatsMergeMode,
+    retain::{RetainSyncMode, RetainTree},
+    types::{NodeId, Retain, TimedValue, TimestampMillis, Topic, TopicFilter, TopicName},
+    utils::{timestamp_millis, CircuitBreaker, StatsMergeMode},
     Result,
 };
 
 use crate::config::PluginConfig;
-use crate::ERR_NOT_SUPPORTED;
+use crate::value_cached::ValueCached;
 
 type Msg = (TopicName, Retain, Option<Duration>);
+
+/// Cluster sync message: updates the in-memory topics tree only (no Redis).
+/// Sent via a dedicated unbounded channel to avoid blocking on batch_store I/O.
+enum SyncMsg {
+    Add(TopicName, Option<Duration>),
+    Remove(TopicName),
+}
 
 type StoredMsg = (Retain, Option<TimestampMillis>);
 
@@ -53,40 +60,155 @@ impl Retainer {
         _node_id: NodeId,
         cfg: Arc<RwLock<PluginConfig>>,
         storage_db: DefaultStorageDB,
-        retain_enable: Arc<AtomicBool>,
         storage_type: StorageType,
         exec: TaskExecQueue,
+        batch_messages_limit: usize,
+        circuit_breaker: CircuitBreaker,
     ) -> Result<Retainer> {
-        let (msg_tx, msg_rx) = mpsc::channel::<Msg>(300_000);
-        let msg_queue_count = Arc::new(AtomicIsize::new(0));
+        let (msg_tx, msg_rx) = mpsc::channel::<Msg>(5_000);
+        let (sync_tx, sync_rx) = mpsc::channel::<SyncMsg>(10_000);
         let storage_messages_count = ValueCached::new(Duration::from_millis(3000));
         let storage_messages_max = ValueCached::new(Duration::from_millis(3000));
+        let abstract_info = ValueCached::new(Duration::from_millis(3000));
+
         let inner = Arc::new(RetainerInner {
             cfg,
             storage_db,
             msg_tx,
-            msg_queue_count,
-            retain_enable,
+            sync_tx,
             storage_messages_count,
             storage_messages_max,
             storage_type,
-            exec,
+            exec: exec.clone(),
+            topics: Arc::new(RwLock::new(RetainTree::default())),
+            circuit_breaker,
+            #[cfg(feature = "rate-counter")]
+            set_rate_counter: RateCounter::new(),
+            #[cfg(feature = "rate-counter")]
+            sync_rate_counter: RateCounter::new(),
+            abstract_info,
         });
-        Self { inner }.serve(msg_rx)
+        let retainer = Self { inner };
+        retainer.serve(exec, msg_rx, sync_rx, batch_messages_limit);
+
+        // Rebuild topics tree from storage on startup.
+        let rebuild = retainer.clone();
+        // tokio::spawn(async move {
+        if let Err(e) = rebuild.rebuild_topics().await {
+            log::error!("rebuild_topics error: {e:?}");
+        }
+        // });
+
+        Ok(retainer)
     }
 
-    fn serve(self, mut msg_rx: mpsc::Receiver<Msg>) -> Result<Retainer> {
-        let msg_queue_count = self.msg_queue_count.clone();
-        let msg_queue_count1 = msg_queue_count.clone();
+    #[inline]
+    async fn get_retain_count(&self) -> usize {
+        let this = self.inner.clone();
+        let cached = self.storage_messages_count.clone();
+        let count = cached
+            .call_timeout(async move { this._len().await }, Duration::from_millis(3000))
+            .await
+            .get()
+            .map(|c| c.copied().unwrap_or_default())
+            .unwrap_or_default();
+        if count > 0 {
+            count - 1
+        } else {
+            count
+        }
+    }
+
+    #[inline]
+    pub(crate) async fn info(&self) -> serde_json::Value {
+        if self.circuit_breaker.is_blocked() {
+            return serde_json::Value::Null;
+        }
+
+        let this = self.inner.clone();
+        let cached = self.abstract_info.clone();
+        let info = cached
+            .call_timeout(async move { this._abstract_info().await }, Duration::from_millis(3000))
+            .await
+            .get()
+            .map(|c| c.cloned().unwrap_or_default())
+            .unwrap_or_default();
+        info
+    }
+
+    fn serve(
+        &self,
+        _exec: TaskExecQueue,
+        mut msg_rx: mpsc::Receiver<Msg>,
+        mut sync_rx: mpsc::Receiver<SyncMsg>,
+        batch_messages_limit: usize,
+    ) {
         let msg_mgr = self.clone();
+        let sync_topics = self.topics.clone();
+
+        #[cfg(feature = "rate-counter")]
+        let rate_counter = self.set_rate_counter.clone();
+        #[cfg(feature = "rate-counter")]
+        let rc = rate_counter.clone();
+        #[cfg(feature = "rate-counter")]
+        let sync_rc = self.sync_rate_counter.clone();
+
+        // Rate sampling loop: compute throughput once per second.
+        #[cfg(feature = "rate-counter")]
+        tokio::spawn(async move {
+            let interval = Duration::from_millis(1500);
+            loop {
+                tokio::time::sleep(interval).await;
+                rc.tick(interval);
+            }
+        });
+
+        // Sync rate sampling loop.
+        #[cfg(feature = "rate-counter")]
+        {
+            let sync_rc_tick = sync_rc.clone();
+            tokio::spawn(async move {
+                let interval = Duration::from_millis(1500);
+                loop {
+                    tokio::time::sleep(interval).await;
+                    sync_rc_tick.tick(interval);
+                }
+            });
+        }
+
+        // Dedicated task: processes retain-sync messages.
+        // This is the ONLY task that writes to `topics` for sync messages,
+        // eliminating lock contention with the raft exec queue (which used to
+        // Sync operations are pure memory (no Redis), so this task never blocks.
+        tokio::spawn(async move {
+            while let Some(msg) = sync_rx.next().await {
+                match msg {
+                    SyncMsg::Add(topic_name, expiry) => {
+                        if let Ok(topic) = Topic::from_str(&topic_name) {
+                            let mut guard = sync_topics.write().await;
+                            let _h = WriteHold::new("sync_task_add");
+                            guard.insert(&topic, TimedValue::new((), expiry));
+                        }
+                    }
+                    SyncMsg::Remove(topic_name) => {
+                        if let Ok(topic) = Topic::from_str(&topic_name) {
+                            let mut guard = sync_topics.write().await;
+                            let _h = WriteHold::new("sync_task_remove");
+                            guard.remove(&topic);
+                        }
+                    }
+                }
+                #[cfg(feature = "rate-counter")]
+                sync_rc.dec();
+            }
+        });
+
         tokio::spawn(async move {
             log::info!("Starting Retainer serve ...");
-            let msg_fwds_count = Arc::new(AtomicIsize::new(0));
             let mut merger_msgs = Vec::new();
             while let Some(msg) = msg_rx.next().await {
-                let msg_mgr = msg_mgr.clone();
                 merger_msgs.push(msg);
-                while merger_msgs.len() < 500 {
+                while merger_msgs.len() < batch_messages_limit {
                     match tokio::time::timeout(Duration::from_millis(0), msg_rx.next()).await {
                         Ok(Some(msg)) => {
                             merger_msgs.push(msg);
@@ -98,26 +220,38 @@ impl Retainer {
                 log::debug!("merger_msgs.len: {}", merger_msgs.len());
                 //merge and send
                 let msgs = std::mem::take(&mut merger_msgs);
+                let batch_size = msgs.len();
 
-                msg_queue_count1.fetch_sub(msgs.len() as isize, Ordering::Relaxed);
-                msg_fwds_count.fetch_add(1, Ordering::SeqCst);
-                while msg_fwds_count.load(Ordering::SeqCst) > 500 {
-                    tokio::time::sleep(Duration::from_millis(1)).await;
+                // When the circuit breaker is OPEN, skip all storage operations
+                // without touching Redis/Sled. This prevents the channel backlog
+                // (cap=5000) from blocking the serve loop while each batch waits
+                // for a storage timeout.
+                // is_blocked() also handles OPEN→HALF_OPEN transitions, so when a
+                // probe is due, the next batch will be processed normally.
+                if msg_mgr.circuit_breaker.is_blocked() {
+                    #[cfg(feature = "rate-counter")]
+                    rate_counter.decs(batch_size as i64);
+                    continue;
                 }
 
-                let msg_fwds_count1 = msg_fwds_count.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = msg_mgr._batch_store(msgs).await {
-                        log::warn!("{e:?}");
+                let start = Instant::now();
+                match msg_mgr._batch_store_new(msgs).await {
+                    Ok(()) => msg_mgr.circuit_breaker.record_success(),
+                    Err(e) => {
+                        log::warn!("batch store failed, {e:?}");
+                        msg_mgr.circuit_breaker.record_failure();
                     }
-                    msg_fwds_count1.fetch_sub(1, Ordering::SeqCst);
-                });
+                }
+
+                #[cfg(feature = "rate-counter")]
+                rate_counter.decs(batch_size as i64);
+
+                if start.elapsed().as_secs() > 3 {
+                    log::info!("batch stored {} msgs in {:?}", batch_size, start.elapsed());
+                }
             }
             log::error!("Recv failed because receiver is gone");
-            // }
         });
-
-        Ok(self)
     }
 }
 
@@ -133,15 +267,53 @@ pub struct RetainerInner {
     cfg: Arc<RwLock<PluginConfig>>,
     pub(crate) storage_db: DefaultStorageDB,
     msg_tx: mpsc::Sender<Msg>,
-    pub(crate) msg_queue_count: Arc<AtomicIsize>,
-    retain_enable: Arc<AtomicBool>,
+    /// Dedicated channel for retain-sync messages (no Redis, no blocking).
+    sync_tx: mpsc::Sender<SyncMsg>,
     storage_messages_count: ValueCached<usize>,
     storage_messages_max: ValueCached<isize>,
     storage_type: StorageType,
     exec: TaskExecQueue,
+    /// In-memory topic name trie index — tracks which topics have active
+    /// retained messages. The value type `()` means only the topic name is
+    /// stored (no retain data). Used for fast wildcard matching and
+    /// cluster-aware topic synchronization.
+    pub(crate) topics: Arc<RwLock<RetainTree<TimedValue<()>>>>,
+    /// Circuit breaker for storage failure detection and fast-fail degradation.
+    pub(crate) circuit_breaker: CircuitBreaker,
+    /// Rate counter for tracking message processing throughput.
+    #[cfg(feature = "rate-counter")]
+    pub(crate) set_rate_counter: RateCounter,
+    /// Rate counter for sync message processing throughput.
+    #[cfg(feature = "rate-counter")]
+    pub(crate) sync_rate_counter: RateCounter,
+    abstract_info: ValueCached<serde_json::Value>,
+}
+
+/// Tracks how long the `topics.write()` lock is HELD (after acquisition).
+/// Create immediately after `write().await` returns, keep alive until guard drop.
+struct WriteHold {
+    label: &'static str,
+    start: Instant,
+}
+
+impl WriteHold {
+    #[inline]
+    fn new(label: &'static str) -> Self {
+        Self { label, start: Instant::now() }
+    }
+}
+
+impl Drop for WriteHold {
+    fn drop(&mut self) {
+        let held = self.start.elapsed();
+        if held > Duration::from_millis(100) {
+            log::warn!("Topics WRITE lock HELD {:?} by [{}]", held, self.label);
+        }
+    }
 }
 
 impl RetainerInner {
+    /// Original per-message version (逐个写入，用于对比重现)
     #[inline]
     async fn _batch_store(&self, msgs: Vec<Msg>) -> Result<()> {
         let (max_retained_messages, max_payload_size, retained_message_ttl) = {
@@ -162,7 +334,14 @@ impl RetainerInner {
                     .map_err(|_e| anyhow!("storage_db.remove timeout"))?
                 {
                     log::warn!("remove from db error, remove(..), {e:?}, topic_name: {topic_name:?}");
+                    return Err(e);
                 };
+                // Remove from in-memory topics tree
+                if let Ok(topic) = Topic::from_str(topic_name.as_ref()) {
+                    let mut guard = self.topics.write().await;
+                    let _h = WriteHold::new("batch_remove");
+                    guard.remove(&topic);
+                }
             } else {
                 match self
                     .check_constraints(topic_name.as_ref(), &retain, max_retained_messages, max_payload_size)
@@ -197,16 +376,28 @@ impl RetainerInner {
                     .map_err(|_e| anyhow!("storage_db.insert timeout"))?
                 {
                     log::warn!("store to db error, insert(..), {e:?}, message: {smsg:?}");
-                    continue;
+                    return Err(e);
                 };
 
                 if let Some(expiry_interval_millis) = expiry_interval_millis {
-                    if let Err(e) =
-                        self.storage_db.expire(store_topic_name.as_slice(), expiry_interval_millis).await
+                    if let Err(e) = self
+                        .storage_db
+                        .expire(store_topic_name.as_slice(), expiry_interval_millis)
+                        .timeout(futures_time::time::Duration::from_millis(5000))
+                        .await
+                        .map_err(|_e| anyhow!("set expire timeout"))?
                     {
                         log::warn!("store to db error, expire(..), {e:?}, message: {smsg:?}");
-                        continue;
+                        return Err(e);
                     }
+                }
+
+                // Update in-memory topics tree
+                if let Ok(topic) = Topic::from_str(topic_name.as_ref()) {
+                    let timeout = expiry_interval_millis.map(|millis| Duration::from_millis(millis as u64));
+                    let mut guard = self.topics.write().await;
+                    let _h = WriteHold::new("batch_insert");
+                    guard.insert(&topic, TimedValue::new((), timeout));
                 }
 
                 count += 1;
@@ -220,6 +411,121 @@ impl RetainerInner {
             .map_err(|_e| anyhow!("storage_messages_max_add timeout"))?
         {
             log::warn!("messages_received_counter add error, {e:?}");
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    /// Batch-optimized version (batch_insert / batch_remove)
+    #[inline]
+    async fn _batch_store_new(&self, msgs: Vec<Msg>) -> Result<()> {
+        let (max_retained_messages, max_payload_size, retained_message_ttl) = {
+            let cfg = self.cfg.read().await;
+            (cfg.max_retained_messages as usize, *cfg.max_payload_size, cfg.retained_message_ttl)
+        };
+
+        let mut insert_batch: Vec<(Vec<u8>, StoredMsg)> = Vec::with_capacity(msgs.len());
+        let mut remove_keys: Vec<Vec<u8>> = Vec::with_capacity(msgs.len());
+        let mut expire_tasks: Vec<(Vec<u8>, i64)> = Vec::new();
+        let mut count = 0;
+        for (topic_name, retain, expiry_interval) in msgs {
+            let store_topic_name = [RETAIN_MESSAGES_PREFIX, topic_name.as_bytes().as_ref()].concat();
+            if retain.publish.payload.is_empty() {
+                //remove retain messagge
+                remove_keys.push(store_topic_name);
+                // Remove from in-memory topics tree
+                if let Ok(topic) = Topic::from_str(topic_name.as_ref()) {
+                    let mut guard = self.topics.write().await;
+                    let _h = WriteHold::new("batch_remove");
+                    guard.remove(&topic);
+                }
+            } else {
+                match self
+                    .check_constraints(topic_name.as_ref(), &retain, max_retained_messages, max_payload_size)
+                    .await
+                {
+                    Ok(false) => {
+                        continue;
+                    }
+                    Ok(true) => {}
+                    Err(e) => {
+                        log::warn!("store to db error, check_constraints(..), {e:?}, message: {retain:?}");
+                        continue;
+                    }
+                }
+
+                //add retain messagge
+                let expiry_interval_millis = retained_message_ttl
+                    .map(|ttl| if ttl.is_zero() { None } else { Some(ttl.as_millis() as i64) })
+                    .unwrap_or_else(|| {
+                        expiry_interval.map(|expiry_interval| expiry_interval.as_millis() as i64)
+                    });
+
+                let expiry_time_at = expiry_interval_millis
+                    .map(|expiry_interval_millis| timestamp_millis() + expiry_interval_millis);
+
+                let smsg: StoredMsg = (retain, expiry_time_at);
+                if let Some(expiry_interval_millis) = expiry_interval_millis {
+                    expire_tasks.push((store_topic_name.clone(), expiry_interval_millis));
+                }
+                insert_batch.push((store_topic_name.clone(), smsg));
+
+                // Update in-memory topics tree
+                if let Ok(topic) = Topic::from_str(topic_name.as_ref()) {
+                    let timeout = expiry_interval_millis.map(|millis| Duration::from_millis(millis as u64));
+                    let mut guard = self.topics.write().await;
+                    let _h = WriteHold::new("batch_insert");
+                    guard.insert(&topic, TimedValue::new((), timeout));
+                }
+
+                count += 1;
+            }
+        }
+
+        // Batch remove — failure propagates to the serve loop so the
+        // circuit breaker can record the failure and eventually trip OPEN.
+        if !remove_keys.is_empty() {
+            self.storage_db
+                .batch_remove(remove_keys)
+                .timeout(futures_time::time::Duration::from_millis(5000))
+                .await
+                .map_err(|_e| anyhow!("storage_db.batch_remove timeout"))?
+                .map_err(|e| anyhow!("batch_remove error: {e:?}"))?;
+        }
+
+        // Batch insert — failure propagates to the serve loop.
+        if !insert_batch.is_empty() {
+            self.storage_db
+                .batch_insert(insert_batch)
+                .timeout(futures_time::time::Duration::from_millis(5000))
+                .await
+                .map_err(|_e| anyhow!("storage_db.batch_insert timeout"))?
+                .map_err(|e| anyhow!("batch_insert error: {e:?}"))?;
+
+            // Set TTL for inserted messages
+            for (key, ms) in expire_tasks {
+                if let Err(e) = self
+                    .storage_db
+                    .expire(key.as_slice(), ms)
+                    .timeout(futures_time::time::Duration::from_millis(5000))
+                    .await
+                    .map_err(|_e| anyhow!("set expire timeout"))?
+                {
+                    log::warn!("store to db error, expire(..), {e:?}");
+                    return Err(e);
+                }
+            }
+        }
+
+        if let Err(e) = self
+            .storage_messages_max_add(count)
+            .timeout(futures_time::time::Duration::from_millis(5000))
+            .await
+            .map_err(|_e| anyhow!("storage_messages_max_add timeout"))?
+        {
+            log::warn!("messages_received_counter add error, {e:?}");
+            return Err(e);
         }
 
         Ok(())
@@ -238,7 +544,7 @@ impl RetainerInner {
             return Ok(false);
         }
 
-        if max_retained_messages > 0 && self.get_retain_count().await >= max_retained_messages {
+        if max_retained_messages > 0 && self.topics.read().await.values_size() >= max_retained_messages {
             log::warn!(
                 "The retained message has exceeded the maximum limit of: {max_retained_messages}, topic: {topic:?}, retain: {retain:?}"
             );
@@ -249,19 +555,24 @@ impl RetainerInner {
     }
 
     #[inline]
-    async fn get_retain_count(&self) -> usize {
-        let db = self.storage_db.clone();
-        let count = self
-            .storage_messages_count
-            .call_timeout(async move { db.len().await }, Duration::from_millis(3000))
+    async fn _len(&self) -> Result<usize> {
+        let len = self
+            .storage_db
+            .len()
+            .timeout(futures_time::time::Duration::from_millis(3000))
             .await
-            .get()
-            .copied()
-            .unwrap_or_default();
-        if count > 0 {
-            count - 1
-        } else {
-            count
+            .map_err(|_e| anyhow!("db.len timeout"))
+            .flatten();
+
+        match len {
+            Ok(len) => {
+                self.circuit_breaker.record_success();
+                Ok(len)
+            }
+            Err(_) => {
+                self.circuit_breaker.record_failure();
+                Ok(0)
+            }
         }
     }
 
@@ -273,10 +584,27 @@ impl RetainerInner {
 
     #[inline]
     async fn storage_messages_max_get(&self) -> Result<isize> {
-        Ok(self.storage_db.counter_get(RETAIN_MESSAGES_MAX).await?.unwrap_or_default())
+        let val = self
+            .storage_db
+            .counter_get(RETAIN_MESSAGES_MAX)
+            .timeout(futures_time::time::Duration::from_millis(3000))
+            .await
+            .map_err(|_e| anyhow!("storage_messages_max_get timeout"))
+            .flatten();
+        match val {
+            Ok(val) => {
+                self.circuit_breaker.record_success();
+                Ok(val.unwrap_or_default())
+            }
+            Err(_) => {
+                self.circuit_breaker.record_failure();
+                Ok(0)
+            }
+        }
     }
 
     #[inline]
+    #[allow(dead_code)]
     fn topic_filter_to_pattern(t: &str) -> Cow<'_, str> {
         if t.len() == 1 && (t == "#" || t == "+") {
             return Cow::Borrowed("*");
@@ -298,7 +626,7 @@ impl RetainerInner {
         // Precise topic short circuit - GET directly without wildcard, O (1) single Redis query
         if !topic_filter.contains(['+', '#']) {
             let exact_key = [RETAIN_MESSAGES_PREFIX, topic_filter.as_bytes()].concat();
-            return match self.storage_db.get::<_, StoredMsg>(exact_key.as_slice()).await {
+            match self.storage_db.get::<_, StoredMsg>(exact_key.as_slice()).await {
                 Ok(Some((retain, expiry_time_at))) => {
                     let retains = if let Some(expiry_time_at) = expiry_time_at {
                         if expiry_time_at > timestamp_millis() {
@@ -314,62 +642,49 @@ impl RetainerInner {
                 Ok(None) => Ok(Vec::new()),
                 Err(e) => {
                     log::error!("get_message exact get error: {e:?}");
-                    Ok(Vec::new())
+                    Err(e)
                 }
+            }
+        } else {
+            // Wildcard path: use in-memory topics tree for fast trie matching,
+            // then fetch the actual retain data from storage for each matching topic.
+            let matched_topics = {
+                let topics = self.topics.read().await;
+                topics
+                    .matches(&topic)
+                    .into_iter()
+                    .filter_map(|(t, tv)| if tv.is_expired() { None } else { Some(t.to_string()) })
+                    .collect::<Vec<_>>()
             };
-        }
 
-        // Wildcard path: Follow SCAN+MATCH unchanged
-        let topic_filter_pattern = Self::topic_filter_to_pattern(topic_filter);
-        let mut matched_topics = Vec::new();
-        let mut db = self.storage_db.clone();
-        let mut iter = match db.scan([RETAIN_MESSAGES_PREFIX, topic_filter_pattern.as_bytes()].concat()).await
-        {
-            Err(e) => {
-                log::error!("{e:?}");
-                return Ok(Vec::new());
-            }
-            Ok(iter) => iter,
-        };
-        while let Some(key) = iter.next().await {
-            match key {
-                Ok(key) => {
-                    if !key.starts_with(RETAIN_MESSAGES_PREFIX) {
-                        continue;
-                    }
-                    if topic.matches_str(&String::from_utf8_lossy(&key[RETAIN_MESSAGES_PREFIX.len()..])) {
-                        matched_topics.push(key);
-                    }
-                }
-                Err(e) => {
-                    log::error!("{e:?}");
-                }
-            }
-        }
-        drop(iter);
-
-        let mut retains = Vec::new();
-        for key in matched_topics {
-            match db.get::<_, StoredMsg>(key.as_slice()).await {
-                Ok(Some((retain, expiry_time_at))) => {
-                    let topic_name = TopicName::from(
-                        String::from_utf8_lossy(&key[RETAIN_MESSAGES_PREFIX.len()..]).as_ref(),
-                    );
-                    if let Some(expiry_time_at) = expiry_time_at {
-                        if expiry_time_at > timestamp_millis() {
+            let mut retains = Vec::new();
+            for topic_str in &matched_topics {
+                let store_key = [RETAIN_MESSAGES_PREFIX, topic_str.as_bytes()].concat();
+                match self.storage_db.get::<_, StoredMsg>(store_key.as_slice()).await {
+                    Ok(Some((retain, expiry_time_at))) => {
+                        let topic_name = TopicName::from(topic_str.as_str());
+                        if let Some(expiry_time_at) = expiry_time_at {
+                            if expiry_time_at > timestamp_millis() {
+                                retains.push((topic_name, retain));
+                            }
+                        } else {
                             retains.push((topic_name, retain));
                         }
-                    } else {
-                        retains.push((topic_name, retain))
+                    }
+                    Ok(None) => {
+                        // Stale topic entry in topics tree — clean it up
+                        // if let Ok(t) = Topic::from_str(topic_str.as_str()) {
+                        //     self.topics.write().await.remove(&t);
+                        // }
+                    }
+                    Err(e) => {
+                        log::error!("get_message get error: {e:?}");
+                        return Err(e);
                     }
                 }
-                Ok(None) => {}
-                Err(e) => {
-                    log::error!("{e:?}");
-                }
             }
+            Ok(retains)
         }
-        Ok(retains)
     }
 
     #[inline]
@@ -379,7 +694,9 @@ impl RetainerInner {
         limit: usize,
     ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
         let mut db = self.storage_db.clone();
-        let mut iter = match db.scan(RETAIN_MESSAGES_PREFIX.to_vec()).await {
+        let topic_filter_pattern = Self::topic_filter_to_pattern("#");
+        let mut iter = match db.scan([RETAIN_MESSAGES_PREFIX, topic_filter_pattern.as_bytes()].concat()).await
+        {
             Err(e) => {
                 log::error!("get_all_paginated scan error: {e:?}");
                 return Ok((Vec::new(), false));
@@ -428,6 +745,93 @@ impl RetainerInner {
 
         Ok((items, has_more))
     }
+
+    /// Rebuild the in-memory `topics` tree by scanning all stored retain
+    /// messages. Called once at startup.
+    #[inline]
+    async fn rebuild_topics(&self) -> Result<()> {
+        let start = std::time::Instant::now();
+        log::info!("Rebuilding topics tree from storage ...");
+        let mut db = self.storage_db.clone();
+        let topic_filter_pattern = Self::topic_filter_to_pattern("#");
+        let mut iter = match db.scan([RETAIN_MESSAGES_PREFIX, topic_filter_pattern.as_bytes()].concat()).await
+        {
+            Err(e) => {
+                log::warn!("rebuild_topics scan error: {e:?}");
+                return Err(e);
+            }
+            Ok(iter) => iter,
+        };
+
+        // Collect keys first, then drop the iterator to release the mutable
+        // borrow on `db`.
+        let mut keys = Vec::new();
+        while let Some(key) = iter.next().await {
+            let key = match key {
+                Ok(k) => k,
+                Err(e) => {
+                    log::warn!("rebuild_topics iter error: {e:?}");
+                    continue;
+                }
+            };
+            if key.starts_with(RETAIN_MESSAGES_PREFIX) {
+                keys.push(key);
+            }
+        }
+        drop(iter);
+
+        let mut topics = self.topics.write().await;
+        let _h_rt = WriteHold::new("rebuild_topics");
+        for key in keys {
+            let topic_str = String::from_utf8_lossy(&key[RETAIN_MESSAGES_PREFIX.len()..]);
+            let topic = match Topic::from_str(topic_str.as_ref()) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            match db.get::<_, StoredMsg>(key.as_slice()).await {
+                Ok(Some((retain, expiry_time_at))) if !retain.publish.payload.is_empty() => {
+                    let timeout = expiry_time_at
+                        .filter(|exp| *exp > timestamp_millis())
+                        .map(|exp| Duration::from_millis((exp - timestamp_millis()) as u64));
+                    topics.insert(&topic, TimedValue::new((), timeout));
+                }
+                _ => {}
+            }
+        }
+        log::info!(
+            "Rebuild topics tree done, nodes: {}, values: {}, elapsed: {:?}",
+            topics.nodes_size(),
+            topics.values_size(),
+            start.elapsed()
+        );
+        Ok(())
+    }
+
+    /// Handle a topic-only retain sync notification from a cluster peer
+    /// (Redis mode). Unconditionally inserts or removes the topic from the
+    /// in-memory `topics` tree **without** querying shared storage —
+    /// notification carries the operation direction.
+    #[inline]
+    async fn _abstract_info(&self) -> Result<serde_json::Value> {
+        let info = self
+            .storage_db
+            .info()
+            .timeout(futures_time::time::Duration::from_millis(3000))
+            .await
+            .map_err(|_e| anyhow!("get info timeout"))
+            .flatten();
+
+        match info {
+            Ok(info) => {
+                self.circuit_breaker.record_success();
+                Ok(info)
+            }
+            Err(e) => {
+                self.circuit_breaker.record_failure();
+                Err(e)
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -461,29 +865,20 @@ impl RetainStorage for Retainer {
 
     ///topic - concrete topic
     async fn set(&self, topic: &TopicName, retain: Retain, expiry_interval: Option<Duration>) -> Result<()> {
-        if !self.retain_enable.load(Ordering::SeqCst) {
-            log::error!("{ERR_NOT_SUPPORTED}");
+        if self.circuit_breaker.is_blocked() {
             return Ok(());
         }
 
-        let res = self
-            .msg_tx
-            .clone()
-            .send((topic.clone(), retain, expiry_interval))
-            .timeout(futures_time::time::Duration::from_millis(3500))
-            .await
-            .map_err(|e| anyhow!(e));
+        let res =
+            self.msg_tx.clone().send((topic.clone(), retain, expiry_interval)).await.map_err(|e| anyhow!(e));
         match res {
-            Ok(Ok(())) => {
-                self.msg_queue_count.fetch_add(1, Ordering::Relaxed);
+            Ok(()) => {
+                #[cfg(feature = "rate-counter")]
+                self.set_rate_counter.inc();
                 Ok(())
             }
-            Ok(Err(e)) => {
-                log::error!("Retainer set error, {e:?}");
-                Err(anyhow!(e.to_string()))
-            }
             Err(e) => {
-                log::warn!("Retainer store timeout, {e:?}");
+                log::error!("Retainer set error, {e:?}");
                 Err(anyhow!(e.to_string()))
             }
         }
@@ -491,33 +886,95 @@ impl RetainStorage for Retainer {
 
     ///topic_filter - Topic filter
     async fn get(&self, topic_filter: &TopicFilter) -> Result<Vec<(TopicName, Retain)>> {
-        if !self.retain_enable.load(Ordering::SeqCst) {
-            log::error!("{ERR_NOT_SUPPORTED}");
-            Ok(Vec::new())
-        } else {
-            let this = self.clone();
-            let tf = topic_filter.clone();
-            async move { this.get_message(&tf).await }
-                .spawn(&self.exec)
-                .result()
-                .await
-                .map_err(|e| anyhow!(e.to_string()))?
+        // Circuit breaker OPEN: return empty without calling get_message.
+        if self.circuit_breaker.is_blocked() {
+            return Ok(Vec::new());
         }
+
+        let this = self.clone();
+        let tf = topic_filter.clone();
+        let result = async move { this.get_message(&tf).await }
+            .spawn(&self.exec)
+            .result()
+            .timeout(futures_time::time::Duration::from_millis(5000))
+            .await;
+
+        match result {
+            Ok(inner) => {
+                // inner is the output of .result(), which is Result<T, JoinError>
+                // where T is the output of get_message (Result<Vec<...>, anyhow::Error>)
+                // So inner is Result<Result<Vec<...>, anyhow::Error>, JoinError>
+                match inner {
+                    Ok(Ok(retains)) => {
+                        // Task succeeded, get_message returned Ok
+                        self.circuit_breaker.record_success();
+                        Ok(retains)
+                    }
+                    Ok(Err(e)) => {
+                        // Task succeeded, but get_message returned Err (storage failure)
+                        log::warn!("retainer get_message error: {:?}", e);
+                        self.circuit_breaker.record_failure();
+                        Ok(Vec::new())
+                    }
+                    Err(_e) => {
+                        // Task failed (panic, etc.)
+                        log::warn!("retainer get task error");
+                        self.circuit_breaker.record_failure();
+                        Ok(Vec::new())
+                    }
+                }
+            }
+            Err(_) => {
+                // Timeout
+                log::warn!("retainer get timeout");
+                self.circuit_breaker.record_failure();
+                Ok(Vec::new())
+            }
+        }
+    }
+
+    async fn get_all_paginated(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
+        if self.circuit_breaker.is_blocked() {
+            return Ok((Vec::new(), false));
+        }
+        self._get_all_paginated(offset, limit)
+            .timeout(futures_time::time::Duration::from_secs(60))
+            .await
+            .map_err(|_e| anyhow!("get_all_paginated timeout"))?
     }
 
     #[inline]
     async fn count(&self) -> isize {
+        if self.circuit_breaker.is_blocked() {
+            return -1;
+        }
         self.get_retain_count().await as isize
     }
 
     #[inline]
     async fn max(&self) -> isize {
-        self.storage_messages_max
-            .call_timeout(self.storage_messages_max_get(), Duration::from_millis(3000))
-            .await
-            .get()
-            .copied()
-            .unwrap_or(-1)
+        if self.circuit_breaker.is_blocked() {
+            return -1;
+        }
+        let this = self.inner.clone();
+
+        let val = self.storage_messages_max.clone();
+        let value_ref = val
+            .call_timeout(async move { this.storage_messages_max_get().await }, Duration::from_millis(3000))
+            .await;
+        // value_ref and val are now distinct locals; the borrow is visible
+        // to the async state machine and drop order is well-defined.
+        match value_ref.get() {
+            Ok(max) => max.copied().unwrap_or(-1),
+            Err(e) => {
+                log::warn!("retainer max error: {e:?}");
+                -1
+            }
+        }
     }
 
     #[inline]
@@ -532,169 +989,30 @@ impl RetainStorage for Retainer {
         }
     }
 
-    async fn get_all_paginated(
+    #[inline]
+    fn retain_sync_mode(&self) -> RetainSyncMode {
+        match self.storage_type {
+            #[cfg(feature = "redis")]
+            StorageType::Redis => RetainSyncMode::TopicOnly,
+            #[allow(unreachable_patterns)]
+            _ => RetainSyncMode::Full,
+        }
+    }
+
+    async fn sync_retain_topic(
         &self,
-        offset: usize,
-        limit: usize,
-    ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
-        if !self.retain_enable.load(Ordering::SeqCst) {
-            log::error!("{ERR_NOT_SUPPORTED}");
-            return Ok((Vec::new(), false));
-        }
-        self._get_all_paginated(offset, limit).await
-    }
-}
-
-#[derive(Clone)]
-pub struct ValueCached<T> {
-    inner: Arc<RwLock<ValueCachedInner<T>>>,
-    guard: Arc<RwLock<()>>,
-}
-
-pub struct ValueCachedInner<T> {
-    cached_val: Option<Result<T>>,
-    expire_interval: Duration,
-    instant: Instant,
-}
-
-impl<T> ValueCached<T> {
-    #[inline]
-    pub fn new(expire_interval: Duration) -> Self {
-        Self {
-            inner: Arc::new(RwLock::new(ValueCachedInner {
-                cached_val: None,
-                expire_interval,
-                instant: Instant::now(),
-            })),
-            guard: Arc::new(RwLock::new(())),
-        }
-    }
-
-    #[inline]
-    #[allow(unused)]
-    pub async fn call<F>(&self, f: F) -> ValueRef<'_, T>
-    where
-        F: Future<Output = Result<T>> + Send,
-    {
-        self._call_timeout(f, None).await
-    }
-
-    #[inline]
-    pub async fn call_timeout<F>(&self, f: F, timeout: Duration) -> ValueRef<'_, T>
-    where
-        F: Future<Output = Result<T>> + Send,
-    {
-        self._call_timeout(f, Some(timeout)).await
-    }
-
-    #[inline]
-    async fn _call_timeout<F>(&self, f: F, timeout: Option<Duration>) -> ValueRef<'_, T>
-    where
-        F: Future<Output = Result<T>> + Send,
-    {
-        let inst = std::time::Instant::now();
-        let (call_enable, updating) = {
-            let mut enable = false;
-            #[allow(unused_assignments)]
-            let mut updating = false;
-            loop {
-                if let Ok(_guard) = self.guard.try_read() {
-                    let inner_rl = self.inner.read().await;
-                    enable = inner_rl.cached_val.is_none() || inner_rl.is_expired();
-                    updating = false;
-                    break;
-                }
-                updating = true;
-
-                if self.inner.read().await.cached_val.is_some() {
-                    break;
-                }
-
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                if let Some(t) = timeout.as_ref() {
-                    if inst.elapsed() > *t {
-                        break;
-                    }
-                }
-            }
-            (enable, updating)
-        };
-
-        let (cached, updating) = if call_enable {
-            if let Ok(_guard) = self.guard.try_write() {
-                let val = if let Some(t) = timeout {
-                    match tokio::time::timeout(t, f).await {
-                        Ok(Ok(v)) => Ok(v),
-                        Ok(Err(e)) => Err(e),
-                        Err(e) => Err(anyhow!(e)),
-                    }
-                } else {
-                    f.await
-                };
-                let mut inner_wl = self.inner.write().await;
-                inner_wl.cached_val = Some(val);
-                inner_wl.instant = Instant::now();
-                (false, false)
-            } else {
-                #[allow(unused_assignments)]
-                let mut updating = false;
-                loop {
-                    if let Ok(_guard) = self.guard.try_read() {
-                        updating = false;
-                        break;
-                    }
-                    updating = true;
-                    if self.inner.read().await.cached_val.is_some() {
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                    if let Some(t) = timeout.as_ref() {
-                        if inst.elapsed() > *t {
-                            break;
-                        }
-                    }
-                }
-                (true, updating)
-            }
+        topic: &TopicName,
+        expiry_interval: Option<Duration>,
+        is_set: bool,
+    ) -> Result<()> {
+        let msg = if is_set {
+            SyncMsg::Add(topic.clone(), expiry_interval)
         } else {
-            (true, updating)
+            SyncMsg::Remove(topic.clone())
         };
-        ValueRef { val_guard: self.inner.read().await, cached, updating }
-    }
-}
-
-impl<T> ValueCachedInner<T> {
-    #[inline]
-    fn is_expired(&self) -> bool {
-        self.instant.elapsed() > self.expire_interval
-    }
-}
-
-pub struct ValueRef<'a, T> {
-    val_guard: tokio::sync::RwLockReadGuard<'a, ValueCachedInner<T>>,
-    cached: bool,
-    updating: bool,
-}
-
-impl<T> ValueRef<'_, T> {
-    #[inline]
-    pub fn get(&self) -> Result<&T> {
-        if let Some(val) = self.val_guard.cached_val.as_ref() {
-            Ok(val.as_ref().map_err(|e| anyhow!(e.to_string()))?)
-        } else {
-            Err(anyhow!("Timeout"))
-        }
-    }
-
-    #[inline]
-    #[allow(unused)]
-    pub fn is_cached(&self) -> bool {
-        self.cached
-    }
-
-    #[inline]
-    #[allow(unused)]
-    pub fn is_updating(&self) -> bool {
-        self.updating
+        self.inner.sync_tx.clone().send(msg).await.map_err(|e| anyhow!(e))?;
+        #[cfg(feature = "rate-counter")]
+        self.sync_rate_counter.inc();
+        Ok(())
     }
 }

--- a/rmqtt-plugins/rmqtt-retainer/src/value_cached.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/value_cached.rs
@@ -28,7 +28,7 @@ use rmqtt::Result;
 // ── ValueCached ──
 
 #[derive(Clone)]
-pub(crate) struct ValueCached<T> {
+pub struct ValueCached<T> {
     inner: Arc<RwLock<ValueCachedInner<T>>>,
     /// Atomic flag: `false` = idle, `true` = a background refresh is running.
     /// Stays `true` until the spawned task finishes and writes the cache.
@@ -202,7 +202,7 @@ impl<T> ValueCachedInner<T> {
 /// Return type of [`ValueCached::call`] / [`ValueCached::call_timeout`].
 ///
 /// Always constructed without awaiting — the caller is never blocked.
-pub(crate) struct ValueRef<'a, T> {
+pub struct ValueRef<'a, T> {
     val_guard: tokio::sync::RwLockReadGuard<'a, ValueCachedInner<T>>,
     /// Whether a cached value existed at the time of the snapshot.
     #[allow(dead_code)]
@@ -282,8 +282,8 @@ mod tests {
             )
             .await;
 
-        // No cached value yet — get() should be Err.
-        assert!(r.get().is_err(), "first call should return Err");
+        // No cached value yet — get() should return Ok(None).
+        assert!(r.get().unwrap().is_none(), "first call should return None (no cached value)");
         assert!(!r.has_value(), "has_value should be false");
         assert!(r.spawned(), "should have spawned a background refresh");
         // Drop r to release the read lock so the background task can write.
@@ -294,7 +294,7 @@ mod tests {
 
         // Now the cache should have the value.
         let r2 = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
-        assert_eq!(*r2.get().unwrap(), 42, "should return the stored 42, not 99");
+        assert_eq!(*r2.get().unwrap().unwrap(), 42, "should return the stored 42, not 99");
         assert!(called.load(Ordering::Acquire), "the closure should have been called");
     }
 
@@ -333,7 +333,7 @@ mod tests {
             )
             .await;
 
-        assert_eq!(*r.get().unwrap(), 42, "should return the cached value");
+        assert_eq!(*r.get().unwrap().unwrap(), 42, "should return the cached value");
         assert!(!r.spawned(), "should NOT have spawned a refresh");
         assert!(!called.load(Ordering::Acquire), "the closure should NOT have been called");
     }
@@ -367,7 +367,7 @@ mod tests {
             .await;
 
         // Must return the stale 10 immediately, never Err.
-        assert_eq!(*r.get().unwrap(), 10, "should return stale value 10, not wait for 20");
+        assert_eq!(*r.get().unwrap().unwrap(), 10, "should return stale value 10, not wait for 20");
         assert!(r.spawned(), "should have spawned a background refresh");
         assert!(!called.load(Ordering::Acquire), "the closure may not have run yet");
         // Drop r to release the read lock so the background task can write.
@@ -378,7 +378,7 @@ mod tests {
 
         // Now the cache should have the fresh value 20.
         let r2 = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
-        assert_eq!(*r2.get().unwrap(), 20, "should now return the refreshed value 20");
+        assert_eq!(*r2.get().unwrap().unwrap(), 20, "should now return the refreshed value 20");
     }
 
     /// 4. CAS prevents redundant background refreshes.
@@ -427,8 +427,8 @@ mod tests {
         );
 
         // Both should return the stale value 1.
-        assert_eq!(*r1.get().unwrap(), 1, "r1: stale value");
-        assert_eq!(*r2.get().unwrap(), 1, "r2: stale value");
+        assert_eq!(*r1.get().unwrap().unwrap(), 1, "r1: stale value");
+        assert_eq!(*r2.get().unwrap().unwrap(), 1, "r2: stale value");
 
         // At least one should have spawned.
         assert!(r1.spawned() || r2.spawned(), "at least one call should spawn");
@@ -474,7 +474,7 @@ mod tests {
 
         // Immediately after drop: still stale (bg task may still be sleeping).
         let r = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
-        assert_eq!(*r.get().unwrap(), 1, "still stale before refresh completes");
+        assert_eq!(*r.get().unwrap().unwrap(), 1, "still stale before refresh completes");
         drop(r);
 
         // Wait for the slow refresh to finish.
@@ -483,7 +483,7 @@ mod tests {
 
         // Now the value should be 2.
         let r = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
-        assert_eq!(*r.get().unwrap(), 2, "cache should now have the refreshed value");
+        assert_eq!(*r.get().unwrap().unwrap(), 2, "cache should now have the refreshed value");
     }
 
     /// 6. When the refresh closure fails, the error is cached.
@@ -515,7 +515,7 @@ mod tests {
         let r = cached.call_timeout(async { Ok(3usize) }, Duration::from_millis(500)).await;
         match r.get() {
             Err(e) => assert!(e.to_string().contains("storage error"), "error should be preserved"),
-            Ok(v) => panic!("expected error, got Ok({v})"),
+            Ok(v) => panic!("expected error, got Ok({v:?})"),
         }
     }
 
@@ -531,15 +531,15 @@ mod tests {
             let r = cached
                 .call_timeout_sync(|| -> Result<usize> { Ok(42usize) }, Duration::from_millis(500))
                 .await;
-            // No value yet (first call).
-            assert!(r.get().is_err() || *r.get().unwrap() == 42);
+            // No value yet (first call, sync variant spawns blocking task).
+            assert!(r.get().unwrap().is_none(), "first call should return None");
             drop(r);
         }
         wait().await;
 
         // Now the value should be available.
         let r = cached.call_timeout_sync(|| Ok(99usize), Duration::from_millis(500)).await;
-        assert_eq!(*r.get().unwrap(), 42, "should have the cached value from spawn_blocking");
+        assert_eq!(*r.get().unwrap().unwrap(), 42, "should have the cached value from spawn_blocking");
     }
 
     /// 8. Multiple expiry cycles work correctly.
@@ -558,7 +558,7 @@ mod tests {
         tokio::time::sleep(SHORT).await;
         {
             let r = cached.call_timeout(async { Ok(2usize) }, Duration::from_millis(500)).await;
-            assert_eq!(*r.get().unwrap(), 1, "stale 1 before refresh");
+            assert_eq!(*r.get().unwrap().unwrap(), 1, "stale 1 before refresh");
             assert!(r.spawned());
             drop(r);
         }
@@ -568,13 +568,13 @@ mod tests {
         tokio::time::sleep(SHORT).await;
         {
             let r = cached.call_timeout(async { Ok(3usize) }, Duration::from_millis(500)).await;
-            assert_eq!(*r.get().unwrap(), 2, "stale 2 before refresh");
+            assert_eq!(*r.get().unwrap().unwrap(), 2, "stale 2 before refresh");
             assert!(r.spawned());
             drop(r);
         }
         wait().await;
 
         let r = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
-        assert_eq!(*r.get().unwrap(), 3, "final value should be 3");
+        assert_eq!(*r.get().unwrap().unwrap(), 3, "final value should be 3");
     }
 }

--- a/rmqtt-plugins/rmqtt-retainer/src/value_cached.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/value_cached.rs
@@ -1,0 +1,580 @@
+//! Non-blocking cache with stale-while-revalidate semantics.
+//!
+//! Provides [`ValueCached<T>`] and [`ValueRef<'_, T>`] for caching
+//! storage query results without blocking the caller.
+//!
+//! # Semantics
+//! - `call` / `call_timeout` always return **immediately**.
+//! - If a cached value exists (even if expired), `get()` returns `Ok(&T)`.
+//! - If the cache is expired (or empty), a background `tokio::spawn` task
+//!   is launched to refresh the value. The caller sees stale data briefly.
+//! - An `AtomicBool` + CAS ensures at most one background refresh runs
+//!   concurrently — redundant calls are silently skipped.
+//! - Two mode families:
+//!   - `call` / `call_timeout` — `f` is a `Future`, runs on `tokio::spawn`.
+//!   - `call_sync` / `call_timeout_sync` — `f` is a `FnOnce`, runs on
+//!     `tokio::task::spawn_blocking`.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::anyhow;
+use tokio::sync::RwLock;
+
+use rmqtt::Result;
+
+// ── ValueCached ──
+
+#[derive(Clone)]
+pub(crate) struct ValueCached<T> {
+    inner: Arc<RwLock<ValueCachedInner<T>>>,
+    /// Atomic flag: `false` = idle, `true` = a background refresh is running.
+    /// Stays `true` until the spawned task finishes and writes the cache.
+    refreshing: Arc<AtomicBool>,
+}
+
+struct ValueCachedInner<T> {
+    cached_val: Option<Result<T>>,
+    expire_interval: Duration,
+    instant: Instant,
+}
+
+impl<T: Send + Sync + 'static> ValueCached<T> {
+    #[inline]
+    pub fn new(expire_interval: Duration) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(ValueCachedInner {
+                cached_val: None,
+                expire_interval,
+                instant: Instant::now(),
+            })),
+            refreshing: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Non-blocking call. `f` is an async future — runs on `tokio::spawn`.
+    #[inline]
+    #[allow(unused)]
+    pub async fn call<F>(&self, f: F) -> ValueRef<'_, T>
+    where
+        F: Future<Output = Result<T>> + Send + 'static,
+    {
+        let (has_value, expired) = {
+            let inner = self.inner.read().await;
+            (inner.cached_val.is_some(), inner.cached_val.as_ref().is_none_or(|_| inner.is_expired()))
+        };
+        let spawned = if expired { self._refresh(f, None) } else { false };
+        ValueRef { val_guard: self.inner.read().await, has_value, spawned, expired }
+    }
+
+    /// Non-blocking call with timeout. `f` is an async future.
+    #[inline]
+    pub async fn call_timeout<F>(&self, f: F, timeout: Duration) -> ValueRef<'_, T>
+    where
+        F: Future<Output = Result<T>> + Send + 'static,
+    {
+        let (has_value, expired) = {
+            let inner = self.inner.read().await;
+            (inner.cached_val.is_some(), inner.cached_val.as_ref().is_none_or(|_| inner.is_expired()))
+        };
+        let spawned = if expired { self._refresh(f, Some(timeout)) } else { false };
+        ValueRef { val_guard: self.inner.read().await, has_value, spawned, expired }
+    }
+
+    /// Non-blocking call, sync variant. `f` runs on `tokio::task::spawn_blocking`.
+    #[inline]
+    #[allow(unused)]
+    pub async fn call_sync<F>(&self, f: F) -> ValueRef<'_, T>
+    where
+        F: FnOnce() -> Result<T> + Send + 'static,
+    {
+        let (has_value, expired) = {
+            let inner = self.inner.read().await;
+            (inner.cached_val.is_some(), inner.cached_val.as_ref().is_none_or(|_| inner.is_expired()))
+        };
+        let spawned = if expired { self._refresh_sync(f, None) } else { false };
+        ValueRef { val_guard: self.inner.read().await, has_value, spawned, expired }
+    }
+
+    /// Non-blocking call with timeout, sync variant.
+    #[inline]
+    #[allow(unused)]
+    pub async fn call_timeout_sync<F>(&self, f: F, timeout: Duration) -> ValueRef<'_, T>
+    where
+        F: FnOnce() -> Result<T> + Send + 'static,
+    {
+        let (has_value, expired) = {
+            let inner = self.inner.read().await;
+            (inner.cached_val.is_some(), inner.cached_val.as_ref().is_none_or(|_| inner.is_expired()))
+        };
+        let spawned = if expired { self._refresh_sync(f, Some(timeout)) } else { false };
+        ValueRef { val_guard: self.inner.read().await, has_value, spawned, expired }
+    }
+
+    // ── Internal helpers ──
+
+    /// Async refresh: spawn `f` onto `tokio::spawn`.
+    /// Returns `true` if a background task was actually spawned.
+    fn _refresh<F>(&self, f: F, timeout: Option<Duration>) -> bool
+    where
+        F: Future<Output = Result<T>> + Send + 'static,
+    {
+        // CAS: only one task gets to refresh
+        if self.refreshing.compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed).is_err() {
+            return false;
+        }
+
+        // Explicitly clone the Arcs so the spawned future owns Send+Sync data.
+        let this_inner = self.inner.clone();
+        let this_refreshing = self.refreshing.clone();
+        tokio::spawn(async move {
+            let result = if let Some(t) = timeout {
+                match tokio::time::timeout(t, f).await {
+                    Ok(Ok(v)) => Ok(v),
+                    Ok(Err(e)) => Err(e),
+                    Err(_) => Err(anyhow!("ValueCached refresh timeout")),
+                }
+            } else {
+                f.await
+            };
+
+            let mut inner = this_inner.write().await;
+            inner.cached_val = Some(result);
+            inner.instant = Instant::now();
+            drop(inner);
+
+            this_refreshing.store(false, Ordering::Release);
+        });
+
+        true
+    }
+
+    /// Sync refresh: spawn `f` onto `tokio::task::spawn_blocking`.
+    fn _refresh_sync<F>(&self, f: F, timeout: Option<Duration>) -> bool
+    where
+        F: FnOnce() -> Result<T> + Send + 'static,
+    {
+        if self.refreshing.compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed).is_err() {
+            return false;
+        }
+
+        let this_inner = self.inner.clone();
+        let this_refreshing = self.refreshing.clone();
+        tokio::spawn(async move {
+            let result = if let Some(t) = timeout {
+                match tokio::time::timeout(t, tokio::task::spawn_blocking(f)).await {
+                    Ok(Ok(Ok(v))) => Ok(v),
+                    Ok(Ok(Err(e))) => Err(e),
+                    Ok(Err(_)) => Err(anyhow!("spawn_blocking panicked")),
+                    Err(_) => Err(anyhow!("ValueCached refresh timeout")),
+                }
+            } else {
+                match tokio::task::spawn_blocking(f).await {
+                    Ok(Ok(v)) => Ok(v),
+                    Ok(Err(e)) => Err(e),
+                    Err(_) => Err(anyhow!("spawn_blocking panicked")),
+                }
+            };
+
+            let mut inner = this_inner.write().await;
+            inner.cached_val = Some(result);
+            inner.instant = Instant::now();
+            drop(inner);
+
+            this_refreshing.store(false, Ordering::Release);
+        });
+
+        true
+    }
+}
+
+impl<T> ValueCachedInner<T> {
+    #[inline]
+    fn is_expired(&self) -> bool {
+        self.instant.elapsed() > self.expire_interval
+    }
+}
+
+// ── ValueRef ──
+
+/// Return type of [`ValueCached::call`] / [`ValueCached::call_timeout`].
+///
+/// Always constructed without awaiting — the caller is never blocked.
+pub(crate) struct ValueRef<'a, T> {
+    val_guard: tokio::sync::RwLockReadGuard<'a, ValueCachedInner<T>>,
+    /// Whether a cached value existed at the time of the snapshot.
+    #[allow(dead_code)]
+    has_value: bool,
+    /// Whether this call initiated a background refresh.
+    #[allow(dead_code)]
+    spawned: bool,
+    /// Whether the cached value was expired (or missing) at snapshot time.
+    #[allow(dead_code)]
+    expired: bool,
+}
+
+impl<T> ValueRef<'_, T> {
+    /// Returns a reference to the cached value.
+    ///
+    /// - If any cached value exists (even stale / from a previous error),
+    ///   returns `Ok(&T)` — the caller can always read what we have.
+    /// - If no value has been fetched yet and the first background refresh
+    ///   is still in progress, returns `Err`.
+    #[inline]
+    pub fn get(&self) -> Result<Option<&T>> {
+        match &self.val_guard.cached_val {
+            Some(Ok(v)) => Ok(Some(v)),
+            Some(Err(e)) => Err(anyhow!(e.to_string())),
+            None => Ok(None),
+        }
+    }
+
+    #[inline]
+    #[allow(unused)]
+    pub fn has_value(&self) -> bool {
+        self.has_value
+    }
+
+    #[inline]
+    #[allow(unused)]
+    pub fn spawned(&self) -> bool {
+        self.spawned
+    }
+
+    #[inline]
+    #[allow(unused)]
+    pub fn expired(&self) -> bool {
+        self.expired
+    }
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    /// Helper: a short expire interval used in all tests.
+    const SHORT: Duration = Duration::from_millis(50);
+
+    /// Helper: wait long enough for a background refresh to complete.
+    async fn wait() {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+
+    /// 1. First call (no cached value) → get() returns Err, bg refresh spawned.
+    #[tokio::test]
+    async fn first_call_no_value() {
+        let cached: ValueCached<usize> = ValueCached::new(SHORT);
+        let called = Arc::new(AtomicBool::new(false));
+        let c = called.clone();
+
+        let r = cached
+            .call_timeout(
+                async move {
+                    c.store(true, Ordering::Release);
+                    Ok(42usize)
+                },
+                Duration::from_millis(500),
+            )
+            .await;
+
+        // No cached value yet — get() should be Err.
+        assert!(r.get().is_err(), "first call should return Err");
+        assert!(!r.has_value(), "has_value should be false");
+        assert!(r.spawned(), "should have spawned a background refresh");
+        // Drop r to release the read lock so the background task can write.
+        drop(r);
+
+        // Wait for the background task to complete.
+        wait().await;
+
+        // Now the cache should have the value.
+        let r2 = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
+        assert_eq!(*r2.get().unwrap(), 42, "should return the stored 42, not 99");
+        assert!(called.load(Ordering::Acquire), "the closure should have been called");
+    }
+
+    /// 2. Fresh cache returns immediately without spawning.
+    #[tokio::test]
+    async fn fresh_cache_no_spawn() {
+        let cached: ValueCached<usize> = ValueCached::new(Duration::from_millis(5000));
+        let called = Arc::new(AtomicBool::new(false));
+
+        // Seed the cache via first call.
+        {
+            let c = called.clone();
+            let r = cached
+                .call_timeout(
+                    async move {
+                        c.store(true, Ordering::Release);
+                        Ok(42usize)
+                    },
+                    Duration::from_millis(500),
+                )
+                .await;
+            drop(r); // release read lock so bg task can write
+        }
+        wait().await; // let the seed complete
+
+        // Second call while still fresh.
+        called.store(false, Ordering::Release);
+        let c2 = called.clone();
+        let r = cached
+            .call_timeout(
+                async move {
+                    c2.store(true, Ordering::Release);
+                    Ok(99usize)
+                },
+                Duration::from_millis(500),
+            )
+            .await;
+
+        assert_eq!(*r.get().unwrap(), 42, "should return the cached value");
+        assert!(!r.spawned(), "should NOT have spawned a refresh");
+        assert!(!called.load(Ordering::Acquire), "the closure should NOT have been called");
+    }
+
+    /// 3. Expired cache returns stale value AND spawns background refresh.
+    #[tokio::test]
+    async fn expired_cache_stale_while_revalidate() {
+        let cached: ValueCached<usize> = ValueCached::new(SHORT);
+
+        // Seed with initial value.
+        {
+            let r = cached.call_timeout(async { Ok(10usize) }, Duration::from_millis(500)).await;
+            drop(r);
+        }
+        wait().await;
+
+        // Wait for expiry.
+        tokio::time::sleep(SHORT).await;
+
+        let called = Arc::new(AtomicBool::new(false));
+        let c = called.clone();
+
+        let r = cached
+            .call_timeout(
+                async move {
+                    c.store(true, Ordering::Release);
+                    Ok(20usize)
+                },
+                Duration::from_millis(500),
+            )
+            .await;
+
+        // Must return the stale 10 immediately, never Err.
+        assert_eq!(*r.get().unwrap(), 10, "should return stale value 10, not wait for 20");
+        assert!(r.spawned(), "should have spawned a background refresh");
+        assert!(!called.load(Ordering::Acquire), "the closure may not have run yet");
+        // Drop r to release the read lock so the background task can write.
+        drop(r);
+
+        // Wait for the background refresh to complete.
+        wait().await;
+
+        // Now the cache should have the fresh value 20.
+        let r2 = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
+        assert_eq!(*r2.get().unwrap(), 20, "should now return the refreshed value 20");
+    }
+
+    /// 4. CAS prevents redundant background refreshes.
+    #[tokio::test]
+    async fn cas_prevents_duplicate_refresh() {
+        let cached: ValueCached<usize> = ValueCached::new(SHORT);
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        // First call to seed.
+        {
+            let cc = call_count.clone();
+            let r = cached
+                .call_timeout(
+                    async move {
+                        cc.fetch_add(1, Ordering::SeqCst);
+                        Ok(1usize)
+                    },
+                    Duration::from_millis(500),
+                )
+                .await;
+            drop(r);
+        }
+        wait().await;
+        tokio::time::sleep(SHORT).await; // ensure expired
+
+        // Fire two concurrent calls — only one should spawn a refresh.
+        call_count.store(0, Ordering::SeqCst);
+        let cc1 = call_count.clone();
+        let cc2 = call_count.clone();
+
+        let (r1, r2) = tokio::join!(
+            cached.call_timeout(
+                async move {
+                    cc1.fetch_add(1, Ordering::SeqCst);
+                    Ok(10usize)
+                },
+                Duration::from_millis(500),
+            ),
+            cached.call_timeout(
+                async move {
+                    cc2.fetch_add(1, Ordering::SeqCst);
+                    Ok(20usize)
+                },
+                Duration::from_millis(500),
+            ),
+        );
+
+        // Both should return the stale value 1.
+        assert_eq!(*r1.get().unwrap(), 1, "r1: stale value");
+        assert_eq!(*r2.get().unwrap(), 1, "r2: stale value");
+
+        // At least one should have spawned.
+        assert!(r1.spawned() || r2.spawned(), "at least one call should spawn");
+        // The closure should have been called exactly once.
+        drop(r1);
+        drop(r2);
+        wait().await;
+        assert_eq!(call_count.load(Ordering::SeqCst), 1, "closure should be called exactly once");
+    }
+
+    /// 5. Background refresh eventually updates the cache value.
+    #[tokio::test]
+    async fn background_refresh_updates_cache() {
+        let cached: ValueCached<usize> = ValueCached::new(SHORT);
+
+        // Seed.
+        {
+            let r = cached.call_timeout(async { Ok(1usize) }, Duration::from_millis(500)).await;
+            drop(r);
+        }
+        wait().await;
+        tokio::time::sleep(SHORT).await; // expire
+
+        // Spawn a slow refresh that takes 100ms. Drop the ValueRef immediately
+        // so the spawned task can acquire the write lock when done.
+        let barrier = Arc::new(AtomicBool::new(false));
+        let b = barrier.clone();
+        {
+            let r = cached
+                .call_timeout(
+                    async move {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        b.store(true, Ordering::Release);
+                        Ok(2usize)
+                    },
+                    Duration::from_millis(500),
+                )
+                .await;
+            // r holds a read lock — drop it before the background task tries
+            // to write.
+            drop(r);
+        }
+
+        // Immediately after drop: still stale (bg task may still be sleeping).
+        let r = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
+        assert_eq!(*r.get().unwrap(), 1, "still stale before refresh completes");
+        drop(r);
+
+        // Wait for the slow refresh to finish.
+        wait().await;
+        assert!(barrier.load(Ordering::Acquire), "slow refresh should have completed");
+
+        // Now the value should be 2.
+        let r = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
+        assert_eq!(*r.get().unwrap(), 2, "cache should now have the refreshed value");
+    }
+
+    /// 6. When the refresh closure fails, the error is cached.
+    #[tokio::test]
+    async fn refresh_error_cached() {
+        let cached: ValueCached<usize> = ValueCached::new(SHORT);
+
+        // Seed a successful value.
+        {
+            let r = cached.call_timeout(async { Ok(1usize) }, Duration::from_millis(500)).await;
+            drop(r);
+        }
+        wait().await;
+        tokio::time::sleep(SHORT).await; // expire
+
+        // Trigger a refresh that fails.
+        {
+            let r = cached
+                .call_timeout(
+                    async { Err::<usize, _>(anyhow::anyhow!("storage error")) },
+                    Duration::from_millis(500),
+                )
+                .await;
+            drop(r);
+        }
+        wait().await;
+
+        // get() should return the error.
+        let r = cached.call_timeout(async { Ok(3usize) }, Duration::from_millis(500)).await;
+        match r.get() {
+            Err(e) => assert!(e.to_string().contains("storage error"), "error should be preserved"),
+            Ok(v) => panic!("expected error, got Ok({v})"),
+        }
+    }
+
+    /// 7. call_sync variant works with a blocking closure.
+    #[tokio::test]
+    #[allow(unused)]
+    async fn sync_variant_works() {
+        let cached: ValueCached<usize> = ValueCached::new(SHORT);
+        let rc = Arc::new(AtomicUsize::new(0));
+
+        // First call — sync variant.
+        {
+            let r = cached
+                .call_timeout_sync(|| -> Result<usize> { Ok(42usize) }, Duration::from_millis(500))
+                .await;
+            // No value yet (first call).
+            assert!(r.get().is_err() || *r.get().unwrap() == 42);
+            drop(r);
+        }
+        wait().await;
+
+        // Now the value should be available.
+        let r = cached.call_timeout_sync(|| Ok(99usize), Duration::from_millis(500)).await;
+        assert_eq!(*r.get().unwrap(), 42, "should have the cached value from spawn_blocking");
+    }
+
+    /// 8. Multiple expiry cycles work correctly.
+    #[tokio::test]
+    async fn multiple_expiry_cycles() {
+        let cached: ValueCached<usize> = ValueCached::new(SHORT);
+
+        // Cycle 1: seed.
+        {
+            let r = cached.call_timeout(async { Ok(1usize) }, Duration::from_millis(500)).await;
+            drop(r);
+        }
+        wait().await;
+
+        // Cycle 2: expire and refresh.
+        tokio::time::sleep(SHORT).await;
+        {
+            let r = cached.call_timeout(async { Ok(2usize) }, Duration::from_millis(500)).await;
+            assert_eq!(*r.get().unwrap(), 1, "stale 1 before refresh");
+            assert!(r.spawned());
+            drop(r);
+        }
+        wait().await;
+
+        // Cycle 3: expire and refresh again.
+        tokio::time::sleep(SHORT).await;
+        {
+            let r = cached.call_timeout(async { Ok(3usize) }, Duration::from_millis(500)).await;
+            assert_eq!(*r.get().unwrap(), 2, "stale 2 before refresh");
+            assert!(r.spawned());
+            drop(r);
+        }
+        wait().await;
+
+        let r = cached.call_timeout(async { Ok(99usize) }, Duration::from_millis(500)).await;
+        assert_eq!(*r.get().unwrap(), 3, "final value should be 3");
+    }
+}

--- a/rmqtt-utils/Cargo.toml
+++ b/rmqtt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-utils"
-version = "0.1.5"
+version = "0.1.6"
 description = "Essential utilities for RMQTT system operations."
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-utils"
 edition.workspace = true

--- a/rmqtt-utils/README-CN.md
+++ b/rmqtt-utils/README-CN.md
@@ -150,6 +150,53 @@ impl CircuitBreaker {
 | **Open** | `is_blocked()` 返回 `true`，调用方快速跳过外部操作 |
 | **HalfOpen** | 探测阶段，放行请求；连续成功足够次后关闭，任意失败立即回到 Open |
 
+## `RateCounter` — 无锁吞吐量和并发跟踪器
+
+```rust
+use std::time::Duration;
+use rmqtt_utils::RateCounter;
+
+let rc = RateCounter::new();
+
+// 任务到达：跟踪吞吐量、并发数和峰值
+rc.incs(42);
+assert_eq!(rc.total(), 42);
+assert_eq!(rc.current(), 42);
+assert_eq!(rc.max(), 42);
+
+// 更高峰值
+rc.incs(10);
+assert_eq!(rc.max(), 52);
+
+// 任务完成：并发数减少，峰值不变
+rc.decs(20);
+assert_eq!(rc.current(), 32);
+assert_eq!(rc.max(), 52);
+
+// 计算 3 秒间隔内的每秒速率
+rc.tick(Duration::from_secs(3));
+assert!((rc.speed() - 17.333).abs() < 1e-12);
+```
+
+纯原子操作、零锁的速率计数器，跟踪以下指标：
+- **`total`**：自创建或重置以来的累计计数。
+- **`speed`**：每秒吞吐量，通过以已知采样间隔调用 `tick(interval)` 计算。
+- **`current`**：当前并发/活跃计数（`inc`/`incs` 增加，`dec`/`decs` 减少）。
+- **`max`**：`current` 的历史峰值。
+
+`Clone` 通过 `Arc` 共享底层原子变量 — 非常适合传入 `tokio::spawn`。
+`snapshot()` 创建独立的深拷贝（值相同，新原子变量）。
+Serde 序列化/反序列化为快照（可安全跨节点传输）。
+
+| 方法 | 作用 |
+|------|------|
+| `inc()` / `incs(n)` | 增加 `total` 和 `current`；更新 `max` |
+| `dec()` / `decs(n)` | 仅减少 `current` |
+| `tick(interval)` | 计算 `speed = (total - last_total) / interval` |
+| `reset()` | 清零所有计数器 |
+| `total()` / `speed()` / `current()` / `max()` | 读取单个计数器值 |
+| `snapshot()` | 创建独立的深拷贝 |
+
 ## 安全性
 
 `#![deny(unsafe_code)]` — 零 unsafe 代码。

--- a/rmqtt-utils/README.md
+++ b/rmqtt-utils/README.md
@@ -156,6 +156,53 @@ blocking the broker when Redis is unreachable.
 
 `#![deny(unsafe_code)]` — zero unsafe code.
 
+## `RateCounter` — lock‑free throughput & in‑flight tracker
+
+```rust
+use std::time::Duration;
+use rmqtt_utils::RateCounter;
+
+let rc = RateCounter::new();
+
+// Task arrives: track throughput, in-flight, and peak
+rc.incs(42);
+assert_eq!(rc.total(), 42);
+assert_eq!(rc.current(), 42);
+assert_eq!(rc.max(), 42);
+
+// Higher peak
+rc.incs(10);
+assert_eq!(rc.max(), 52);
+
+// Task completes: in-flight decreases, peak unchanged
+rc.decs(20);
+assert_eq!(rc.current(), 32);
+assert_eq!(rc.max(), 52);
+
+// Compute per-second rate over a 3 s interval
+rc.tick(Duration::from_secs(3));
+assert!((rc.speed() - 17.333).abs() < 1e-12);
+```
+
+A pure‑atomics, zero‑lock rate counter that tracks:
+- **`total`**: Cumulative count since construction or reset.
+- **`speed`**: Per‑second throughput, computed by calling `tick(interval)` at a known sampling interval.
+- **`current`**: Current in‑flight / active count (incremented by `inc`/`incs`, decremented by `dec`/`decs`).
+- **`max`**: Historical peak of the `current` field.
+
+`Clone` shares the underlying atomics via `Arc` — ideal for passing into `tokio::spawn`.  
+`snapshot()` creates an independent deep copy with the same values but new atomics.  
+Serde serialises/deserialises as a snapshot (safe for cross‑node transfer).
+
+| Method | Effect |
+|--------|--------|
+| `inc()` / `incs(n)` | Increment `total` and `current`; update `max` |
+| `dec()` / `decs(n)` | Decrement `current` only |
+| `tick(interval)` | Compute `speed = (total - last_total) / interval` |
+| `reset()` | Zero all counters |
+| `total()` / `speed()` / `current()` / `max()` | Read individual counters |
+| `snapshot()` | Create independent deep copy |
+
 ## License
 
 MIT OR Apache-2.0

--- a/rmqtt-utils/src/circuit_breaker.rs
+++ b/rmqtt-utils/src/circuit_breaker.rs
@@ -268,6 +268,16 @@ impl CircuitBreaker {
         }
     }
 
+    #[inline]
+    pub fn failure_count(&self) -> usize {
+        self.failure_count.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    pub fn success_count(&self) -> usize {
+        self.success_count.load(Ordering::SeqCst)
+    }
+
     /// Manually reset the circuit breaker to CLOSED state.
     ///
     /// This is useful after administrative recovery of the downstream service.

--- a/rmqtt-utils/src/lib.rs
+++ b/rmqtt-utils/src/lib.rs
@@ -83,9 +83,11 @@ use serde::{
 
 mod circuit_breaker;
 mod counter;
+mod rate_counter;
 
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, CircuitState};
 pub use counter::{Counter, StatsMergeMode};
+pub use rate_counter::RateCounter;
 
 /// Cluster node identifier type (64-bit unsigned integer)
 pub type NodeId = u64;

--- a/rmqtt-utils/src/rate_counter.rs
+++ b/rmqtt-utils/src/rate_counter.rs
@@ -1,0 +1,513 @@
+//! Lightweight rate counter for tracking cumulative throughput,
+//! per-second processing speed, current in-flight count, and peak.
+//!
+//! Uses `AtomicU64` / `AtomicI64` fields with Relaxed ordering
+//! throughout. The caller drives the sampling by calling
+//! [`RateCounter::tick`] at a known interval.
+//!
+//! [`inc`](RateCounter::inc) / [`incs`](RateCounter::incs) increment
+//! **both** the cumulative `total` **and** the current in-flight count,
+//! and update the peak (`max`) via atomc `fetch_max`.
+//! [`dec`](RateCounter::dec) / [`decs`](RateCounter::decs) only
+//! decrement `current` — matching the pattern of a
+//! producer-consumer pipeline.
+//!
+//! # Example
+//! ```
+//! use std::time::Duration;
+//! use rmqtt_utils::RateCounter;
+//!
+//! let rc = RateCounter::new();
+//!
+//! // Task arrives: track throughput, in-flight, and peak
+//! rc.incs(42);
+//! assert_eq!(rc.total(), 42);
+//! assert_eq!(rc.current(), 42);
+//! assert_eq!(rc.max(), 42);
+//!
+//! // Higher peak
+//! rc.incs(10);
+//! assert_eq!(rc.max(), 52);
+//!
+//! // Task completes: in-flight decreases, peak unchanged
+//! rc.decs(20);
+//! assert_eq!(rc.current(), 32);
+//! assert_eq!(rc.max(), 52);
+//!
+//! // Compute per-second rate over a 3 s interval
+//! rc.tick(Duration::from_secs(3));
+//! assert!((rc.speed() - 17.333333333333332).abs() < 1e-12);
+//! ```
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::json;
+
+use crate::StatsMergeMode;
+
+/// A lock-free, thread-safe rate counter with current in-flight tracking
+/// and peak water mark.
+///
+/// Wraps five atomic values in `Arc` so the counter is [`Clone`] —
+/// clones share the same underlying counters, making it easy to pass
+/// into concurrent tasks (e.g. [`tokio::spawn`]).
+///
+/// The `speed` field stores a true **per-second rate** as an `f64`
+/// (encoded via `f64::to_bits` / `f64::from_bits` in the `AtomicU64`),
+/// normalised by the sampling interval passed to [`tick`](RateCounter::tick).
+///
+/// The `current` field tracks the current in-flight or active count.
+/// [`inc`](RateCounter::inc) / [`incs`](RateCounter::incs) increment **both**
+/// `total` and `current` simultaneously and update `max` to the new peak.
+/// [`dec`](RateCounter::dec) / [`decs`](RateCounter::decs) only decrement
+/// `current` without affecting `max`.
+/// [`tick`](RateCounter::tick) does **not** affect `current` or `max`.
+///
+/// # Serialisation
+///
+/// `RateCounter` serialises as a snapshot of the **current** counter values
+/// (total, speed, current, max). Deserialisation produces a fresh,
+/// **independent** counter initialised to those values — it does NOT share
+/// atomics with the original. This makes it safe for cross-node transfer
+/// (e.g. via gRPC).
+#[derive(Debug)]
+pub struct RateCounter {
+    /// Total cumulative count since construction (or last reset).
+    total: Arc<AtomicU64>,
+    /// Per-second rate, stored as `f64::to_bits` in an `AtomicU64`.
+    speed: Arc<AtomicU64>,
+    /// Snapshot of `total` at the time of the last [`tick`](RateCounter::tick).
+    last_total: Arc<AtomicU64>,
+    /// Current (in-flight / active) count.
+    current: Arc<AtomicI64>,
+    /// Peak (historical maximum) of the current count.
+    max: Arc<AtomicI64>,
+    /// Merge behaviour for [`Stats::add`] aggregation.
+    mode: StatsMergeMode,
+}
+
+impl Clone for RateCounter {
+    fn clone(&self) -> Self {
+        Self {
+            total: Arc::clone(&self.total),
+            speed: Arc::clone(&self.speed),
+            last_total: Arc::clone(&self.last_total),
+            current: Arc::clone(&self.current),
+            max: Arc::clone(&self.max),
+            mode: self.mode.clone(),
+        }
+    }
+}
+
+impl Default for RateCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RateCounter {
+    /// Creates a new `RateCounter` with all values initialised to zero
+    /// and [`StatsMergeMode::None`].
+    #[inline]
+    pub fn new() -> Self {
+        Self::new_with_mode(StatsMergeMode::None)
+    }
+
+    /// Creates a new `RateCounter` with a given merge mode.
+    #[inline]
+    pub fn new_with_mode(mode: StatsMergeMode) -> Self {
+        Self {
+            total: Arc::new(AtomicU64::new(0)),
+            speed: Arc::new(AtomicU64::new(0)),
+            last_total: Arc::new(AtomicU64::new(0)),
+            current: Arc::new(AtomicI64::new(0)),
+            max: Arc::new(AtomicI64::new(0)),
+            mode,
+        }
+    }
+
+    /// Creates an independent deep copy (new atomics) with the same values.
+    #[inline]
+    pub fn snapshot(&self) -> Self {
+        Self {
+            total: Arc::new(AtomicU64::new(self.total())),
+            speed: Arc::new(AtomicU64::new(f64::to_bits(self.speed()))),
+            last_total: Arc::new(AtomicU64::new(self.total())),
+            current: Arc::new(AtomicI64::new(self.current())),
+            max: Arc::new(AtomicI64::new(self.max())),
+            mode: self.mode.clone(),
+        }
+    }
+
+    /// Increments total, current, and potentially updates max by 1.
+    #[inline]
+    pub fn inc(&self) {
+        self.total.fetch_add(1, Ordering::Relaxed);
+        let old = self.current.fetch_add(1, Ordering::Relaxed);
+        self.max.fetch_max(old + 1, Ordering::Relaxed);
+    }
+
+    /// Increments total, current, and potentially updates max by `n`.
+    #[inline]
+    pub fn incs(&self, n: u64) {
+        self.total.fetch_add(n, Ordering::Relaxed);
+        let old = self.current.fetch_add(n as i64, Ordering::Relaxed);
+        self.max.fetch_max(old + n as i64, Ordering::Relaxed);
+    }
+
+    /// Returns the cumulative total count.
+    #[inline]
+    pub fn total(&self) -> u64 {
+        self.total.load(Ordering::Relaxed)
+    }
+
+    /// Returns the per-second rate computed by the most recent [`tick`].
+    ///
+    /// Returns `0.0` if [`tick`] has never been called.
+    #[inline]
+    pub fn speed(&self) -> f64 {
+        f64::from_bits(self.speed.load(Ordering::Relaxed))
+    }
+
+    /// Computes the per-second rate: `speed = (total - last_total) / interval`.
+    ///
+    /// Call this periodically at a known `interval` (e.g. every 3 s) to get
+    /// a true per-second throughput, regardless of the sampling duration.
+    #[inline]
+    pub fn tick(&self, interval: Duration) {
+        let curr = self.total.load(Ordering::Relaxed);
+        let prev = self.last_total.swap(curr, Ordering::Relaxed);
+        let delta = curr.wrapping_sub(prev) as f64;
+        let rate = delta / interval.as_secs_f64();
+        self.speed.store(f64::to_bits(rate), Ordering::Relaxed);
+    }
+
+    /// Resets all counters to zero.
+    #[inline]
+    pub fn reset(&self) {
+        self.total.store(0, Ordering::Relaxed);
+        self.speed.store(f64::to_bits(0.0), Ordering::Relaxed);
+        self.last_total.store(0, Ordering::Relaxed);
+        self.current.store(0, Ordering::Relaxed);
+        self.max.store(0, Ordering::Relaxed);
+    }
+
+    // ── current (in-flight) counter ──
+
+    /// Returns the current (in-flight / active) count.
+    #[inline]
+    pub fn current(&self) -> i64 {
+        self.current.load(Ordering::Relaxed)
+    }
+
+    /// Returns the peak (historical maximum) of the current count.
+    #[inline]
+    pub fn max(&self) -> i64 {
+        self.max.load(Ordering::Relaxed)
+    }
+
+    /// Converts the rate counter to JSON format.
+    #[inline]
+    pub fn to_json(&self) -> serde_json::Value {
+        json!({
+            "total": self.total(),
+            "speed": self.speed(),
+            "current": self.current(),
+            "max": self.max(),
+        })
+    }
+
+    // ── Aggregation helpers (mirroring Counter) ──
+
+    /// Sums `total`, `current` and `max` from `other` into `self`.
+    #[inline]
+    pub fn add(&self, other: &Self) {
+        self.total.fetch_add(other.total(), Ordering::Relaxed);
+        self.current.fetch_add(other.current(), Ordering::Relaxed);
+        self.max.fetch_add(other.max(), Ordering::Relaxed);
+    }
+
+    /// Replaces all fields with the values from `other`.
+    #[inline]
+    pub fn set(&self, other: &Self) {
+        self.total.store(other.total(), Ordering::Relaxed);
+        self.speed.store(f64::to_bits(other.speed()), Ordering::Relaxed);
+        self.last_total.store(other.total(), Ordering::Relaxed);
+        self.current.store(other.current(), Ordering::Relaxed);
+        self.max.store(other.max(), Ordering::Relaxed);
+    }
+
+    /// Merges `other` into `self` according to [`self.mode`](StatsMergeMode).
+    ///
+    /// * [`None`](StatsMergeMode::None) — no-op.
+    /// * [`Sum`](StatsMergeMode::Sum) — totals are summed,
+    ///   `current` / `max` take the larger value.
+    /// * [`Max`](StatsMergeMode::Max) / [`Min`](StatsMergeMode::Min) —
+    ///   only `current` and `max` are affected.
+    #[inline]
+    pub fn merge(&self, other: &Self) {
+        match self.mode {
+            StatsMergeMode::None => {}
+            StatsMergeMode::Sum => {
+                self.add(other);
+            }
+            StatsMergeMode::Max => {
+                self.current.fetch_max(other.current(), Ordering::Relaxed);
+                self.max.fetch_max(other.max(), Ordering::Relaxed);
+                self.total.fetch_max(other.total(), Ordering::Relaxed);
+            }
+            StatsMergeMode::Min => {
+                self.current.fetch_min(other.current(), Ordering::Relaxed);
+                self.max.fetch_min(other.max(), Ordering::Relaxed);
+                self.total.fetch_min(other.total(), Ordering::Relaxed);
+            }
+            _ => {}
+        }
+    }
+
+    /// Decrements the current count by 1 (total and max unchanged).
+    #[inline]
+    pub fn dec(&self) {
+        self.current.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Decrements the current count by `n` (total and max unchanged).
+    #[inline]
+    pub fn decs(&self, n: i64) {
+        self.current.fetch_sub(n, Ordering::Relaxed);
+    }
+}
+
+// ── Serde: snapshot-based serialisation ──
+
+/// Helper struct carrying the fields we serialise.
+#[derive(Serialize, Deserialize)]
+struct RateCounterData {
+    total: u64,
+    speed: f64,
+    current: i64,
+    max: i64,
+    mode: StatsMergeMode,
+}
+
+impl Serialize for RateCounter {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        RateCounterData {
+            total: self.total(),
+            speed: self.speed(),
+            current: self.current(),
+            max: self.max(),
+            mode: self.mode.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for RateCounter {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let data = RateCounterData::deserialize(deserializer)?;
+        Ok(RateCounter {
+            total: Arc::new(AtomicU64::new(data.total)),
+            speed: Arc::new(AtomicU64::new(f64::to_bits(data.speed))),
+            last_total: Arc::new(AtomicU64::new(data.total)),
+            current: Arc::new(AtomicI64::new(data.current)),
+            max: Arc::new(AtomicI64::new(data.max)),
+            mode: data.mode,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn new_is_zero() {
+        let rc = RateCounter::new();
+        assert_eq!(rc.total(), 0);
+        assert_eq!(rc.speed(), 0.0);
+        assert_eq!(rc.current(), 0);
+        assert_eq!(rc.max(), 0);
+    }
+
+    #[test]
+    fn inc_updates_current_and_max() {
+        let rc = RateCounter::new();
+        rc.inc();
+        assert_eq!(rc.total(), 1);
+        assert_eq!(rc.current(), 1);
+        assert_eq!(rc.max(), 1);
+    }
+
+    #[test]
+    fn incs_updates_current_and_max() {
+        let rc = RateCounter::new();
+        rc.incs(42);
+        assert_eq!(rc.total(), 42);
+        assert_eq!(rc.current(), 42);
+        assert_eq!(rc.max(), 42);
+    }
+
+    #[test]
+    fn max_tracks_peak() {
+        let rc = RateCounter::new();
+        rc.incs(10);
+        assert_eq!(rc.max(), 10);
+
+        rc.decs(5);
+        assert_eq!(rc.current(), 5);
+        assert_eq!(rc.max(), 10, "decrease should not lower max");
+
+        rc.incs(20);
+        assert_eq!(rc.current(), 25);
+        assert_eq!(rc.max(), 25, "new higher peak should update max");
+    }
+
+    #[test]
+    fn dec_does_not_affect_total_nor_max() {
+        let rc = RateCounter::new();
+        rc.incs(10);
+        assert_eq!(rc.total(), 10);
+        assert_eq!(rc.max(), 10);
+
+        rc.dec();
+        assert_eq!(rc.total(), 10, "dec should not change total");
+        assert_eq!(rc.current(), 9);
+        assert_eq!(rc.max(), 10, "dec should not change max");
+
+        rc.decs(5);
+        assert_eq!(rc.total(), 10, "decs should not change total");
+        assert_eq!(rc.current(), 4);
+        assert_eq!(rc.max(), 10, "decs should not change max");
+    }
+
+    #[test]
+    fn tick_does_not_affect_current_nor_max() {
+        let rc = RateCounter::new();
+        rc.incs(100);
+        assert_eq!(rc.current(), 100);
+        assert_eq!(rc.max(), 100);
+
+        rc.tick(Duration::from_secs(1));
+        assert!((rc.speed() - 100.0).abs() < f64::EPSILON);
+        assert_eq!(rc.total(), 100);
+        assert_eq!(rc.current(), 100, "tick should not affect current");
+        assert_eq!(rc.max(), 100, "tick should not affect max");
+    }
+
+    #[test]
+    fn reset_clears_all_including_max() {
+        let rc = RateCounter::new();
+        rc.incs(100);
+        rc.decs(20);
+        rc.tick(Duration::from_secs(1));
+        rc.reset();
+        assert_eq!(rc.total(), 0);
+        assert_eq!(rc.speed(), 0.0);
+        assert_eq!(rc.current(), 0);
+        assert_eq!(rc.max(), 0);
+
+        // tick after reset should yield 0
+        rc.tick(Duration::from_secs(1));
+        assert_eq!(rc.speed(), 0.0);
+    }
+
+    #[test]
+    fn concurrent_incs_max() {
+        use std::thread;
+
+        let rc = Arc::new(RateCounter::new());
+        let mut handles = Vec::new();
+
+        for _ in 0..8 {
+            let rc = rc.clone();
+            handles.push(thread::spawn(move || {
+                for _ in 0..1_000 {
+                    rc.inc();
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(rc.total(), 8_000);
+        assert_eq!(rc.current(), 8_000);
+        // With 8 threads racing, the max should be 8_000 (all incs at once)
+        // or less (some threads may have started before others completed decs
+        // in other tests, but here there are no decs, so max == current)
+        assert_eq!(rc.max(), 8_000);
+    }
+
+    #[test]
+    fn clone_shares_max() {
+        let a = RateCounter::new();
+        let b = a.clone();
+
+        a.incs(10);
+        assert_eq!(b.total(), 10, "clone should see the same total");
+        assert_eq!(b.current(), 10, "clone should see the same current");
+        assert_eq!(b.max(), 10, "clone should see the same max");
+
+        b.dec();
+        assert_eq!(a.current(), 9, "original should see b's dec");
+
+        a.incs(20);
+        assert_eq!(b.current(), 29, "clone should see a's new current");
+        assert_eq!(b.max(), 29, "clone should see a's new max");
+
+        a.tick(Duration::from_secs(1));
+        assert!((b.speed() - 30.0).abs() < f64::EPSILON, "speed computed on a should also be visible on b");
+    }
+
+    #[test]
+    fn concurrent_inc_dec_pair_max() {
+        use std::thread;
+
+        let rc = Arc::new(RateCounter::new());
+        let mut handles = Vec::new();
+
+        // 8 threads each inc and dec 1_000 times → net current should be 0
+        for _ in 0..8 {
+            let rc = rc.clone();
+            handles.push(thread::spawn(move || {
+                for _ in 0..1_000 {
+                    rc.inc();
+                    rc.dec();
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // total should reflect all incs
+        assert_eq!(rc.total(), 8_000);
+        // net current should be 0
+        assert_eq!(rc.current(), 0);
+        // max should be > 0 (at some point there were concurrent incs)
+        assert!(rc.max() > 0, "concurrent inc/dec should have produced a peak");
+    }
+
+    #[test]
+    fn to_json_includes_all_fields() {
+        let rc = RateCounter::new();
+        rc.incs(100);
+        rc.decs(20);
+        rc.tick(Duration::from_secs(5));
+
+        let json = rc.to_json();
+        let obj = json.as_object().expect("to_json should return an object");
+
+        assert_eq!(obj["total"].as_u64(), Some(100));
+        assert!((obj["speed"].as_f64().unwrap() - 20.0).abs() < f64::EPSILON);
+        assert_eq!(obj["current"].as_i64(), Some(80));
+        assert_eq!(obj["max"].as_i64(), Some(100));
+    }
+}

--- a/rmqtt/Cargo.toml
+++ b/rmqtt/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 [features]
 default = []
 debug = []
-full = ["metrics", "stats", "plugin", "grpc", "tls", "ws", "quic", "delayed", "retain", "msgstore", "shared-subscription", "auto-subscription", "limit-subscription"]
+full = ["metrics", "stats", "plugin", "grpc", "tls", "ws", "quic", "delayed", "retain", "msgstore", "shared-subscription", "auto-subscription", "limit-subscription", "rate-counter"]
 metrics = ["rmqtt-macros/metrics"]
 stats = []
 plugin = ["rmqtt-macros/plugin"]
@@ -33,6 +33,7 @@ msgstore = []
 shared-subscription = []
 auto-subscription = []
 limit-subscription = []
+rate-counter = ["stats"]
 macros = ["dep:rmqtt-macros", "metrics", "plugin"]
 
 [dependencies]
@@ -70,6 +71,7 @@ url.workspace = true
 config = { workspace = true, features = ["toml"] }
 scopeguard.workspace = true
 parking_lot.workspace = true
+strum = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
 chrono = { workspace = true, features = ["clock"] }

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -67,6 +67,7 @@ use rust_box::handy_grpc::{
 use rust_box::mpsc::priority_channel as channel;
 use scopeguard::defer;
 use serde::{Deserialize, Serialize};
+use strum::EnumCount;
 
 use crate::context::ServerContext;
 use crate::types::{
@@ -101,9 +102,24 @@ impl GrpcServer {
         reuseport: bool,
     ) -> Result<()> {
         let runner = async move {
-            let (tx, mut rx) = channel::<Priority, GrpcMessage>(300_000);
+            let (tx, mut rx) = channel::<Priority, GrpcMessage>(100_000);
+
+            #[cfg(feature = "rate-counter")]
+            {
+                let counters = self.scx.stats.grpc_message_counters.clone();
+                tokio::spawn(async move {
+                    let interval = Duration::from_millis(1500);
+                    loop {
+                        tokio::time::sleep(interval).await;
+                        for (_, c) in counters.iter() {
+                            c.tick(interval);
+                        }
+                    }
+                });
+            }
+
             let recv_data_fut = async move {
-                let exec = self.scx.get_exec("GRPC_SERVER_EXEC");
+                let exec = self.scx.get_exec(("GRPC_SERVER_EXEC", 5_000, 50_000));
                 while let Some((_, (data, reply_tx))) = rx.next().await {
                     #[cfg(feature = "stats")]
                     self.scx.stats.grpc_server_actives.inc();
@@ -148,7 +164,21 @@ impl GrpcServer {
 
     async fn on_recv_message(&self, req: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let (typ, msg) = Message::decode(&req)?;
+
+        #[cfg(feature = "rate-counter")]
+        let vid = msg.variant_id();
+        #[cfg(feature = "rate-counter")]
+        if let Some(c) = self.scx.stats.grpc_message_counters.get(&vid) {
+            c.inc();
+        }
+
         let reply = self.scx.extends.hook_mgr().grpc_message_received(typ, msg).await?;
+
+        #[cfg(feature = "rate-counter")]
+        if let Some(c) = self.scx.stats.grpc_message_counters.get(&vid) {
+            c.dec();
+        }
+
         Ok(Some(reply.encode()?))
     }
 }
@@ -248,11 +278,12 @@ impl GrpcClient {
         }
 
         // Fast-fail if the duplex request queue is full (peer node may be down).
-        if self.duplex_mailbox.req_queue_is_full() {
-            return Err(anyhow::anyhow!(
-                "send_message failed: duplex request queue is full (peer node may be down)"
-            ));
-        }
+        // if self.duplex_mailbox.req_queue_is_full() {
+        //     return Err(anyhow::anyhow!(
+        //         "send_message failed: duplex request queue is full (peer node may be down)"
+        //     ));
+        // }
+
         let req = msg.encode(typ)?;
         let reply = if let Some(timeout) = timeout {
             tokio::time::timeout(timeout, self.duplex_mailbox.send(req)).await??
@@ -309,9 +340,10 @@ impl GrpcClient {
         // mailbox.send().await blocks indefinitely when the queue is full because
         // poll_ready returns Pending until the consumer drains it — and a dead node
         // never will.  Returning an error immediately prevents worker starvation.
-        if self.mailbox.req_queue_is_full() {
-            return Err(anyhow::anyhow!("notify failed: transfer queue is full (peer node may be down)"));
-        }
+        // if self.mailbox.req_queue_is_full() {
+        //     return Err(anyhow::anyhow!("notify failed: transfer queue is full (peer node may be down)"));
+        // }
+
         let req = msg.encode(typ)?;
         if let Some(timeout) = timeout {
             tokio::time::timeout(timeout, self.mailbox.send(req)).await??;
@@ -331,15 +363,26 @@ pub type MessageType = u64;
 ///
 /// Each variant represents a specific cluster operation:
 /// message forwarding, client management, state queries, etc.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, EnumCount)]
 pub enum Message {
     Forwards(From, Publish),
     ForwardsTo(From, Publish, SubRelations, Option<MsgID>),
     ForwardsToAck(MsgID, NodeId, ForwardedRecipients),
     Kick(Id, CleanStart, ClearSubscriptions, IsAdmin),
     GetRetains(TopicFilter),
-    GetAllRetains { offset: usize, limit: usize },
+    GetAllRetains {
+        offset: usize,
+        limit: usize,
+    },
     SetRetain(TopicName, Retain, Option<Duration>),
+    /// Lightweight topic-only retain sync — set (for shared backends like Redis).
+    /// Carries the topic name and expiry — the receiver unconditionally
+    /// inserts the topic into its in-memory index without querying Redis.
+    SetRetainTopicAdd(TopicName, Option<Duration>),
+    /// Lightweight topic-only retain sync — remove (for shared backends like Redis).
+    /// Carries only the topic name — the receiver unconditionally removes
+    /// the topic from its in-memory index.
+    SetRetainTopicRemove(TopicName),
     SubscriptionsSearch(SubsSearchParams),
     SubscriptionsGet(ClientId),
     RoutesGet(usize),
@@ -361,6 +404,72 @@ impl Message {
     pub fn decode(data: &[u8]) -> Result<(MessageType, Message)> {
         Ok(postcard::from_bytes::<(MessageType, Message)>(data)?)
     }
+
+    /// Returns a unique byte ID for each enum variant, used as the key
+    /// in [`Stats::grpc_message_counters`] for per-variant rate tracking.
+    #[inline]
+    pub fn variant_id(&self) -> u8 {
+        match self {
+            Message::Forwards(..) => 0,
+            Message::ForwardsTo(..) => 1,
+            Message::ForwardsToAck(..) => 2,
+            Message::Kick(..) => 3,
+            Message::GetRetains(..) => 4,
+            Message::GetAllRetains { .. } => 5,
+            Message::SetRetain(..) => 6,
+            Message::SetRetainTopicAdd(..) => 7,
+            Message::SetRetainTopicRemove(..) => 8,
+            Message::SubscriptionsSearch(..) => 9,
+            Message::SubscriptionsGet(..) => 10,
+            Message::RoutesGet(..) => 11,
+            Message::RoutesGetBy(..) => 12,
+            Message::NumberOfClients => 13,
+            Message::NumberOfSessions => 14,
+            Message::Online(..) => 15,
+            Message::SessionStatus(..) => 16,
+            Message::MessageGet(..) => 17,
+            Message::Data(..) => 18,
+        }
+    }
+
+    /// Returns the display name for a given variant ID (inverse of [`variant_id`]).
+    ///
+    /// Used by [`Stats::to_sys_json`] to label per-variant rate counters.
+    #[inline]
+    pub fn variant_id_to_name(id: u8) -> &'static str {
+        match id {
+            0 => "Forwards",
+            1 => "ForwardsTo",
+            2 => "ForwardsToAck",
+            3 => "Kick",
+            4 => "GetRetains",
+            5 => "GetAllRetains",
+            6 => "SetRetain",
+            7 => "SetRetainTopicAdd",
+            8 => "SetRetainTopicRemove",
+            9 => "SubscriptionsSearch",
+            10 => "SubscriptionsGet",
+            11 => "RoutesGet",
+            12 => "RoutesGetBy",
+            13 => "NumberOfClients",
+            14 => "NumberOfSessions",
+            15 => "Online",
+            16 => "SessionStatus",
+            17 => "MessageGet",
+            18 => "Data",
+            _ => "Unknown",
+        }
+    }
+
+    /// Shorthand: returns the display name of this variant.
+    #[inline]
+    pub fn variant_name(&self) -> &'static str {
+        Self::variant_id_to_name(self.variant_id())
+    }
+
+    /// Total number of [`Message`] variants — used to pre-allocate
+    /// per-variant rate counters in [`crate::stats::Stats`].
+    pub const VARIANT_COUNT: usize = <Self as EnumCount>::COUNT;
 }
 
 /// Reply variants for cluster message responses.

--- a/rmqtt/src/retain.rs
+++ b/rmqtt/src/retain.rs
@@ -82,6 +82,19 @@ use crate::Result;
 ///
 /// The default in-memory implementation ([`DefaultRetainStorage`]) is
 /// functional but logs a warning recommending the `rmqtt-retainer`
+/// What type of retain synchronization a storage backend requires.
+///
+/// - `Full`: send the full retain message (`SetRetain`) — for local-only
+///   backends like in-memory (Ram) or per-node Sled.
+/// - `TopicOnly`: send only the topic name (`SetRetainTopic`) — for shared
+///   backends like Redis where the retain data is already visible to all
+///   nodes, but the in-memory topic index must be kept in sync.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetainSyncMode {
+    Full,
+    TopicOnly,
+}
+
 /// plugin for production use.
 #[async_trait]
 pub trait RetainStorage: Sync + Send {
@@ -139,6 +152,36 @@ pub trait RetainStorage: Sync + Send {
     #[inline]
     fn stats_merge_mode(&self) -> StatsMergeMode {
         StatsMergeMode::None
+    }
+
+    /// What type of retain synchronization this storage requires from the
+    /// cluster plugin when [`retain_set_broadcast`] is called.
+    ///
+    /// [`retain_set_broadcast`]: crate::shared::ClusterShared::retain_set_broadcast
+    #[inline]
+    fn retain_sync_mode(&self) -> RetainSyncMode {
+        RetainSyncMode::Full
+    }
+
+    /// Handle a topic-only retain sync notification from a cluster peer.
+    ///
+    /// Called when the cluster plugin receives `SetRetainTopicAdd` or
+    /// `SetRetainTopicRemove` — only used when [`retain_sync_mode`] returns
+    /// `TopicOnly`. The storage backend should unconditionally insert or
+    /// remove the topic from its in-memory index **without** querying the
+    /// shared storage, since the actual retain data is already in Redis.
+    ///
+    /// - `is_set = true` : retain exists, insert into index
+    /// - `is_set = false`: retain deleted, remove from index
+    ///
+    /// [`retain_sync_mode`]: Self::retain_sync_mode
+    async fn sync_retain_topic(
+        &self,
+        _topic: &TopicName,
+        _expiry_interval: Option<Duration>,
+        _is_set: bool,
+    ) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/rmqtt/src/stats.rs
+++ b/rmqtt/src/stats.rs
@@ -56,6 +56,8 @@ use crate::context::ServerContext;
 use crate::context::TaskExecStats;
 use crate::types::{HashMap, NodeId};
 use crate::utils::Counter;
+#[cfg(feature = "rate-counter")]
+use rmqtt_utils::{RateCounter, StatsMergeMode};
 
 /// Aggregated runtime statistics for the broker.
 ///
@@ -110,6 +112,10 @@ pub struct Stats {
     /// Active tasks per named executor.
     pub execs_actives: HashMap<String, TaskExecStats>,
 
+    /// Per-variant gRPC message rate counters (set/retains, forwards, etc.).
+    #[cfg(feature = "rate-counter")]
+    pub grpc_message_counters: HashMap<u8, RateCounter>,
+
     #[cfg(feature = "debug")]
     /// Client state machine transitions per node.
     debug_client_states_map: HashMap<NodeId, usize>,
@@ -151,6 +157,15 @@ impl Stats {
             routes_map: HashMap::default(),
 
             execs_actives: HashMap::default(),
+
+            #[cfg(feature = "rate-counter")]
+            grpc_message_counters: {
+                let mut m = HashMap::default();
+                for id in 0..crate::grpc::Message::VARIANT_COUNT as u8 {
+                    m.insert(id, RateCounter::new_with_mode(StatsMergeMode::Sum));
+                }
+                m
+            },
 
             #[cfg(feature = "debug")]
             debug_client_states_map: HashMap::default(),
@@ -277,6 +292,13 @@ impl Stats {
 
             execs_actives,
 
+            #[cfg(feature = "rate-counter")]
+            grpc_message_counters: self
+                .grpc_message_counters
+                .iter()
+                .map(|(k, v)| (*k, v.snapshot()))
+                .collect(),
+
             #[cfg(feature = "debug")]
             debug_client_states_map,
             #[cfg(feature = "debug")]
@@ -330,6 +352,11 @@ impl Stats {
             self.debug_shared_peers.add(&other.debug_shared_peers);
             self.debug_subscriptions += other.debug_subscriptions;
             self.debug_session_channels.add(&other.debug_session_channels);
+        }
+
+        #[cfg(feature = "rate-counter")]
+        for (k, v) in other.grpc_message_counters {
+            self.grpc_message_counters.entry(k).and_modify(|self_v| self_v.merge(&v)).or_insert(v);
         }
     }
 
@@ -406,6 +433,23 @@ impl Stats {
 
             "execs_actives": self.execs_actives,
         });
+
+        #[cfg(feature = "rate-counter")]
+        {
+            if !self.grpc_message_counters.is_empty() {
+                if let Some(obj) = json_val.as_object_mut() {
+                    let counters_json: HashMap<String, serde_json::Value> = self
+                        .grpc_message_counters
+                        .iter()
+                        .map(|(vid, c)| {
+                            let name = crate::grpc::Message::variant_id_to_name(*vid);
+                            (name.to_string(), c.to_json())
+                        })
+                        .collect();
+                    obj.insert("grpc_message_rates".into(), json!(counters_json));
+                }
+            }
+        }
 
         #[cfg(feature = "debug")]
         {


### PR DESCRIPTION
Major refactoring of the retain message subsystem across the retainer plugin, cluster sync protocol, and monitoring infrastructure.

rmqtt-retainer storage layer:
- In-memory Topic Trie (RetainTree) rebuilt on startup, fast wildcard matching, incremental updates on set/remove
- Batch storage via mpsc channel, batch_insert/batch_remove with configurable batch_messages_limit (default 500)
- CircuitBreaker integrated into store/get paths, OPEN state fast-fails without touching storage backend
- Dedicated sync thread for topic-only messages (pure memory, no I/O)
- RateCounters for set and sync throughput (feature: rate-counter)
- ValueCached for bounded-wait count/info query caching
- New config: batch_messages_limit, circuit_breaker_enabled, circuit_failure_threshold, circuit_reset_timeout, circuit_half_open_success_threshold
- Removed retain_enable/AtomicBool from RamRetainer
- RETAINER_EXEC queue capacity 100000 -> 10000

Cluster sync protocol:
- RetainSyncMode enum (Full / TopicOnly) with sync_retain_topic() method
- gRPC Message: new SetRetainTopicAdd/SetRetainTopicRemove variants
- retain_set_broadcast dispatches Full or TopicOnly by RetainSyncMode
- Handlers: removed timestamp comparison, added topic-only handlers
- raft: dedicated retainer_exec task queue

GRPC per-variant rate tracking:
- variant_id() returning unique byte ID per Message variant
- grpc_message_counters: HashMap<u8, RateCounter> in ServerContextInner
- inc/dec on on_recv_message entry/exit, 1.5s tick for throughput
- Exposed in stats via grpc_message_rates
- All behind #[cfg(feature = "rate-counter")]
- gRPC server exec queue adjusted to (5000, 50000)

Utilities (rmqtt-utils):
- RateCounter: lock-free AtomicU64 counter (total/speed/current/max), tick(interval) throughput, snapshot(), Serde support
- CircuitBreaker: failure_count() / success_count() accessors

Documentation:
- docs/en_US|zh_CN/retainer.md: v0.22.0+ architecture section
- rmqtt-plugins/rmqtt-retainer/README: version 0.21->0.22, new config
- rmqtt-utils/README: RateCounter section
- docs/en_US|zh_CN/cluster-raft.md: uncomment rmqtt-retainer in example
- rmqtt.toml: uncomment rmqtt-retainer in default_startups