### PR TITLE
refactor(cluster): add dedicated exec queue for retain operations in cluster-broadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,9 +5306,9 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-storage"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ac7a928efa745506e646a281201067efba5d2e536a38f45c9fe12c209dd393"
+checksum = "550399d8a60b45b6c4e7eb81363e417d6b66baa876a89c41b3813e10ca05619f"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ rmqtt-net = "0.3.5"
 rmqtt-conf = "0.3.5"
 rmqtt-macros = "0.1.2"
 rmqtt-utils = "0.1.6"
-rmqtt-storage = { version = "0.8",  default-features = false }
+rmqtt-storage = { version = "0.9",  default-features = false }
 
 rmqtt-plugins = "0.22.0"
 rmqtt-acl = "0.22.0"

--- a/rmqtt-bin/Cargo.toml
+++ b/rmqtt-bin/Cargo.toml
@@ -66,7 +66,6 @@ rmqtt-p2p-messaging.workspace = true
 [package.metadata.plugins]
 rmqtt-acl = { default_startup = true }
 rmqtt-retainer = { }
-rmqtt-http-api = { default_startup = true }
 rmqtt-counter = { default_startup = true }
 rmqtt-auth-http = { }
 rmqtt-auth-jwt = { }
@@ -90,6 +89,7 @@ rmqtt-web-hook = { }
 rmqtt-cluster-raft = { immutable = true }
 rmqtt-cluster-broadcast = { immutable = true }
 rmqtt-p2p-messaging = { }
+rmqtt-http-api = { default_startup = true }
 #rmqtt-plugin-template = { }
 
 [build-dependencies]

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -215,6 +215,7 @@ pub struct ClusterShared {
     scx: ServerContext,
     exec: TaskExecQueue,
     forwards_exec: TaskExecQueue,
+    retainer_exec: TaskExecQueue,
     grpc_clients: GrpcClients,
     /// The gRPC message type used for cluster communication.
     pub message_type: MessageType,
@@ -241,11 +242,13 @@ impl ClusterShared {
     ) -> ClusterShared {
         let scx1 = scx.clone();
         let forwards_exec = scx.get_exec("BC_FORWARDS_EXEC");
+        let retainer_exec = scx.get_exec("BC_RETAINER_EXEC");
         Self {
             inner: DefaultShared::new(Some(scx1)),
             scx,
             exec,
             forwards_exec,
+            retainer_exec,
             grpc_clients,
             message_type,
             node_names: Arc::new(node_names),
@@ -856,26 +859,36 @@ impl Shared for ClusterShared {
             let mut all_retains = retain_mgr.get(topic_filter).await?;
 
             if !self.grpc_clients.is_empty() {
-                let replys = MessageBroadcaster::new(
-                    self.grpc_clients.clone(),
-                    self.message_type,
-                    Message::GetRetains(topic_filter.clone()),
-                    Some(self.rw_timeout),
-                )
-                .join_all_with_async(move |reply| async move {
-                    match reply {
-                        Ok(MessageReply::GetRetains(retains)) => Ok(retains),
-                        Ok(other) => {
-                            log::warn!("unexpected reply: {other:?}");
-                            Ok(vec![])
+                let grpc_clients = self.grpc_clients.clone();
+                let message_type = self.message_type;
+                let rw_timeout = self.rw_timeout;
+                let topic_filter = topic_filter.clone();
+                let replys: Vec<(NodeId, Result<Vec<(TopicName, Retain)>>)> = async move {
+                    MessageBroadcaster::new(
+                        grpc_clients,
+                        message_type,
+                        Message::GetRetains(topic_filter),
+                        Some(rw_timeout),
+                    )
+                    .join_all_with_async(move |reply| async move {
+                        match reply {
+                            Ok(MessageReply::GetRetains(retains)) => Ok(retains),
+                            Ok(other) => {
+                                log::warn!("unexpected reply: {other:?}");
+                                Ok(vec![])
+                            }
+                            Err(e) => {
+                                log::warn!("Message::GetRetains failed, {e:?}");
+                                Ok(vec![])
+                            }
                         }
-                        Err(e) => {
-                            log::warn!("Message::GetRetains failed, {e:?}");
-                            Ok(vec![])
-                        }
-                    }
-                })
-                .await;
+                    })
+                    .await
+                }
+                .spawn(&self.retainer_exec)
+                .result()
+                .await
+                .map_err(|_| anyhow!("ClusterShared::retain_load_with task execution failure"))?;
 
                 for (node_id, result) in replys {
                     match result {
@@ -913,8 +926,8 @@ impl Shared for ClusterShared {
                         msg.clone(),
                         Some(self.rw_timeout),
                     );
-                    if let Err(e) = sender.notify().await {
-                        log::warn!("retain_set_broadcast to node {node_id} failed, {e:?}");
+                    if let Err(e) = sender.notify().spawn(&self.retainer_exec).await {
+                        log::warn!("retain_set_broadcast to node {node_id} failed, {e}");
                     }
                 }
             }
@@ -932,8 +945,8 @@ impl Shared for ClusterShared {
                         msg.clone(),
                         Some(self.rw_timeout),
                     );
-                    if let Err(e) = sender.notify().await {
-                        log::warn!("retain_set_broadcast(topic) to node {node_id} failed, {e:?}");
+                    if let Err(e) = sender.notify().spawn(&self.retainer_exec).await {
+                        log::warn!("retain_set_broadcast(topic) to node {node_id} failed, {e}");
                     }
                 }
             }


### PR DESCRIPTION
**Problem**
Retain load operations and retain set broadcasts were running on the general `forwards_exec` queue or executing synchronously, potentially blocking higher-priority cluster operations.

**Solution**
- Add dedicated `retainer_exec` task execution queue for retain-related async work
- Spawn `retain_load_with` remote fetch on `retainer_exec`
- Spawn `retain_set_broadcast` notify calls on `retainer_exec`
- Improves isolation between retain and forward workloads

**Cleanup**
- Move `rmqtt-http-api` plugin metadata entry to maintain alphabetical order
- Fix error logging to use `{e}` instead of `{e:?}` for consistency

**Benefits**
- Better workload isolation
- Prevents retain operations from blocking forwards
- More consistent error logging