### PR TITLE
feat(grpc): add circuit breaker for gRPC client operations

### DIFF
--- a/examples/cluster-broadcast/1/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-broadcast/1/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-broadcast/2/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-broadcast/2/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-broadcast/3/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-broadcast/3/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-3/1/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-3/1/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-cluster-raft.toml
@@ -54,3 +54,9 @@ raft.priority = 0
 
 
 
+
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-3/2/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-3/2/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-cluster-raft.toml
@@ -51,3 +51,9 @@ raft.read_only_option = "Safe"
 raft.skip_bcast_commit = false
 raft.batch_append = false
 raft.priority = 0
+
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-3/3/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-3/3/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-cluster-raft.toml
@@ -52,3 +52,9 @@ raft.skip_bcast_commit = false
 raft.batch_append = false
 raft.priority = 0
 
+
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/1/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/1/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-cluster-raft.toml
@@ -58,3 +58,9 @@ raft.priority = 0
 
 
 
+
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/2/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/2/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-cluster-raft.toml
@@ -49,3 +49,8 @@ raft.read_only_option = "Safe"
 raft.skip_bcast_commit = false
 raft.batch_append = false
 raft.priority = 0
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/3/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/3/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-cluster-raft.toml
@@ -50,3 +50,9 @@ raft.skip_bcast_commit = false
 raft.batch_append = false
 raft.priority = 0
 
+
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/4/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/4/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-cluster-raft.toml
@@ -50,3 +50,9 @@ raft.skip_bcast_commit = false
 raft.batch_append = false
 raft.priority = 0
 
+
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/5/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-cluster-broadcast.toml
@@ -6,3 +6,8 @@
 message_type = 98
 #Node GRPC service address list
 node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/examples/cluster-raft-5/5/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-cluster-raft.toml
@@ -50,3 +50,9 @@ raft.skip_bcast_commit = false
 raft.batch_append = false
 raft.priority = 0
 
+
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/rmqtt-plugins/rmqtt-cluster-broadcast.toml
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast.toml
@@ -14,6 +14,11 @@ node_grpc_batch_size = 128
 node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
 node_grpc_client_timeout = "15s"
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3
 
 ##Task execution queue workers
 task_exec_queue_workers = 500

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/config.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/config.rs
@@ -41,6 +41,28 @@ pub struct PluginConfig {
     //#Task execution queue max capacity
     #[serde(default = "PluginConfig::task_exec_queue_max_default")]
     pub task_exec_queue_max: usize,
+
+    // ─── gRPC circuit breaker ──────────────────────────────────────────────
+    /// Enable circuit breaker for gRPC client. When enabled and the
+    /// circuit is OPEN, all gRPC requests fast-fail without sending.
+    #[serde(default = "PluginConfig::node_grpc_circuit_breaker_enabled_default")]
+    pub node_grpc_circuit_breaker_enabled: bool,
+
+    /// Consecutive gRPC failures before tripping the circuit to OPEN.
+    #[serde(default = "PluginConfig::node_grpc_circuit_failure_threshold_default")]
+    pub node_grpc_circuit_failure_threshold: usize,
+
+    /// Duration in OPEN state before transitioning to HALF_OPEN (probe).
+    /// Example: "15s", "1m".
+    #[serde(
+        default = "PluginConfig::node_grpc_circuit_reset_timeout_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub node_grpc_circuit_reset_timeout: Duration,
+
+    /// Consecutive probe successes in HALF_OPEN before closing the circuit.
+    #[serde(default = "PluginConfig::node_grpc_circuit_half_open_success_threshold_default")]
+    pub node_grpc_circuit_half_open_success_threshold: usize,
 }
 
 impl PluginConfig {
@@ -65,6 +87,22 @@ impl PluginConfig {
 
     fn task_exec_queue_max_default() -> usize {
         100_000
+    }
+
+    fn node_grpc_circuit_breaker_enabled_default() -> bool {
+        true
+    }
+
+    fn node_grpc_circuit_failure_threshold_default() -> usize {
+        10
+    }
+
+    fn node_grpc_circuit_reset_timeout_default() -> Duration {
+        Duration::from_secs(15)
+    }
+
+    fn node_grpc_circuit_half_open_success_threshold_default() -> usize {
+        3
     }
 
     /// Serializes the configuration to a JSON value.

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/lib.rs
@@ -27,6 +27,7 @@ use rmqtt::{
     plugin::{PackageInfo, Plugin},
     register,
     types::{From, OfflineSession, Publish, Reason, To},
+    utils::{CircuitBreaker, CircuitBreakerConfig},
     Result,
 };
 
@@ -73,6 +74,12 @@ impl ClusterPlugin {
                 let batch_size = cfg.node_grpc_batch_size;
                 let client_concurrency_limit = cfg.node_grpc_client_concurrency_limit;
                 let client_timeout = cfg.node_grpc_client_timeout;
+                let circuit_breaker = Arc::new(CircuitBreaker::new(CircuitBreakerConfig {
+                    enabled: cfg.node_grpc_circuit_breaker_enabled,
+                    failure_threshold: cfg.node_grpc_circuit_failure_threshold,
+                    reset_timeout: cfg.node_grpc_circuit_reset_timeout,
+                    half_open_success_threshold: cfg.node_grpc_circuit_half_open_success_threshold,
+                }));
                 grpc_clients.insert(
                     node_addr.id,
                     (
@@ -83,6 +90,7 @@ impl ClusterPlugin {
                                 client_timeout,
                                 client_concurrency_limit,
                                 batch_size,
+                                circuit_breaker.clone(),
                             )
                             .await?,
                     ),
@@ -160,6 +168,7 @@ impl Plugin for ClusterPlugin {
                 "transfer_queue_len": c.transfer_queue_len(),
                 "active_tasks_count": c.active_tasks().count(),
                 "active_tasks_max": c.active_tasks().max(),
+                "circuit_breaker": c.circuit_breaker().to_json(),
             });
             nodes.insert(format!("{id}-{addr}"), stats);
         }

--- a/rmqtt-plugins/rmqtt-cluster-raft.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft.toml
@@ -17,6 +17,11 @@ node_grpc_batch_size = 128
 node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
 node_grpc_client_timeout = "10s"
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3
 
 # The list of Raft peer addresses for the nodes in the cluster.
 # Each entry contains the node ID and the corresponding IP address and port for Raft consensus communication.

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/config.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/config.rs
@@ -63,6 +63,28 @@ pub struct PluginConfig {
     #[serde(default = "PluginConfig::task_exec_queue_max_default")]
     pub task_exec_queue_max: usize,
 
+    // ─── gRPC circuit breaker ──────────────────────────────────────────────
+    /// Enable circuit breaker for gRPC client. When enabled and the
+    /// circuit is OPEN, all gRPC requests fast-fail without sending.
+    #[serde(default = "PluginConfig::node_grpc_circuit_breaker_enabled_default")]
+    pub node_grpc_circuit_breaker_enabled: bool,
+
+    /// Consecutive gRPC failures before tripping the circuit to OPEN.
+    #[serde(default = "PluginConfig::node_grpc_circuit_failure_threshold_default")]
+    pub node_grpc_circuit_failure_threshold: usize,
+
+    /// Duration in OPEN state before transitioning to HALF_OPEN (probe).
+    /// Example: "15s", "1m".
+    #[serde(
+        default = "PluginConfig::node_grpc_circuit_reset_timeout_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub node_grpc_circuit_reset_timeout: Duration,
+
+    /// Consecutive probe successes in HALF_OPEN before closing the circuit.
+    #[serde(default = "PluginConfig::node_grpc_circuit_half_open_success_threshold_default")]
+    pub node_grpc_circuit_half_open_success_threshold: usize,
+
     #[serde(default)]
     pub verify_addr: bool,
 
@@ -116,6 +138,22 @@ impl PluginConfig {
 
     fn task_exec_queue_max_default() -> usize {
         100_000
+    }
+
+    fn node_grpc_circuit_breaker_enabled_default() -> bool {
+        true
+    }
+
+    fn node_grpc_circuit_failure_threshold_default() -> usize {
+        10
+    }
+
+    fn node_grpc_circuit_reset_timeout_default() -> Duration {
+        Duration::from_secs(15)
+    }
+
+    fn node_grpc_circuit_half_open_success_threshold_default() -> usize {
+        3
     }
 
     fn raft_default() -> RaftConfig {

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
@@ -49,6 +49,7 @@ use rmqtt::{
     plugin::{PackageInfo, Plugin},
     register,
     types::{From, NodeId, Publish, Reason, To},
+    utils::{CircuitBreaker, CircuitBreakerConfig},
     Result,
 };
 use rmqtt_raft::{Mailbox, Raft};
@@ -104,6 +105,12 @@ impl ClusterPlugin {
                 let batch_size = cfg.node_grpc_batch_size;
                 let client_concurrency_limit = cfg.node_grpc_client_concurrency_limit;
                 let client_timeout = cfg.node_grpc_client_timeout;
+                let circuit_breaker = Arc::new(CircuitBreaker::new(CircuitBreakerConfig {
+                    enabled: cfg.node_grpc_circuit_breaker_enabled,
+                    failure_threshold: cfg.node_grpc_circuit_failure_threshold,
+                    reset_timeout: cfg.node_grpc_circuit_reset_timeout,
+                    half_open_success_threshold: cfg.node_grpc_circuit_half_open_success_threshold,
+                }));
                 grpc_clients.insert(
                     node_addr.id,
                     (
@@ -114,6 +121,7 @@ impl ClusterPlugin {
                                 client_timeout,
                                 client_concurrency_limit,
                                 batch_size,
+                                circuit_breaker.clone(),
                             )
                             .await?,
                     ),
@@ -444,6 +452,7 @@ impl Plugin for ClusterPlugin {
                 "transfer_queue_len": c.transfer_queue_len(),
                 "active_tasks_count": c.active_tasks().count(),
                 "active_tasks_max": c.active_tasks().max(),
+                "circuit_breaker": c.circuit_breaker().to_json(),
             });
             nodes.insert(*node_id, stats);
         }

--- a/rmqtt-utils/src/circuit_breaker.rs
+++ b/rmqtt-utils/src/circuit_breaker.rs
@@ -128,6 +128,11 @@ pub struct CircuitBreaker {
     failure_count: AtomicUsize,
     opened_at: AtomicI64,
     success_count: AtomicUsize,
+    /// Permits available for HALF_OPEN probe requests.
+    /// Initialised to `half_open_success_threshold` when transitioning OPEN→HALF_OPEN,
+    /// and decremented atomically for each probe request. When zero, the circuit is
+    /// blocked until the probe phase ends (success → CLOSED, failure → OPEN).
+    half_open_permits: AtomicUsize,
     config: CircuitBreakerConfig,
 }
 
@@ -137,6 +142,7 @@ impl fmt::Debug for CircuitBreaker {
             .field("state", &self.state())
             .field("failure_count", &self.failure_count.load(Ordering::Relaxed))
             .field("success_count", &self.success_count.load(Ordering::Relaxed))
+            .field("half_open_permits", &self.half_open_permits.load(Ordering::Relaxed))
             .field("config", &self.config)
             .finish()
     }
@@ -151,6 +157,7 @@ impl CircuitBreaker {
             failure_count: AtomicUsize::new(0),
             opened_at: AtomicI64::new(0),
             success_count: AtomicUsize::new(0),
+            half_open_permits: AtomicUsize::new(0),
             config,
         }
     }
@@ -160,8 +167,11 @@ impl CircuitBreaker {
     ///
     /// Side effects (atomic transitions):
     /// - OPEN → HALF_OPEN after `reset_timeout` has elapsed (at most one thread
-    ///   will perform the transition; others still see OPEN and are blocked).
-    /// - CLOSED, HALF_OPEN → no transition.
+    ///   performs the transition via `compare_exchange`; the transitioning thread
+    ///   is implicitly granted one permit).
+    /// - HALF_OPEN → may decrement `half_open_permits`; when permits are exhausted,
+    ///   subsequent callers are blocked until the probe phase resolves.
+    /// - CLOSED → no transition.
     #[inline]
     pub fn is_blocked(&self) -> bool {
         if !self.config.enabled {
@@ -172,30 +182,56 @@ impl CircuitBreaker {
 
         match state {
             CLOSED => false,
-            HALF_OPEN => false,
+            HALF_OPEN => self.try_acquire_permit(),
             OPEN => {
                 // Check whether it is time to attempt a probe.
                 let elapsed_ms = (crate::timestamp_millis() - self.opened_at.load(Ordering::Relaxed)) as u64;
                 let reset_ms = self.config.reset_timeout.as_millis() as u64;
 
-                if elapsed_ms >= reset_ms {
-                    // Reset success counter before entering HALF_OPEN.
-                    self.success_count.store(0, Ordering::Release);
-                    self.state.store(HALF_OPEN, Ordering::Release);
-                    false
-                } else {
-                    true
+                if elapsed_ms < reset_ms {
+                    return true;
+                }
+
+                // CAS transition from OPEN → HALF_OPEN.
+                // Only one thread wins; the winner initialises permits to
+                // (threshold - 1) since it consumes one permit itself.
+                match self.state.compare_exchange(OPEN, HALF_OPEN, Ordering::SeqCst, Ordering::SeqCst) {
+                    Ok(_) => {
+                        self.success_count.store(0, Ordering::Release);
+                        self.half_open_permits.store(
+                            self.config.half_open_success_threshold.saturating_sub(1),
+                            Ordering::Release,
+                        );
+                        false
+                    }
+                    Err(HALF_OPEN) => self.try_acquire_permit(),
+                    Err(other) => {
+                        log::warn!("circuit breaker: CAS OPEN→HALF_OPEN unexpected state {}", other);
+                        false
+                    }
                 }
             }
             _ => false,
         }
     }
 
+    /// Try to acquire one permit from the HALF_OPEN permit pool.
+    ///
+    /// Returns `false` (not blocked) if a permit was successfully claimed,
+    /// `true` (blocked) if the permit pool is exhausted.
+    #[inline]
+    fn try_acquire_permit(&self) -> bool {
+        self.half_open_permits
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |p| if p > 0 { Some(p - 1) } else { None })
+            .is_err()
+    }
+
     /// Record a successful call.
     ///
     /// - **CLOSED**: reset the `failure_count` to 0.
     /// - **HALF_OPEN**: increment success count; if it reaches
-    ///   `half_open_success_threshold`, transition to CLOSED and reset all counters.
+    ///   `half_open_success_threshold`, transition to CLOSED, reset all counters
+    ///   and clear the permit pool.
     /// - **OPEN**: no-op.
     #[inline]
     pub fn record_success(&self) {
@@ -211,6 +247,7 @@ impl CircuitBreaker {
                     self.state.store(CLOSED, Ordering::Release);
                     self.failure_count.store(0, Ordering::Release);
                     self.success_count.store(0, Ordering::Release);
+                    self.half_open_permits.store(0, Ordering::Release);
                     log::info!("circuit breaker: CLOSED (recovered)");
                 }
             }
@@ -248,6 +285,7 @@ impl CircuitBreaker {
             HALF_OPEN => {
                 self.state.store(OPEN, Ordering::Release);
                 self.opened_at.store(timestamp_millis(), Ordering::Release);
+                self.half_open_permits.store(0, Ordering::Release);
                 log::warn!("circuit breaker: OPEN (half-open probe failed)");
             }
             OPEN => {
@@ -287,6 +325,7 @@ impl CircuitBreaker {
         self.failure_count.store(0, Ordering::Release);
         self.success_count.store(0, Ordering::Release);
         self.opened_at.store(0, Ordering::Release);
+        self.half_open_permits.store(0, Ordering::Release);
         log::info!("circuit breaker: CLOSED (manual reset)");
     }
 
@@ -294,6 +333,18 @@ impl CircuitBreaker {
     #[inline]
     pub fn config(&self) -> &CircuitBreakerConfig {
         &self.config
+    }
+
+    /// Serialize circuit breaker state to JSON for observability.
+    #[inline]
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "enabled": self.config.enabled,
+            "state": format!("{:?}", self.state()),
+            "failure_count": self.failure_count(),
+            "success_count": self.success_count(),
+            "half_open_permits": self.half_open_permits.load(Ordering::Relaxed),
+        })
     }
 }
 
@@ -437,5 +488,85 @@ mod tests {
         cb.record_failure();
         cb.record_failure();
         assert_eq!(cb.state(), CircuitState::Open);
+    }
+
+    #[test]
+    fn test_half_open_concurrency_limited() {
+        // Verifies that at most half_open_success_threshold probe requests
+        // are allowed through concurrently in HALF_OPEN state.
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 1,
+            reset_timeout: Duration::from_millis(1),
+            half_open_success_threshold: 3,
+        });
+
+        // Trip → wait → HALF_OPEN
+        cb.record_failure();
+        std::thread::sleep(Duration::from_millis(5));
+
+        // First call: CAS transitions to HALF_OPEN, consumes 1 permit → allowed
+        assert!(!cb.is_blocked());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        // Next 2 calls should be allowed (permits = 3 - 1 = 2 remaining)
+        assert!(!cb.is_blocked(), "2nd probe should be allowed");
+        assert!(!cb.is_blocked(), "3rd probe should be allowed");
+
+        // Now permits should be exhausted → 4th call blocked
+        assert!(cb.is_blocked(), "4th probe should be blocked (no permits)");
+        assert!(cb.is_blocked(), "5th probe should remain blocked");
+    }
+
+    #[test]
+    fn test_half_open_permits_reset_on_success_close() {
+        // After all permitted probes succeed and circuit closes,
+        // permits are cleared and next is_blocked calls are not blocked.
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 1,
+            reset_timeout: Duration::from_millis(1),
+            half_open_success_threshold: 2,
+        });
+
+        // Trip → wait → HALF_OPEN
+        cb.record_failure();
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(!cb.is_blocked(), "first probe allowed");
+        assert!(!cb.is_blocked(), "second probe allowed");
+        assert!(cb.is_blocked(), "third probe blocked (permits exhausted)");
+
+        // 2 successes → CLOSED
+        cb.record_success(); // c=1, still HALF_OPEN
+        cb.record_success(); // c=2 → CLOSED
+        assert_eq!(cb.state(), CircuitState::Closed);
+
+        // Back to CLOSED - not blocked
+        assert!(!cb.is_blocked());
+    }
+
+    #[test]
+    fn test_race_reset_during_open_to_half_open() {
+        // Verify that a concurrent reset() during the OPEN→HALF_OPEN transition
+        // does NOT trigger unreachable!() / panic.
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 1,
+            reset_timeout: Duration::from_millis(1),
+            half_open_success_threshold: 2,
+        });
+
+        // Trip to OPEN
+        cb.record_failure();
+        std::thread::sleep(Duration::from_millis(5));
+
+        // Simulate: someone calls reset() right before is_blocked()
+        // checks the CAS. The CAS sees CLOSED (not OPEN), and should
+        // log a warning + return false instead of panicking.
+        cb.reset();
+
+        // is_blocked() should not panic - it should just return false
+        // since state is now CLOSED.
+        assert!(!cb.is_blocked(), "after reset should not be blocked");
     }
 }

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -75,7 +75,7 @@ use crate::types::{
     NodeId, OfflineSession, Publish, Retain, Route, SessionStatus, SharedGroup, SubRelations,
     SubRelationsMap, SubsSearchParams, SubsSearchResult, TopicFilter, TopicName,
 };
-use crate::utils::Counter;
+use crate::utils::{CircuitBreaker, Counter};
 use crate::Result;
 
 /// Internal type alias for async join_all_with handler futures.
@@ -195,6 +195,7 @@ pub struct GrpcClient {
     mailbox: Mailbox,
     duplex_mailbox: DuplexMailbox,
     active_tasks: Arc<Counter>,
+    circuit_breaker: Arc<CircuitBreaker>,
 }
 
 impl GrpcClient {
@@ -204,6 +205,7 @@ impl GrpcClient {
         server_addr: &str,
         client_timeout: Duration,
         client_concurrency_limit: usize,
+        circuit_breaker: Arc<CircuitBreaker>,
     ) -> Result<Self> {
         log::info!(
             "GrpcClient::new server_addr: {server_addr}, client_concurrency_limit: {client_concurrency_limit}"
@@ -216,7 +218,7 @@ impl GrpcClient {
         let duplex_mailbox = c.duplex_transfer_start(100_000).await;
         let mailbox = c.transfer_start(100_000).await;
         let active_tasks = Arc::new(Counter::new());
-        Ok(Self { mailbox, duplex_mailbox, active_tasks })
+        Ok(Self { mailbox, duplex_mailbox, active_tasks, circuit_breaker })
     }
 
     #[inline]
@@ -227,6 +229,11 @@ impl GrpcClient {
     #[inline]
     pub fn transfer_queue_len(&self) -> usize {
         self.mailbox.req_queue_len()
+    }
+
+    #[inline]
+    pub fn circuit_breaker(&self) -> &CircuitBreaker {
+        &self.circuit_breaker
     }
 
     #[inline]
@@ -267,30 +274,33 @@ impl GrpcClient {
         timeout: Option<Duration>,
         quick: bool,
     ) -> Result<MessageReply> {
-        if quick {
-            let req = msg.encode(typ)?;
-            let reply = if let Some(timeout) = timeout {
-                tokio::time::timeout(timeout, self.duplex_mailbox.quick_send(req)).await??
-            } else {
-                self.duplex_mailbox.quick_send(req).await?
-            };
-            return MessageReply::decode(&reply);
+        if self.circuit_breaker.is_blocked() {
+            return Err(anyhow::anyhow!("gRPC circuit breaker is OPEN, skipping send_message"));
         }
 
-        // Fast-fail if the duplex request queue is full (peer node may be down).
-        // if self.duplex_mailbox.req_queue_is_full() {
-        //     return Err(anyhow::anyhow!(
-        //         "send_message failed: duplex request queue is full (peer node may be down)"
-        //     ));
-        // }
+        let req = msg.encode(typ)?; // encoding error → fast exit, NOT a CB failure
 
-        let req = msg.encode(typ)?;
-        let reply = if let Some(timeout) = timeout {
-            tokio::time::timeout(timeout, self.duplex_mailbox.send(req)).await??
-        } else {
-            self.duplex_mailbox.send(req).await?
-        };
-        MessageReply::decode(&reply)
+        let result = async {
+            let reply = if quick {
+                if let Some(timeout) = timeout {
+                    tokio::time::timeout(timeout, self.duplex_mailbox.quick_send(req)).await??
+                } else {
+                    self.duplex_mailbox.quick_send(req).await?
+                }
+            } else if let Some(timeout) = timeout {
+                tokio::time::timeout(timeout, self.duplex_mailbox.send(req)).await??
+            } else {
+                self.duplex_mailbox.send(req).await?
+            };
+            MessageReply::decode(&reply) // decode failure → CB failure (bad network response)
+        }
+        .await;
+
+        match &result {
+            Ok(_) => self.circuit_breaker.record_success(),
+            Err(_) => self.circuit_breaker.record_failure(),
+        }
+        result
     }
 
     #[inline]
@@ -326,31 +336,33 @@ impl GrpcClient {
         timeout: Option<Duration>,
         quick: bool,
     ) -> Result<()> {
-        if quick {
-            let req = msg.encode(typ)?;
-            if let Some(timeout) = timeout {
-                tokio::time::timeout(timeout, self.mailbox.quick_send(req)).await??;
-            } else {
-                self.mailbox.quick_send(req).await?;
-            };
-            return Ok(());
+        if self.circuit_breaker.is_blocked() {
+            return Err(anyhow::anyhow!("gRPC circuit breaker is OPEN, skipping notify"));
         }
 
-        // Fast-fail if the transfer queue is full (e.g. the peer node is down).
-        // mailbox.send().await blocks indefinitely when the queue is full because
-        // poll_ready returns Pending until the consumer drains it — and a dead node
-        // never will.  Returning an error immediately prevents worker starvation.
-        // if self.mailbox.req_queue_is_full() {
-        //     return Err(anyhow::anyhow!("notify failed: transfer queue is full (peer node may be down)"));
-        // }
+        let req = msg.encode(typ)?; // encoding error → fast exit, NOT a CB failure
 
-        let req = msg.encode(typ)?;
-        if let Some(timeout) = timeout {
-            tokio::time::timeout(timeout, self.mailbox.send(req)).await??;
-        } else {
-            self.mailbox.send(req).await?;
-        };
-        Ok(())
+        let result = async {
+            if quick {
+                if let Some(timeout) = timeout {
+                    tokio::time::timeout(timeout, self.mailbox.quick_send(req)).await??;
+                } else {
+                    self.mailbox.quick_send(req).await?;
+                };
+            } else if let Some(timeout) = timeout {
+                tokio::time::timeout(timeout, self.mailbox.send(req)).await??;
+            } else {
+                self.mailbox.send(req).await?;
+            }
+            Ok(())
+        }
+        .await;
+
+        match &result {
+            Ok(_) => self.circuit_breaker.record_success(),
+            Err(_) => self.circuit_breaker.record_failure(),
+        }
+        result
     }
 }
 

--- a/rmqtt/src/node.rs
+++ b/rmqtt/src/node.rs
@@ -32,6 +32,8 @@ use crate::context::ServerContext;
 use crate::grpc::{GrpcClient, GrpcServer};
 use crate::types::{NodeId, TimestampMillis};
 use crate::utils::timestamp_millis;
+#[cfg(feature = "grpc")]
+use crate::utils::CircuitBreaker;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -103,8 +105,9 @@ impl Node {
         connect_timeout: Duration,
         client_concurrency_limit: usize,
         _batch_size: usize,
+        circuit_breaker: std::sync::Arc<CircuitBreaker>,
     ) -> crate::Result<GrpcClient> {
-        GrpcClient::new(remote_addr, connect_timeout, client_concurrency_limit).await
+        GrpcClient::new(remote_addr, connect_timeout, client_concurrency_limit, circuit_breaker).await
     }
 
     #[cfg(feature = "grpc")]


### PR DESCRIPTION
**Problem**
When a cluster peer node becomes unresponsive, gRPC requests can block or time out after a fixed timeout, causing worker threads to stall and degrading broker performance.

**Solution**
Add a circuit breaker to the gRPC client, similar to the storage circuit breaker. When consecutive gRPC failures exceed the configured threshold, the circuit trips to OPEN and all requests fast-fail immediately without attempting to send.

**Key Changes**

Circuit Breaker Enhancements (rmqtt-utils):
- Add `half_open_permits` atomic counter for concurrent probe limiting
- Implement `try_acquire_permit()` for HALF_OPEN state
- Only a limited number of probe requests are allowed through concurrently
- Add `to_json()` for observability (state, failure/success counts, permits)

gRPC Client:
- Add `circuit_breaker: Arc<CircuitBreaker>` field to `GrpcClient`
- Check `is_blocked()` before sending any request
- Record success/failure based on request result
- Encode errors are fast-exit (not counted as CB failures)

Configuration:
- Add circuit breaker settings to cluster-broadcast and cluster-raft configs
  - `node_grpc_circuit_breaker_enabled` (default: true)
  - `node_grpc_circuit_failure_threshold` (default: 10)
  - `node_grpc_circuit_reset_timeout` (default: "15s")
  - `node_grpc_circuit_half_open_success_threshold` (default: 3)
- Update `GrpcClient::new()` and `Node::grpc_client()` to accept circuit_breaker

Observability:
- Add circuit breaker state to plugin `attrs` JSON output
- Includes state, failure_count, success_count, half_open_permits

**Benefits**
- Fast-fail when cluster peer is unresponsive
- Prevents worker starvation from gRPC timeouts
- Configurable thresholds per plugin
- Full observability via plugin attributes
- Consistent pattern with storage circuit breaker