### PR TITLE
feat(storage): integrate unified circuit breaker across message/retainer/session plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,9 +5306,9 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-storage"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550399d8a60b45b6c4e7eb81363e417d6b66baa876a89c41b3813e10ca05619f"
+checksum = "510886f2ecb83d282eade327d3c73d5c2c0ac64c45e8ee2022101a4f9f4a7ed1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5324,6 +5324,8 @@ dependencies = [
  "serde_json",
  "sled",
  "tokio",
+ "tower",
+ "tower-resilience-circuitbreaker",
 ]
 
 [[package]]
@@ -6971,6 +6973,29 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-resilience-circuitbreaker"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c89ebacecf47734e7a562f615997bd54e1867ca26fb596f309d63ca5f6f42a"
+dependencies = [
+ "futures",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tower-resilience-core",
+]
+
+[[package]]
+name = "tower-resilience-core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d51ef3353f58a987373162f9f68d6c9e555d1e09a215c224bf4e1f9e135138"
+dependencies = [
+ "thiserror 2.0.18",
+ "tokio",
+]
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ rmqtt-net = "0.3.5"
 rmqtt-conf = "0.3.5"
 rmqtt-macros = "0.1.2"
 rmqtt-utils = "0.1.6"
-rmqtt-storage = { version = "0.9",  default-features = false }
+rmqtt-storage = { version = "0.10.2",  default-features = false }
 
 rmqtt-plugins = "0.22.0"
 rmqtt-acl = "0.22.0"

--- a/rmqtt-plugins/rmqtt-message-storage.toml
+++ b/rmqtt-plugins/rmqtt-message-storage.toml
@@ -30,20 +30,42 @@ cleanup_count = 5000
 timeout = "5s"
 
 ##─── Circuit breaker ─────────────────────────────────────────────────────────
-##Enable circuit breaker. When Redis fails consecutively beyond the threshold,
-##the broker stops waiting for Redis and returns immediately.
-##Default: true
-#circuit_breaker_enabled = true
-
-##Consecutive storage failures before tripping the circuit to OPEN (fast-fail).
+##Optional circuit-breaker tuning.
+##When this section is absent (or commented out), the built-in
+##CircuitBreakerConfig::default() is used verbatim.
+##Only the fields you explicitly set override the defaults.
+##
+##Failure rate threshold (0.0 – 1.0). Default: 0.25
+##When the sliding-window failure rate exceeds this value, the
+##circuit trips to OPEN and all storage operations fast-fail.
+#circuit_breaker.failure_rate_threshold = 0.25
+##
+##Sliding window type: "CountBased" or "TimeBased". Default: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+##
+##Sliding window size (number of calls). Default: 20
+#circuit_breaker.sliding_window_size = 20
+##
+##Sliding window duration for TimeBased mode.
+##Only used when sliding_window_type is "TimeBased".
+##Calls older than this duration are excluded from the failure rate.
+##Default: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+##
+##Minimum number of calls before the breaker can trip.
+##Prevents premature tripping during low-traffic periods.
 ##Default: 10
-#circuit_failure_threshold = 10
-
-##Duration to wait in OPEN state before allowing a probe (HALF_OPEN).
-##Default: "15s"
-#circuit_reset_timeout = "15s"
-
-##Consecutive probe successes needed to close the circuit.
-##Higher values avoid premature recovery on flaky connections.
-##Default: 3
-#circuit_half_open_success_threshold = 3
+#circuit_breaker.minimum_number_of_calls = 10
+##
+##Duration in OPEN state before transitioning to HALF_OPEN (probe).
+##Default: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+##
+##Slow call duration threshold. Default: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+##
+##Slow call rate threshold (0.0 – 1.0). 1.0 = disabled. Default: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+##
+##Per-operation timeout. Set to "0s" to disable. Default: "8s"
+#circuit_breaker.operation_timeout = "8s"

--- a/rmqtt-plugins/rmqtt-message-storage/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-message-storage/Cargo.toml
@@ -14,8 +14,9 @@ all-features = true
 [features]
 default = []
 ram = []
-redis = ["rmqtt-storage/redis"]
+redis = ["rmqtt-storage/redis", "circuit-breaker"]
 redis-cluster = ["redis", "rmqtt-storage/redis-cluster"]
+circuit-breaker = ["rmqtt-storage/circuit-breaker"]
 
 [dependencies]
 rmqtt = { workspace = true, features = ["plugin", "msgstore", "retain"] }

--- a/rmqtt-plugins/rmqtt-message-storage/src/config.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/config.rs
@@ -11,6 +11,8 @@ use serde::{
 use std::time::Duration;
 
 use rmqtt::utils::{deserialize_duration, Bytesize};
+#[cfg(feature = "circuit-breaker")]
+use rmqtt_storage::{CircuitBreakerConfig, CountBasedWindowConfig, TimeBasedWindowConfig, WindowConfig};
 
 /// Top-level configuration for the message storage plugin.
 #[derive(Debug, Clone, Deserialize)]
@@ -26,28 +28,12 @@ pub struct PluginConfig {
     #[serde(default = "PluginConfig::timeout_default", deserialize_with = "deserialize_duration")]
     pub timeout: Duration,
 
-    // ─── Circuit breaker ─────────────────────────────────────────────────────
-    /// Enable circuit breaker for Redis storage operations.
-    /// When enabled and the circuit is OPEN, store/mark_forwarded/get
-    /// return immediately without touching Redis.
-    #[serde(default = "PluginConfig::circuit_breaker_enabled_default")]
-    pub circuit_breaker_enabled: bool,
-
-    /// Consecutive failures before tripping to OPEN.
-    #[serde(default = "PluginConfig::circuit_failure_threshold_default")]
-    pub circuit_failure_threshold: usize,
-
-    /// Duration in OPEN state before transitioning to HALF_OPEN (probe).
-    /// Example: "30s", "1m".
-    #[serde(
-        default = "PluginConfig::circuit_reset_timeout_default",
-        deserialize_with = "deserialize_duration"
-    )]
-    pub circuit_reset_timeout: Duration,
-
-    /// Consecutive probe successes in HALF_OPEN before closing the circuit.
-    #[serde(default = "PluginConfig::circuit_half_open_success_threshold_default")]
-    pub circuit_half_open_success_threshold: usize,
+    /// Optional circuit-breaker tuning.
+    /// When `None` (default), the built-in `CircuitBreakerConfig::default()`
+    /// is used verbatim. When `Some(...)`, the given fields override the
+    /// corresponding defaults.
+    #[serde(default)]
+    pub circuit_breaker: CircuitBreakerPluginConfig,
 }
 
 impl PluginConfig {
@@ -64,22 +50,6 @@ impl PluginConfig {
 
     fn timeout_default() -> Duration {
         Duration::from_millis(5000)
-    }
-
-    fn circuit_breaker_enabled_default() -> bool {
-        true
-    }
-
-    fn circuit_failure_threshold_default() -> usize {
-        10
-    }
-
-    fn circuit_reset_timeout_default() -> Duration {
-        Duration::from_secs(15)
-    }
-
-    fn circuit_half_open_success_threshold_default() -> usize {
-        3
     }
 
     #[inline]
@@ -133,11 +103,40 @@ impl PluginConfig {
             "storage": storage,
             "cleanup_count": self.cleanup_count,
             "timeout": format!("{:?}", self.timeout),
-            "circuit_breaker_enabled": self.circuit_breaker_enabled,
-            "circuit_failure_threshold": self.circuit_failure_threshold,
-            "circuit_reset_timeout": format!("{:?}", self.circuit_reset_timeout),
-            "circuit_half_open_success_threshold": self.circuit_half_open_success_threshold,
+            "circuit_breaker": serde_json::json!(self.circuit_breaker),
         })
+    }
+
+    #[cfg(feature = "circuit-breaker")]
+    #[inline]
+    pub(crate) fn to_cb_config(&self) -> CircuitBreakerConfig {
+        let cb = &self.circuit_breaker;
+        let window = match cb.sliding_window_type.as_str() {
+            "TimeBased" | "time_based" | "time" => {
+                let dur = if cb.sliding_window_duration.is_zero() {
+                    TimeBasedWindowConfig::default().sliding_window_duration
+                } else {
+                    cb.sliding_window_duration
+                };
+                WindowConfig::TimeBased(TimeBasedWindowConfig {
+                    sliding_window_duration: dur,
+                    sliding_window_size: cb.sliding_window_size,
+                })
+            }
+            _ => WindowConfig::CountBased(CountBasedWindowConfig {
+                sliding_window_size: cb.sliding_window_size,
+            }),
+        };
+        CircuitBreakerConfig {
+            failure_rate_threshold: cb.failure_rate_threshold,
+            window,
+            minimum_number_of_calls: cb.minimum_number_of_calls,
+            wait_duration_in_open: cb.wait_duration_in_open,
+            slow_call_duration_threshold: cb.slow_call_duration_threshold,
+            slow_call_rate_threshold: cb.slow_call_rate_threshold,
+            operation_timeout: if cb.operation_timeout.is_zero() { None } else { Some(cb.operation_timeout) },
+            ..CircuitBreakerConfig::default()
+        }
     }
 }
 
@@ -179,5 +178,111 @@ impl Default for RamConfig {
 impl RamConfig {
     fn queue_max_default() -> usize {
         300_000
+    }
+}
+
+/// User-facing circuit-breaker settings.
+///
+/// Each field carries its own `serde(default = ...)` so that users can
+/// specify only the values they wish to override inside `[circuit_breaker]`.
+///
+/// Fields that are not set in TOML fall back to the values below, which
+/// match `CircuitBreakerConfig::default()` where practical.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CircuitBreakerPluginConfig {
+    /// Failure rate threshold (0.0 – 1.0). Default: 0.25
+    #[serde(default = "CircuitBreakerPluginConfig::failure_rate_threshold_default")]
+    pub failure_rate_threshold: f64,
+
+    /// Sliding window type: "CountBased" or "TimeBased". Default: "TimeBased"
+    #[serde(default = "CircuitBreakerPluginConfig::sliding_window_type_default")]
+    pub sliding_window_type: String,
+
+    /// Sliding window size (number of calls). Default: 20
+    #[serde(default = "CircuitBreakerPluginConfig::sliding_window_size_default")]
+    pub sliding_window_size: usize,
+
+    /// Sliding window duration for TimeBased mode. Only used when sliding_window_type
+    /// is "TimeBased". Calls older than this duration are excluded from failure rate
+    /// calculation. Default: "45s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::sliding_window_duration_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub sliding_window_duration: Duration,
+
+    /// Minimum calls before the breaker can trip. Default: 10
+    #[serde(default = "CircuitBreakerPluginConfig::minimum_number_of_calls_default")]
+    pub minimum_number_of_calls: usize,
+
+    /// Duration in OPEN state before transitioning to HALF_OPEN. Default: "30s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::wait_duration_in_open_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub wait_duration_in_open: Duration,
+
+    /// Slow call duration threshold. Default: "2s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::slow_call_duration_threshold_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub slow_call_duration_threshold: Duration,
+
+    /// Slow call rate threshold (0.0 – 1.0). 1.0 = disabled. Default: 1.0
+    #[serde(default = "CircuitBreakerPluginConfig::slow_call_rate_threshold_default")]
+    pub slow_call_rate_threshold: f64,
+
+    /// Per-operation timeout. Set to "0s" to disable. Default: "0s" (disabled)
+    #[serde(
+        default = "CircuitBreakerPluginConfig::operation_timeout_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub operation_timeout: Duration,
+}
+
+impl Default for CircuitBreakerPluginConfig {
+    fn default() -> Self {
+        Self {
+            failure_rate_threshold: Self::failure_rate_threshold_default(),
+            sliding_window_type: Self::sliding_window_type_default(),
+            sliding_window_size: Self::sliding_window_size_default(),
+            sliding_window_duration: Self::sliding_window_duration_default(),
+            minimum_number_of_calls: Self::minimum_number_of_calls_default(),
+            wait_duration_in_open: Self::wait_duration_in_open_default(),
+            slow_call_duration_threshold: Self::slow_call_duration_threshold_default(),
+            slow_call_rate_threshold: Self::slow_call_rate_threshold_default(),
+            operation_timeout: Self::operation_timeout_default(),
+        }
+    }
+}
+
+impl CircuitBreakerPluginConfig {
+    fn failure_rate_threshold_default() -> f64 {
+        0.25
+    }
+    fn sliding_window_type_default() -> String {
+        "TimeBased".to_string()
+    }
+    fn sliding_window_size_default() -> usize {
+        20
+    }
+    fn sliding_window_duration_default() -> Duration {
+        Duration::from_secs(45)
+    }
+    fn minimum_number_of_calls_default() -> usize {
+        10
+    }
+    fn wait_duration_in_open_default() -> Duration {
+        Duration::from_secs(30)
+    }
+    fn slow_call_duration_threshold_default() -> Duration {
+        Duration::from_secs(2)
+    }
+    fn slow_call_rate_threshold_default() -> f64 {
+        1.0
+    }
+    fn operation_timeout_default() -> Duration {
+        Duration::from_secs(8)
     }
 }

--- a/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
@@ -31,6 +31,8 @@ use rmqtt::{
 
 #[cfg(any(feature = "redis", feature = "redis-cluster"))]
 use rmqtt_storage::init_db;
+#[cfg(any(feature = "redis", feature = "redis-cluster"))]
+use storage::StorageDb;
 
 use config::PluginConfig;
 #[cfg(feature = "ram")]
@@ -85,6 +87,9 @@ impl StoragePlugin {
                     log::error!("{name} init storage db error, {e}");
                     e
                 })?;
+
+                #[cfg(feature = "circuit-breaker")]
+                let storage_db = StorageDb::new(storage_db, cfg.to_cb_config());
 
                 let cfg = Arc::new(cfg);
                 let message_mgr = StorageMessageManager::new(cfg.clone(), storage_db.clone()).await?;
@@ -207,10 +212,6 @@ impl MessageMgr {
                         "topic_nodes": topic_nodes,
                         "receiveds": receiveds,
                         "cost_time":cost_time,
-                    },
-                    "circuit_breaker": {
-                        "enabled": mgr.circuit_breaker.config().enabled,
-                        "state": format!("{:?}", mgr.circuit_breaker.state()),
                     },
                 })
             }

--- a/rmqtt-plugins/rmqtt-message-storage/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/storage.rs
@@ -27,13 +27,17 @@ use rmqtt::{
         ForwardedRecipients, From, MsgID, Publish, SharedGroup, StoredMessage, TimestampMillis, Topic,
         TopicFilter,
     },
-    utils::{timestamp_millis, CircuitBreaker, CircuitBreakerConfig},
+    utils::timestamp_millis,
     Result,
 };
-use serde_json::{self, json};
 
 use rmqtt::topic::Level;
-use rmqtt_storage::{DefaultStorageDB, Map, StorageMap};
+#[cfg(feature = "circuit-breaker")]
+pub(crate) use rmqtt_storage::{CircuitBrokenDB as StorageDb, CircuitBrokenMap as StorageMap};
+#[cfg(not(feature = "circuit-breaker"))]
+pub(crate) use rmqtt_storage::{DefaultStorageDB as StorageDb, StorageMap};
+
+use rmqtt_storage::{Map, StorageDB as _};
 
 use crate::config::PluginConfig;
 
@@ -86,10 +90,7 @@ impl StorageMessageManager {
     /// a `MarkForwarded` message is guaranteed to execute **after** the
     /// corresponding `Store` message for the same `msg_id`.
     #[inline]
-    pub(crate) async fn new(
-        cfg: Arc<PluginConfig>,
-        storage_db: DefaultStorageDB,
-    ) -> Result<StorageMessageManager> {
+    pub(crate) async fn new(cfg: Arc<PluginConfig>, storage_db: StorageDb) -> Result<StorageMessageManager> {
         let id_generater = StorageMessageManagerInner::storage_new_msg_id_generater(&storage_db).await?;
         log::info!("current msg_id: {}", id_generater.load(Ordering::SeqCst));
         let messages_received_max =
@@ -98,14 +99,6 @@ impl StorageMessageManager {
 
         let msg_queue_count = Arc::new(AtomicIsize::new(0));
         let timeout = cfg.timeout;
-
-        // Build the circuit breaker from config.
-        let circuit_breaker = CircuitBreaker::new(CircuitBreakerConfig {
-            enabled: cfg.circuit_breaker_enabled,
-            failure_threshold: cfg.circuit_failure_threshold,
-            reset_timeout: cfg.circuit_reset_timeout,
-            half_open_success_threshold: cfg.circuit_half_open_success_threshold,
-        });
 
         // Build the shared inner state first, so workers can clone it.
         let inner = Arc::new(StorageMessageManagerInner {
@@ -116,7 +109,6 @@ impl StorageMessageManager {
             msg_queue_count: msg_queue_count.clone(),
             id_generater,
             timeout,
-            circuit_breaker,
         });
 
         // Spawn N worker tasks — one per routing bucket.
@@ -136,22 +128,12 @@ impl StorageMessageManager {
                 while let Some(msg) = rx.next().await {
                     inner.msg_queue_count.fetch_sub(1, Ordering::Relaxed);
 
-                    // When the circuit breaker is OPEN, skip all queued messages
-                    // without touching Redis. This prevents the channel backlog
-                    // (64×5000 = 320K messages) from blocking workers for hours
-                    // while each message waits for a Redis timeout.
-                    // is_blocked() also handles OPEN→HALF_OPEN transitions,
-                    // so when a probe is due, the next message will be processed.
-                    if inner.circuit_breaker.is_blocked() {
-                        continue;
-                    }
-
-                    match inner._process_single(msg).await {
-                        Ok(()) => inner.circuit_breaker.record_success(),
-                        Err(e) => {
-                            log::warn!("worker {} _process_single error: {:?}", i, e);
-                            inner.circuit_breaker.record_failure();
-                        }
+                    // When the backing storage is unreachable, storage operations
+                    // will fast-fail through the rmqtt-storage circuit breaker.
+                    // The worker simply logs the error and continues, preventing
+                    // the channel backlog from blocking workers indefinitely.
+                    if let Err(e) = inner._process_single(msg).await {
+                        log::warn!("worker {} _process_single error: {:?}", i, e);
                     }
                 }
 
@@ -261,7 +243,7 @@ impl Deref for StorageMessageManager {
 }
 
 pub struct StorageMessageManagerInner {
-    pub(crate) storage_db: DefaultStorageDB,
+    pub(crate) storage_db: StorageDb,
     pub(crate) topic_tree: TopicTreeType,
     topic_list: TopicListType,
 
@@ -273,9 +255,6 @@ pub struct StorageMessageManagerInner {
 
     /// Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
     timeout: Duration,
-
-    /// Circuit breaker for Redis failure detection and fast-fall degradation.
-    pub(crate) circuit_breaker: CircuitBreaker,
 }
 
 impl StorageMessageManagerInner {
@@ -299,6 +278,28 @@ impl StorageMessageManagerInner {
                 .map_err(Into::into)
         } else {
             fut.await.map_err(Into::into)
+        }
+    }
+
+    /// Execute an async operation with an optional timeout.
+    ///
+    /// Like [`with_timeout`], but accepts a future that does NOT return `Result`.
+    /// The timeout error becomes the outer `anyhow::Error`.
+    ///
+    /// * When `timeout > Duration::ZERO`, wraps the future with the given timeout,
+    ///   converting timeout errors to `anyhow::Error`.
+    /// * When `timeout == Duration::ZERO`, runs the future directly.
+    #[inline]
+    async fn with_timeout_direct<F, T>(fut: F, timeout: Duration, err_msg: &'static str) -> Result<T>
+    where
+        F: std::future::Future<Output = T>,
+    {
+        if timeout > Duration::ZERO {
+            fut.timeout(futures_time::time::Duration::from(timeout))
+                .await
+                .map_err(|_e| anyhow!("{} timeout", err_msg))
+        } else {
+            Ok(fut.await)
         }
     }
 
@@ -359,7 +360,7 @@ impl StorageMessageManagerInner {
     }
 
     #[inline]
-    async fn storage_new_msg_id_generater(storage_db: &DefaultStorageDB) -> Result<AtomicUsize> {
+    async fn storage_new_msg_id_generater(storage_db: &StorageDb) -> Result<AtomicUsize> {
         if let Some(curr_msg_id) = storage_db.get::<_, usize>("id_generater").await? {
             Ok(AtomicUsize::new(curr_msg_id))
         } else {
@@ -379,7 +380,7 @@ impl StorageMessageManagerInner {
     }
 
     #[inline]
-    async fn storage_new_messages_counter(storage_db: &DefaultStorageDB) -> Result<AtomicIsize> {
+    async fn storage_new_messages_counter(storage_db: &StorageDb) -> Result<AtomicIsize> {
         let max = storage_db.counter_get("messages_received_max").await?.unwrap_or_default();
         Ok(AtomicIsize::new(max))
     }
@@ -423,7 +424,7 @@ impl StorageMessageManagerInner {
 
                 // received messages
                 let msg_key = msg_id.to_be_bytes();
-                let msg_map = Self::with_timeout(
+                let msg_map = Self::with_timeout_direct(
                     self.storage_db.map(msg_key, Some(expiry_interval.as_millis() as TimestampMillis)),
                     timeout,
                     "storage_db.map",
@@ -456,10 +457,13 @@ impl StorageMessageManagerInner {
             }
             Msg::MarkForwarded { msg_id, recipients } => {
                 let msg_key = msg_id.to_be_bytes();
-                let msg_map =
-                    Self::with_timeout(self.storage_db.map(msg_key, None), timeout, "add_forwardeds map")
-                        .await
-                        .map_err(|e| anyhow!("add_forwardeds map error: {:?}", e))?;
+                let msg_map = Self::with_timeout_direct(
+                    self.storage_db.map(msg_key, None),
+                    timeout,
+                    "add_forwardeds map",
+                )
+                .await
+                .map_err(|e| anyhow!("add_forwardeds map error: {:?}", e))?;
 
                 let found =
                     Self::with_timeout(msg_map.contains_key(DATA), timeout, "add_forwardeds contains_key")
@@ -509,54 +513,34 @@ impl StorageMessageManagerInner {
             inner.topic_tree.read().await.matches(&topic).into_iter().map(|(_t, msg_id)| msg_id).collect();
 
         log::debug!("_get matcheds msg_ids: {matcheds:?}");
-        let storage_err_count = AtomicUsize::new(0);
-        let matcheds: Vec<_> = futures::future::join_all(matcheds.into_iter().map(|msg_id| {
-            let storage_err = &storage_err_count;
-            async move {
-                let msg_key = msg_id.to_be_bytes();
-                let msg_map = self.storage_db.map(msg_key, None).await;
-                match msg_map {
-                    Ok(mut msg_map) => {
-                        let is_forwarded =
-                            match self._is_forwarded(&mut msg_map, client_id, topic_filter, group).await {
-                                Ok(v) => v,
-                                Err(e) => {
-                                    log::warn!("_get _is_forwarded error, {e}");
-                                    storage_err.fetch_add(1, Ordering::Relaxed);
-                                    return None;
-                                }
-                            };
+        let matcheds: Vec<_> = futures::future::join_all(matcheds.into_iter().map(|msg_id| async move {
+            let msg_key = msg_id.to_be_bytes();
+            let mut msg_map = self.storage_db.map(msg_key, None).await;
+            let is_forwarded = match self._is_forwarded(&mut msg_map, client_id, topic_filter, group).await {
+                Ok(v) => v,
+                Err(e) => {
+                    log::warn!("_get _is_forwarded error, {e}");
+                    return None;
+                }
+            };
 
-                        if is_forwarded {
+            if is_forwarded {
+                None
+            } else {
+                match inner._get_message(&msg_map).await {
+                    Ok(Some(msg)) => {
+                        log::debug!("_get msg: {:?}, msg.is_expiry(): {}", msg, msg.is_expiry());
+                        if msg.is_expiry()
+                            || msg.publish.target_clientid.as_ref().is_some_and(|t_cid| t_cid != client_id)
+                        {
                             None
                         } else {
-                            match inner._get_message(&msg_map).await {
-                                Ok(Some(msg)) => {
-                                    log::debug!("_get msg: {:?}, msg.is_expiry(): {}", msg, msg.is_expiry());
-                                    if msg.is_expiry()
-                                        || msg
-                                            .publish
-                                            .target_clientid
-                                            .as_ref()
-                                            .is_some_and(|t_cid| t_cid != client_id)
-                                    {
-                                        None
-                                    } else {
-                                        Some((msg_id, msg.from, msg.publish))
-                                    }
-                                }
-                                Ok(None) => None,
-                                Err(e) => {
-                                    log::warn!("_get_message error, {e}");
-                                    storage_err.fetch_add(1, Ordering::Relaxed);
-                                    None
-                                }
-                            }
+                            Some((msg_id, msg.from, msg.publish))
                         }
                     }
+                    Ok(None) => None,
                     Err(e) => {
-                        log::warn!("_get new map error, {e}");
-                        storage_err.fetch_add(1, Ordering::Relaxed);
+                        log::warn!("_get_message error, {e}");
                         None
                     }
                 }
@@ -566,14 +550,6 @@ impl StorageMessageManagerInner {
         .into_iter()
         .flatten()
         .collect();
-
-        if storage_err_count.load(Ordering::Relaxed) > 0 {
-            self.circuit_breaker.record_failure();
-        } else if !matcheds.is_empty() {
-            // Only record success if we actually touched Redis.
-            // Zero matcheds = no map() calls = unknown Redis state.
-            self.circuit_breaker.record_success();
-        }
 
         Ok(matcheds)
     }
@@ -618,13 +594,9 @@ impl StorageMessageManagerInner {
         msg_map.get::<_, StoredMessage>(DATA).await
     }
 
-    /// Return storage backend info, with circuit breaker fast-path.
-    /// When the circuit is OPEN, skip the Redis call and return an "unavailable"
-    /// marker instead of waiting for a timeout.
+    /// Return storage backend info, including circuit breaker state (when applicable)
+    /// via `CircuitBrokenDB::info()`.
     pub(crate) async fn storage_info(&self) -> serde_json::Value {
-        if self.circuit_breaker.is_blocked() {
-            return json!({"status": "unavailable"});
-        }
         self.storage_db.info().await.unwrap_or_default()
     }
 }
@@ -645,10 +617,6 @@ impl MessageManager for StorageMessageManager {
         expiry_interval: Duration,
         recipients: Option<ForwardedRecipients>,
     ) -> Result<()> {
-        if self.circuit_breaker.is_blocked() {
-            log::debug!("circuit breaker OPEN: skip store for msg_id {:?}", msg_id);
-            return Ok(());
-        }
         let msg = Msg::Store { from, publish: p, expiry_interval, msg_id, recipients };
         self.route_msg(msg).await
     }
@@ -660,10 +628,6 @@ impl MessageManager for StorageMessageManager {
         topic_filter: &str,
         group: Option<&SharedGroup>,
     ) -> Result<Vec<(MsgID, From, Publish)>> {
-        if self.circuit_breaker.is_blocked() {
-            log::debug!("circuit breaker OPEN: skip get");
-            return Ok(vec![]);
-        }
         let now = std::time::Instant::now();
         let timeout = self.timeout;
 
@@ -686,7 +650,6 @@ impl MessageManager for StorageMessageManager {
             }
             Err(e) => {
                 log::warn!("StorageMessageManager get timeout, {e}");
-                self.circuit_breaker.record_failure();
                 vec![]
             }
         };
@@ -699,10 +662,6 @@ impl MessageManager for StorageMessageManager {
 
     #[inline]
     async fn mark_forwarded(&self, msg_id: MsgID, recipients: ForwardedRecipients) -> Result<()> {
-        if self.circuit_breaker.is_blocked() {
-            log::debug!("circuit breaker OPEN: skip mark_forwarded for msg_id {:?}", msg_id);
-            return Ok(());
-        }
         // Route to the worker responsible for this msg_id.
         // Because the worker processes messages sequentially (one batch at a time),
         // the corresponding `Store` for the same `msg_id` is guaranteed

--- a/rmqtt-plugins/rmqtt-retainer.toml
+++ b/rmqtt-plugins/rmqtt-retainer.toml
@@ -33,15 +33,40 @@ retained_message_ttl = "0m"
 batch_messages_limit = 500
 
 ##─── Circuit breaker ──────────────────────────────────────────────
-##Enable circuit breaker. When storage fails consecutively beyond the threshold,
-##all retain operations fast-fail without touching the storage backend.
-#circuit_breaker_enabled = true
-
-##Consecutive storage failures before tripping the circuit to OPEN (fast-fail).
-#circuit_failure_threshold = 10
-
+##Optional circuit-breaker tuning.
+##When this section is absent (or commented out), the built-in
+##CircuitBreakerConfig::default() is used verbatim.
+##Only the fields you explicitly set override the defaults.
+##
+##Failure rate threshold (0.0 – 1.0). Default: 0.25
+#circuit_breaker.failure_rate_threshold = 0.25
+##
+##Sliding window type: "CountBased" or "TimeBased". Default: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+##
+##Sliding window size (number of calls). Default: 20
+#circuit_breaker.sliding_window_size = 20
+##
+##Sliding window duration for TimeBased mode.
+##Only used when sliding_window_type is "TimeBased".
+##Calls older than this duration are excluded from the failure rate.
+##Default: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+##
+##Minimum number of calls before the breaker can trip.
+##Prevents premature tripping during low-traffic periods.
+##Default: 10
+#circuit_breaker.minimum_number_of_calls = 10
+##
 ##Duration in OPEN state before transitioning to HALF_OPEN (probe).
-#circuit_reset_timeout = "15s"
-
-##Consecutive probe successes needed to close the circuit.
-#circuit_half_open_success_threshold = 3
+##Default: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+##
+##Slow call duration threshold. Default: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+##
+##Slow call rate threshold (0.0 – 1.0). 1.0 = disabled. Default: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+##
+##Per-operation timeout. Set to "0s" to disable. Default: "8s"
+#circuit_breaker.operation_timeout = "8s"

--- a/rmqtt-plugins/rmqtt-retainer/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-retainer/Cargo.toml
@@ -16,9 +16,10 @@ all-features = true
 [features]
 default = ["rate-counter"]
 ram = []
-sled = ["rmqtt-storage/sled"]
-redis = ["rmqtt-storage/redis"]
+sled = ["rmqtt-storage/sled", "circuit-breaker"]
+redis = ["rmqtt-storage/redis", "circuit-breaker"]
 rate-counter = []
+circuit-breaker = ["rmqtt-storage/circuit-breaker"]
 
 [dependencies]
 rmqtt = { workspace = true, features = ["plugin", "retain"] }

--- a/rmqtt-plugins/rmqtt-retainer/src/config.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/config.rs
@@ -12,6 +12,9 @@ use serde::{Deserialize, Serialize};
 use rmqtt::utils::{deserialize_duration, deserialize_duration_option, Bytesize};
 use rmqtt::Result;
 
+#[cfg(feature = "circuit-breaker")]
+use rmqtt_storage::{CircuitBreakerConfig, CountBasedWindowConfig, TimeBasedWindowConfig, WindowConfig};
+
 /// Top-level configuration for the retained messages plugin.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PluginConfig {
@@ -41,27 +44,12 @@ pub struct PluginConfig {
     pub batch_messages_limit: usize,
 
     // ─── Circuit breaker ─────────────────────────────────────────────────
-    /// Enable circuit breaker for storage operations. When enabled and the
-    /// circuit is OPEN, all retain store/get operations fast-fail without
-    /// touching the storage backend.
-    #[serde(default = "PluginConfig::circuit_breaker_enabled_default")]
-    pub circuit_breaker_enabled: bool,
-
-    /// Consecutive storage failures before tripping the circuit to OPEN.
-    #[serde(default = "PluginConfig::circuit_failure_threshold_default")]
-    pub circuit_failure_threshold: usize,
-
-    /// Duration in OPEN state before transitioning to HALF_OPEN (probe).
-    /// Example: "15s", "1m".
-    #[serde(
-        default = "PluginConfig::circuit_reset_timeout_default",
-        deserialize_with = "deserialize_duration"
-    )]
-    pub circuit_reset_timeout: Duration,
-
-    /// Consecutive probe successes in HALF_OPEN before closing the circuit.
-    #[serde(default = "PluginConfig::circuit_half_open_success_threshold_default")]
-    pub circuit_half_open_success_threshold: usize,
+    /// Optional circuit-breaker tuning.
+    /// When `None` (default), the built-in `CircuitBreakerConfig::default()`
+    /// is used verbatim. When `Some(...)`, the given fields override the
+    /// corresponding defaults.
+    #[serde(default)]
+    pub circuit_breaker: CircuitBreakerPluginConfig,
 }
 
 impl PluginConfig {
@@ -82,22 +70,6 @@ impl PluginConfig {
 
     fn batch_messages_limit_default() -> usize {
         500
-    }
-
-    fn circuit_breaker_enabled_default() -> bool {
-        true
-    }
-
-    fn circuit_failure_threshold_default() -> usize {
-        10
-    }
-
-    fn circuit_reset_timeout_default() -> Duration {
-        Duration::from_secs(15)
-    }
-
-    fn circuit_half_open_success_threshold_default() -> usize {
-        3
     }
 
     #[inline]
@@ -135,6 +107,38 @@ impl PluginConfig {
     pub fn to_json(&self) -> Result<serde_json::Value> {
         Ok(serde_json::to_value(self)?)
     }
+
+    #[cfg(feature = "circuit-breaker")]
+    #[inline]
+    pub(crate) fn to_cb_config(&self) -> CircuitBreakerConfig {
+        let cb = &self.circuit_breaker;
+        let window = match cb.sliding_window_type.as_str() {
+            "TimeBased" | "time_based" | "time" => {
+                let dur = if cb.sliding_window_duration.is_zero() {
+                    TimeBasedWindowConfig::default().sliding_window_duration
+                } else {
+                    cb.sliding_window_duration
+                };
+                WindowConfig::TimeBased(TimeBasedWindowConfig {
+                    sliding_window_duration: dur,
+                    sliding_window_size: cb.sliding_window_size,
+                })
+            }
+            _ => WindowConfig::CountBased(CountBasedWindowConfig {
+                sliding_window_size: cb.sliding_window_size,
+            }),
+        };
+        CircuitBreakerConfig {
+            failure_rate_threshold: cb.failure_rate_threshold,
+            window,
+            minimum_number_of_calls: cb.minimum_number_of_calls,
+            wait_duration_in_open: cb.wait_duration_in_open,
+            slow_call_duration_threshold: cb.slow_call_duration_threshold,
+            slow_call_rate_threshold: cb.slow_call_rate_threshold,
+            operation_timeout: if cb.operation_timeout.is_zero() { None } else { Some(cb.operation_timeout) },
+            ..CircuitBreakerConfig::default()
+        }
+    }
 }
 
 /// Storage backend selector for retained messages.
@@ -149,3 +153,109 @@ pub enum Config {
 /// RAM-only retainer configuration (no additional options).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RamConfig {}
+
+/// User-facing circuit-breaker settings.
+///
+/// Each field carries its own `serde(default = ...)` so that users can
+/// specify only the values they wish to override inside `[circuit_breaker]`.
+///
+/// Fields that are not set in TOML fall back to the values below, which
+/// match `CircuitBreakerConfig::default()` where practical.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CircuitBreakerPluginConfig {
+    /// Failure rate threshold (0.0 – 1.0). Default: 0.25
+    #[serde(default = "CircuitBreakerPluginConfig::failure_rate_threshold_default")]
+    pub failure_rate_threshold: f64,
+
+    /// Sliding window type: "CountBased" or "TimeBased". Default: "TimeBased"
+    #[serde(default = "CircuitBreakerPluginConfig::sliding_window_type_default")]
+    pub sliding_window_type: String,
+
+    /// Sliding window size (number of calls). Default: 20
+    #[serde(default = "CircuitBreakerPluginConfig::sliding_window_size_default")]
+    pub sliding_window_size: usize,
+
+    /// Sliding window duration for TimeBased mode. Only used when sliding_window_type
+    /// is "TimeBased". Calls older than this duration are excluded from failure rate
+    /// calculation. Default: "45s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::sliding_window_duration_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub sliding_window_duration: Duration,
+
+    /// Minimum calls before the breaker can trip. Default: 10
+    #[serde(default = "CircuitBreakerPluginConfig::minimum_number_of_calls_default")]
+    pub minimum_number_of_calls: usize,
+
+    /// Duration in OPEN state before transitioning to HALF_OPEN. Default: "30s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::wait_duration_in_open_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub wait_duration_in_open: Duration,
+
+    /// Slow call duration threshold. Default: "2s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::slow_call_duration_threshold_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub slow_call_duration_threshold: Duration,
+
+    /// Slow call rate threshold (0.0 – 1.0). 1.0 = disabled. Default: 1.0
+    #[serde(default = "CircuitBreakerPluginConfig::slow_call_rate_threshold_default")]
+    pub slow_call_rate_threshold: f64,
+
+    /// Per-operation timeout. Set to "0s" to disable. Default: "8s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::operation_timeout_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub operation_timeout: Duration,
+}
+
+impl Default for CircuitBreakerPluginConfig {
+    fn default() -> Self {
+        Self {
+            failure_rate_threshold: Self::failure_rate_threshold_default(),
+            sliding_window_type: Self::sliding_window_type_default(),
+            sliding_window_size: Self::sliding_window_size_default(),
+            sliding_window_duration: Self::sliding_window_duration_default(),
+            minimum_number_of_calls: Self::minimum_number_of_calls_default(),
+            wait_duration_in_open: Self::wait_duration_in_open_default(),
+            slow_call_duration_threshold: Self::slow_call_duration_threshold_default(),
+            slow_call_rate_threshold: Self::slow_call_rate_threshold_default(),
+            operation_timeout: Self::operation_timeout_default(),
+        }
+    }
+}
+
+impl CircuitBreakerPluginConfig {
+    fn failure_rate_threshold_default() -> f64 {
+        0.25
+    }
+    fn sliding_window_type_default() -> String {
+        "TimeBased".to_string()
+    }
+    fn sliding_window_size_default() -> usize {
+        20
+    }
+    fn sliding_window_duration_default() -> Duration {
+        Duration::from_secs(45)
+    }
+    fn minimum_number_of_calls_default() -> usize {
+        10
+    }
+    fn wait_duration_in_open_default() -> Duration {
+        Duration::from_secs(30)
+    }
+    fn slow_call_duration_threshold_default() -> Duration {
+        Duration::from_secs(2)
+    }
+    fn slow_call_rate_threshold_default() -> f64 {
+        1.0
+    }
+    fn operation_timeout_default() -> Duration {
+        Duration::from_secs(8)
+    }
+}

--- a/rmqtt-plugins/rmqtt-retainer/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/lib.rs
@@ -21,22 +21,13 @@ use async_trait::async_trait;
 use serde_json::{self, json};
 use tokio::sync::RwLock;
 
-use rmqtt::{
-    context::ServerContext,
-    hook::Register,
-    macros::Plugin,
-    plugin::Plugin,
-    register,
-    utils::{CircuitBreaker, CircuitBreakerConfig},
-    Result,
-};
+use rmqtt::{context::ServerContext, hook::Register, macros::Plugin, plugin::Plugin, register, Result};
 
 #[cfg(feature = "ram")]
 use ram::RamRetainer;
 #[cfg(any(feature = "sled", feature = "redis"))]
 use rmqtt_storage::{init_db, StorageType};
 
-#[cfg_attr(not(any(feature = "ram", feature = "sled", feature = "redis")), allow(unused_imports))]
 use config::{Config, PluginConfig};
 use rmqtt::plugin::PackageInfo;
 use rmqtt::retain::RetainStorage;
@@ -51,7 +42,6 @@ mod config;
 mod ram;
 #[cfg(any(feature = "sled", feature = "redis"))]
 mod storage;
-#[cfg_attr(not(any(feature = "sled", feature = "redis")), allow(dead_code))]
 mod value_cached;
 
 register!(RetainerPlugin::new);
@@ -68,10 +58,6 @@ struct RetainerPlugin {
 
 impl RetainerPlugin {
     #[inline]
-    #[cfg_attr(
-        not(any(feature = "ram", feature = "sled", feature = "redis")),
-        allow(unused, unreachable_code)
-    )]
     async fn new<N: Into<String>>(scx: ServerContext, name: N) -> Result<Self> {
         let name = name.into();
 
@@ -86,15 +72,8 @@ impl RetainerPlugin {
         let retainer = {
             let cfg_guard = cfg.read().await;
             let batch_messages_limit = cfg_guard.batch_messages_limit;
-            // Build the circuit breaker here (before cfg.write() below) to
-            // avoid deadlock: tokio::sync::RwLock is NOT reentrant, and
-            // cfg.write() is held inside the match block.
-            let circuit_breaker = CircuitBreaker::new(CircuitBreakerConfig {
-                enabled: cfg_guard.circuit_breaker_enabled,
-                failure_threshold: cfg_guard.circuit_failure_threshold,
-                reset_timeout: cfg_guard.circuit_reset_timeout,
-                half_open_success_threshold: cfg_guard.circuit_half_open_success_threshold,
-            });
+            #[cfg(feature = "circuit-breaker")]
+            let cb_config = cfg_guard.to_cb_config();
             drop(cfg_guard);
 
             match &mut cfg.write().await.storage {
@@ -116,16 +95,14 @@ impl RetainerPlugin {
                         _ => return Err(anyhow::anyhow!("unsupported storage type")),
                     };
                     let storage_db = init_db(s_cfg).await?;
+
+                    #[cfg(feature = "circuit-breaker")]
+                    let storage_db = storage::StorageDb::new(storage_db, cb_config);
+
                     let exec = scx.get_exec(("RETAINER_EXEC", 1000, 10_000));
-                    let (r, msg_rx, sync_rx) = storage::Retainer::new(
-                        node_id,
-                        cfg.clone(),
-                        storage_db,
-                        s_cfg.typ.clone(),
-                        exec,
-                        circuit_breaker,
-                    )
-                    .await?;
+                    let (r, msg_rx, sync_rx) =
+                        storage::Retainer::new(node_id, cfg.clone(), storage_db, s_cfg.typ.clone(), exec)
+                            .await?;
                     serve_state = Some(ServeState { msg_rx, sync_rx, batch_messages_limit });
                     Retainer::Storage(r)
                 }
@@ -294,19 +271,11 @@ impl Retainer {
                 let msg_count = r.count().await;
                 let storage_info = r.info().await;
                 let topics_size = r.topics.read().await.values_size();
-                let cb_state = format!("{:?}", r.circuit_breaker.state());
-                let cb_enabled = r.circuit_breaker.config().enabled;
-                let cb_failure_count = r.circuit_breaker.failure_count();
-                let cb_success_count = r.circuit_breaker.success_count();
+                // storage_info from CircuitBrokenDB already includes
+                // a "circuit_breaker" field with state/metrics/config.
                 let mut info = json!({
                     "storage_info": storage_info,
                     "topics_size": topics_size,
-                    "circuit_breaker": {
-                        "success_count": cb_success_count,
-                        "failure_count": cb_failure_count,
-                        "state": cb_state,
-                        "enabled": cb_enabled,
-                    },
                     "message": {
                         "max": msg_max,
                         "count": msg_count,

--- a/rmqtt-plugins/rmqtt-retainer/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-retainer/src/storage.rs
@@ -19,7 +19,11 @@ use futures_time::{self, future::FutureExt};
 use rust_box::task_exec_queue::{SpawnExt, TaskExecQueue};
 use tokio::sync::RwLock;
 
-use rmqtt_storage::{DefaultStorageDB, StorageType};
+#[cfg(feature = "circuit-breaker")]
+pub(crate) use rmqtt_storage::CircuitBrokenDB as StorageDb;
+#[cfg(not(feature = "circuit-breaker"))]
+pub(crate) use rmqtt_storage::DefaultStorageDB as StorageDb;
+use rmqtt_storage::{StorageDB as _, StorageType};
 
 #[cfg(feature = "rate-counter")]
 use rmqtt::utils::RateCounter;
@@ -27,7 +31,7 @@ use rmqtt::{
     retain::RetainStorage,
     retain::{RetainSyncMode, RetainTree},
     types::{NodeId, Retain, TimedValue, TimestampMillis, Topic, TopicFilter, TopicName},
-    utils::{timestamp_millis, CircuitBreaker, StatsMergeMode},
+    utils::{timestamp_millis, StatsMergeMode},
     Result,
 };
 
@@ -59,10 +63,9 @@ impl Retainer {
     pub(crate) async fn new(
         _node_id: NodeId,
         cfg: Arc<RwLock<PluginConfig>>,
-        storage_db: DefaultStorageDB,
+        storage_db: StorageDb,
         storage_type: StorageType,
         exec: TaskExecQueue,
-        circuit_breaker: CircuitBreaker,
     ) -> Result<(Retainer, mpsc::Receiver<Msg>, mpsc::Receiver<SyncMsg>)> {
         let (msg_tx, msg_rx) = mpsc::channel::<Msg>(5_000);
         let (sync_tx, sync_rx) = mpsc::channel::<SyncMsg>(10_000);
@@ -80,7 +83,6 @@ impl Retainer {
             storage_type,
             exec: exec.clone(),
             topics: Arc::new(RwLock::new(RetainTree::default())),
-            circuit_breaker,
             #[cfg(feature = "rate-counter")]
             set_rate_counter: RateCounter::new(),
             #[cfg(feature = "rate-counter")]
@@ -112,10 +114,6 @@ impl Retainer {
 
     #[inline]
     pub(crate) async fn info(&self) -> serde_json::Value {
-        if self.circuit_breaker.is_blocked() {
-            return serde_json::Value::Null;
-        }
-
         let this = self.inner.clone();
         let cached = self.abstract_info.clone();
         let info = cached
@@ -212,25 +210,13 @@ impl Retainer {
                 let msgs = std::mem::take(&mut merger_msgs);
                 let batch_size = msgs.len();
 
-                // When the circuit breaker is OPEN, skip all storage operations
-                // without touching Redis/Sled. This prevents the channel backlog
-                // (cap=5000) from blocking the serve loop while each batch waits
-                // for a storage timeout.
-                // is_blocked() also handles OPEN→HALF_OPEN transitions, so when a
-                // probe is due, the next batch will be processed normally.
-                if msg_mgr.circuit_breaker.is_blocked() {
-                    #[cfg(feature = "rate-counter")]
-                    rate_counter.decs(batch_size as i64);
-                    continue;
-                }
-
+                // When the backing storage is unreachable, storage operations
+                // will fast-fail through the rmqtt-storage circuit breaker.
+                // The serve loop simply logs the error and continues, preventing
+                // the channel backlog from blocking indefinitely.
                 let start = Instant::now();
-                match msg_mgr._batch_store_new(msgs).await {
-                    Ok(()) => msg_mgr.circuit_breaker.record_success(),
-                    Err(e) => {
-                        log::warn!("batch store failed, {e}");
-                        msg_mgr.circuit_breaker.record_failure();
-                    }
+                if let Err(e) = msg_mgr._batch_store_new(msgs).await {
+                    log::warn!("batch store failed, {e}");
                 }
 
                 #[cfg(feature = "rate-counter")]
@@ -255,7 +241,7 @@ impl Deref for Retainer {
 
 pub struct RetainerInner {
     cfg: Arc<RwLock<PluginConfig>>,
-    pub(crate) storage_db: DefaultStorageDB,
+    pub(crate) storage_db: StorageDb,
     msg_tx: mpsc::Sender<Msg>,
     /// Dedicated channel for retain-sync messages (no Redis, no blocking).
     sync_tx: mpsc::Sender<SyncMsg>,
@@ -268,8 +254,6 @@ pub struct RetainerInner {
     /// stored (no retain data). Used for fast wildcard matching and
     /// cluster-aware topic synchronization.
     pub(crate) topics: Arc<RwLock<RetainTree<TimedValue<()>>>>,
-    /// Circuit breaker for storage failure detection and fast-fail degradation.
-    pub(crate) circuit_breaker: CircuitBreaker,
     /// Rate counter for tracking message processing throughput.
     #[cfg(feature = "rate-counter")]
     pub(crate) set_rate_counter: RateCounter,
@@ -474,7 +458,8 @@ impl RetainerInner {
         }
 
         // Batch remove — failure propagates to the serve loop so the
-        // circuit breaker can record the failure and eventually trip OPEN.
+        // circuit breaker (via CircuitBrokenDB) can record the failure
+        // and eventually trip OPEN.
         if !remove_keys.is_empty() {
             self.storage_db
                 .batch_remove(remove_keys)
@@ -546,24 +531,12 @@ impl RetainerInner {
 
     #[inline]
     async fn _len(&self) -> Result<usize> {
-        let len = self
-            .storage_db
+        self.storage_db
             .len()
             .timeout(futures_time::time::Duration::from_millis(3000))
             .await
             .map_err(|_e| anyhow!("db.len timeout"))
-            .flatten();
-
-        match len {
-            Ok(len) => {
-                self.circuit_breaker.record_success();
-                Ok(len)
-            }
-            Err(_) => {
-                self.circuit_breaker.record_failure();
-                Ok(0)
-            }
-        }
+            .flatten()
     }
 
     #[inline]
@@ -574,23 +547,13 @@ impl RetainerInner {
 
     #[inline]
     async fn storage_messages_max_get(&self) -> Result<isize> {
-        let val = self
-            .storage_db
+        self.storage_db
             .counter_get(RETAIN_MESSAGES_MAX)
             .timeout(futures_time::time::Duration::from_millis(3000))
             .await
             .map_err(|_e| anyhow!("storage_messages_max_get timeout"))
-            .flatten();
-        match val {
-            Ok(val) => {
-                self.circuit_breaker.record_success();
-                Ok(val.unwrap_or_default())
-            }
-            Err(_) => {
-                self.circuit_breaker.record_failure();
-                Ok(0)
-            }
-        }
+            .flatten()
+            .map(|v| v.unwrap_or_default())
     }
 
     #[inline]
@@ -802,24 +765,12 @@ impl RetainerInner {
     /// notification carries the operation direction.
     #[inline]
     async fn _abstract_info(&self) -> Result<serde_json::Value> {
-        let info = self
-            .storage_db
+        self.storage_db
             .info()
             .timeout(futures_time::time::Duration::from_millis(3000))
             .await
             .map_err(|_e| anyhow!("get info timeout"))
-            .flatten();
-
-        match info {
-            Ok(info) => {
-                self.circuit_breaker.record_success();
-                Ok(info)
-            }
-            Err(e) => {
-                self.circuit_breaker.record_failure();
-                Err(e)
-            }
-        }
+            .flatten()
     }
 }
 
@@ -854,10 +805,6 @@ impl RetainStorage for Retainer {
 
     ///topic - concrete topic
     async fn set(&self, topic: &TopicName, retain: Retain, expiry_interval: Option<Duration>) -> Result<()> {
-        if self.circuit_breaker.is_blocked() {
-            return Ok(());
-        }
-
         let res =
             self.msg_tx.clone().send((topic.clone(), retain, expiry_interval)).await.map_err(|e| anyhow!(e));
         match res {
@@ -875,11 +822,6 @@ impl RetainStorage for Retainer {
 
     ///topic_filter - Topic filter
     async fn get(&self, topic_filter: &TopicFilter) -> Result<Vec<(TopicName, Retain)>> {
-        // Circuit breaker OPEN: return empty without calling get_message.
-        if self.circuit_breaker.is_blocked() {
-            return Ok(Vec::new());
-        }
-
         let this = self.clone();
         let tf = topic_filter.clone();
         let result = async move { this.get_message(&tf).await }
@@ -896,19 +838,16 @@ impl RetainStorage for Retainer {
                 match inner {
                     Ok(Ok(retains)) => {
                         // Task succeeded, get_message returned Ok
-                        self.circuit_breaker.record_success();
                         Ok(retains)
                     }
                     Ok(Err(e)) => {
                         // Task succeeded, but get_message returned Err (storage failure)
                         log::warn!("retainer get_message error: {:?}", e);
-                        self.circuit_breaker.record_failure();
                         Ok(Vec::new())
                     }
                     Err(_e) => {
                         // Task failed (panic, etc.)
                         log::warn!("retainer get task error");
-                        self.circuit_breaker.record_failure();
                         Ok(Vec::new())
                     }
                 }
@@ -916,7 +855,6 @@ impl RetainStorage for Retainer {
             Err(_) => {
                 // Timeout
                 log::warn!("retainer get timeout");
-                self.circuit_breaker.record_failure();
                 Ok(Vec::new())
             }
         }
@@ -927,9 +865,6 @@ impl RetainStorage for Retainer {
         offset: usize,
         limit: usize,
     ) -> Result<(Vec<(TopicName, Retain, Option<Duration>)>, bool)> {
-        if self.circuit_breaker.is_blocked() {
-            return Ok((Vec::new(), false));
-        }
         self._get_all_paginated(offset, limit)
             .timeout(futures_time::time::Duration::from_secs(60))
             .await
@@ -938,17 +873,11 @@ impl RetainStorage for Retainer {
 
     #[inline]
     async fn count(&self) -> isize {
-        if self.circuit_breaker.is_blocked() {
-            return -1;
-        }
         self.get_retain_count().await as isize
     }
 
     #[inline]
     async fn max(&self) -> isize {
-        if self.circuit_breaker.is_blocked() {
-            return -1;
-        }
         let this = self.inner.clone();
 
         let val = self.storage_messages_max.clone();

--- a/rmqtt-plugins/rmqtt-session-storage.toml
+++ b/rmqtt-plugins/rmqtt-session-storage.toml
@@ -16,3 +16,47 @@ storage.redis.prefix = "session-{node}"
 ##redis-cluster
 storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
 storage.redis-cluster.prefix = "session-{node}"
+
+##─── Circuit breaker ─────────────────────────────────────────────────────────
+##Uncomment the following section to customize circuit-breaker behaviour.
+##When the whole section is absent, the upstream default is used verbatim.
+
+##Failure rate threshold (0.0 – 1.0). When exceeded, circuit opens.
+##Default: 0.25
+#circuit_breaker.failure_rate_threshold = 0.25
+
+##Sliding window type: "CountBased" or "TimeBased".
+##  CountBased — window slides after N calls (sliding_window_size).
+##  TimeBased  — window slides after a fixed duration (e.g. 45s).
+##Default: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+
+##Sliding window size (number of calls) for CountBased type.
+##For TimeBased, this value sets the max tracked calls (fallback for minimum_number_of_calls).
+##Default: 20
+#circuit_breaker.sliding_window_size = 20
+
+##Sliding window duration for TimeBased type (e.g. "45s").
+##Only used when sliding_window_type is "TimeBased".
+##Default: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+
+##Minimum calls before the breaker can trip.
+##Default: 10
+#circuit_breaker.minimum_number_of_calls = 10
+
+##Duration in OPEN state before transitioning to HALF_OPEN (probe).
+##Default: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+
+##Slow call duration threshold.
+##Default: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+
+##Slow call rate threshold (0.0 – 1.0). 1.0 = disabled.
+##Default: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+
+##Per-operation timeout. Set to "0s" to disable.
+##Default: "15s"
+#circuit_breaker.operation_timeout = "15s"

--- a/rmqtt-plugins/rmqtt-session-storage/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-session-storage/Cargo.toml
@@ -12,10 +12,11 @@ license.workspace = true
 all-features = true
 
 [features]
-default = ["rmqtt-storage"]
+default = ["rmqtt-storage", "circuit-breaker"]
 sled = ["rmqtt-storage/sled"]
 redis = ["rmqtt-storage/redis"]
 redis-cluster = ["redis", "rmqtt-storage/redis-cluster"]
+circuit-breaker = ["rmqtt-storage/circuit-breaker"]
 
 [dependencies]
 rmqtt = { workspace = true, features = ["plugin"] }

--- a/rmqtt-plugins/rmqtt-session-storage/src/config.rs
+++ b/rmqtt-plugins/rmqtt-session-storage/src/config.rs
@@ -1,16 +1,28 @@
 //! Configuration for the session storage plugin.
 //!
 //! Defines [`PluginConfig`] wrapping an `rmqtt_storage::Config` for
-//! persisting session state.
+//! persisting session state, plus optional [`CircuitBreakerPluginConfig`]
+//! for circuit-breaker tuning (powered by `rmqtt_storage::CircuitBreakerConfig`).
 
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
+use rmqtt::utils::deserialize_duration;
 use rmqtt_storage::Config;
+#[cfg(feature = "circuit-breaker")]
+use rmqtt_storage::{CircuitBreakerConfig, CountBasedWindowConfig, TimeBasedWindowConfig, WindowConfig};
 
 /// Top-level configuration for the session storage plugin.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PluginConfig {
     pub storage: Config,
+
+    /// Optional circuit-breaker tuning.
+    /// When `None` (default), the built-in `CircuitBreakerConfig::default()`
+    /// is used verbatim. When `Some(...)`, the given fields override the
+    /// corresponding defaults.
+    #[serde(default)]
+    pub circuit_breaker: CircuitBreakerPluginConfig,
 }
 
 impl PluginConfig {
@@ -18,5 +30,143 @@ impl PluginConfig {
     #[inline]
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::json!(self)
+    }
+
+    #[cfg(feature = "circuit-breaker")]
+    #[inline]
+    pub(crate) fn to_cb_config(&self) -> CircuitBreakerConfig {
+        let cb = &self.circuit_breaker;
+        let window = match cb.sliding_window_type.as_str() {
+            "TimeBased" | "time_based" | "time" => {
+                let dur = if cb.sliding_window_duration.is_zero() {
+                    TimeBasedWindowConfig::default().sliding_window_duration
+                } else {
+                    cb.sliding_window_duration
+                };
+                WindowConfig::TimeBased(TimeBasedWindowConfig {
+                    sliding_window_duration: dur,
+                    sliding_window_size: cb.sliding_window_size,
+                })
+            }
+            _ => WindowConfig::CountBased(CountBasedWindowConfig {
+                sliding_window_size: cb.sliding_window_size,
+            }),
+        };
+        CircuitBreakerConfig {
+            failure_rate_threshold: cb.failure_rate_threshold,
+            window,
+            minimum_number_of_calls: cb.minimum_number_of_calls,
+            wait_duration_in_open: cb.wait_duration_in_open,
+            slow_call_duration_threshold: cb.slow_call_duration_threshold,
+            slow_call_rate_threshold: cb.slow_call_rate_threshold,
+            operation_timeout: if cb.operation_timeout.is_zero() { None } else { Some(cb.operation_timeout) },
+            ..CircuitBreakerConfig::default()
+        }
+    }
+}
+
+/// User-facing circuit-breaker settings.
+///
+/// Each field carries its own `serde(default = ...)` so that users can
+/// specify only the values they wish to override inside `[circuit_breaker]`.
+///
+/// Fields that are not set in TOML fall back to the values below, which
+/// match `CircuitBreakerConfig::default()` where practical.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CircuitBreakerPluginConfig {
+    /// Failure rate threshold (0.0 – 1.0). Default: 0.25
+    #[serde(default = "CircuitBreakerPluginConfig::failure_rate_threshold_default")]
+    pub failure_rate_threshold: f64,
+
+    /// Sliding window type: "CountBased" or "TimeBased". Default: "TimeBased"
+    #[serde(default = "CircuitBreakerPluginConfig::sliding_window_type_default")]
+    pub sliding_window_type: String,
+
+    /// Sliding window size (number of calls). Default: 20
+    #[serde(default = "CircuitBreakerPluginConfig::sliding_window_size_default")]
+    pub sliding_window_size: usize,
+
+    /// Sliding window duration for TimeBased mode. Only used when sliding_window_type
+    /// is "TimeBased". Calls older than this duration are excluded from failure rate
+    /// calculation. Default: "45s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::sliding_window_duration_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub sliding_window_duration: Duration,
+
+    /// Minimum calls before the breaker can trip. Default: 10
+    #[serde(default = "CircuitBreakerPluginConfig::minimum_number_of_calls_default")]
+    pub minimum_number_of_calls: usize,
+
+    /// Duration in OPEN state before transitioning to HALF_OPEN. Default: "30s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::wait_duration_in_open_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub wait_duration_in_open: Duration,
+
+    /// Slow call duration threshold. Default: "2s"
+    #[serde(
+        default = "CircuitBreakerPluginConfig::slow_call_duration_threshold_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub slow_call_duration_threshold: Duration,
+
+    /// Slow call rate threshold (0.0 – 1.0). 1.0 = disabled. Default: 1.0
+    #[serde(default = "CircuitBreakerPluginConfig::slow_call_rate_threshold_default")]
+    pub slow_call_rate_threshold: f64,
+
+    /// Per-operation timeout. Set to "0s" to disable. Default: "0s" (disabled)
+    #[serde(
+        default = "CircuitBreakerPluginConfig::operation_timeout_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub operation_timeout: Duration,
+}
+
+impl Default for CircuitBreakerPluginConfig {
+    fn default() -> Self {
+        Self {
+            failure_rate_threshold: Self::failure_rate_threshold_default(),
+            sliding_window_type: Self::sliding_window_type_default(),
+            sliding_window_size: Self::sliding_window_size_default(),
+            sliding_window_duration: Self::sliding_window_duration_default(),
+            minimum_number_of_calls: Self::minimum_number_of_calls_default(),
+            wait_duration_in_open: Self::wait_duration_in_open_default(),
+            slow_call_duration_threshold: Self::slow_call_duration_threshold_default(),
+            slow_call_rate_threshold: Self::slow_call_rate_threshold_default(),
+            operation_timeout: Self::operation_timeout_default(),
+        }
+    }
+}
+
+impl CircuitBreakerPluginConfig {
+    fn failure_rate_threshold_default() -> f64 {
+        0.25
+    }
+    fn sliding_window_type_default() -> String {
+        "TimeBased".to_string()
+    }
+    fn sliding_window_size_default() -> usize {
+        20
+    }
+    fn sliding_window_duration_default() -> Duration {
+        Duration::from_secs(45)
+    }
+    fn minimum_number_of_calls_default() -> usize {
+        10
+    }
+    fn wait_duration_in_open_default() -> Duration {
+        Duration::from_secs(30)
+    }
+    fn slow_call_duration_threshold_default() -> Duration {
+        Duration::from_secs(2)
+    }
+    fn slow_call_rate_threshold_default() -> f64 {
+        1.0
+    }
+    fn operation_timeout_default() -> Duration {
+        Duration::from_secs(15)
     }
 }

--- a/rmqtt-plugins/rmqtt-session-storage/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-session-storage/src/lib.rs
@@ -37,7 +37,16 @@ use rmqtt::{
     Result,
 };
 
-use rmqtt_storage::{init_db, DefaultStorageDB, List, Map, StorageType};
+#[cfg(feature = "circuit-breaker")]
+pub(crate) use rmqtt_storage::{
+    init_db, CircuitBrokenDB as StorageDb, CircuitBrokenList as StorageList, CircuitBrokenMap as StorageMap,
+    List, Map, StorageDB, StorageType,
+};
+
+#[cfg(not(feature = "circuit-breaker"))]
+pub(crate) use rmqtt_storage::{
+    init_db, DefaultStorageDB as StorageDb, List, Map, StorageDB, StorageList, StorageMap, StorageType,
+};
 
 use config::PluginConfig;
 use rmqtt::context::ServerContext;
@@ -63,7 +72,7 @@ register!(StoragePlugin::new);
 struct StoragePlugin {
     scx: ServerContext,
     cfg: Arc<PluginConfig>,
-    storage_db: DefaultStorageDB,
+    storage_db: StorageDb,
     stored_session_infos: StoredSessionInfos,
     register: Box<dyn Register>,
     session_mgr: StorageSessionManager,
@@ -99,7 +108,16 @@ impl StoragePlugin {
                 log::error!("{name} init storage db error, {e}");
                 return Err(e);
             }
-            Ok(db) => db,
+            Ok(db) => {
+                #[cfg(feature = "circuit-breaker")]
+                {
+                    StorageDb::new(db, cfg.to_cb_config())
+                }
+                #[cfg(not(feature = "circuit-breaker"))]
+                {
+                    db
+                }
+            }
         };
 
         let stored_session_infos = StoredSessionInfos::new();
@@ -295,6 +313,7 @@ impl StoragePlugin {
                                     "Rebuild offline sessions, completed_count: {}, active_count: {}, waiting_count: {}, rate: {:?}, cost: {:?}",
                                     exec.completed_count().await, exec.active_count(), exec.waiting_count(), exec.rate().await, now.elapsed()
                                 );
+                                break;
                         }
                     }
                 }
@@ -364,7 +383,7 @@ impl Plugin for StoragePlugin {
 
     #[inline]
     async fn attrs(&self) -> serde_json::Value {
-        async fn stats(storage_db: &DefaultStorageDB) -> (String, String, String, serde_json::Value) {
+        async fn stats(storage_db: &StorageDb) -> (String, String, String) {
             let max_limit = 1000;
             let mut session_count = 0;
             let mut storage_db_map = storage_db.clone();
@@ -430,21 +449,25 @@ impl Plugin for StoragePlugin {
                 format!("{offline_message_count}")
             };
 
-            let storage_info = storage_db.info().await.unwrap_or_default();
-
-            (session_count, offline_session_count, offline_message_count, storage_info)
+            (session_count, offline_session_count, offline_message_count)
         }
 
         let (session_count, offline_session_count, offline_message_count, storage_info) =
             match tokio::time::timeout(Duration::from_secs(10), stats(&self.storage_db)).await {
-                Ok((session_count, offline_session_count, offline_message_count, storage_info)) => {
-                    (session_count, offline_session_count, offline_message_count, storage_info)
-                }
+                Ok((session_count, offline_session_count, offline_message_count)) => (
+                    session_count,
+                    offline_session_count,
+                    offline_message_count,
+                    self.storage_db.info().await.unwrap_or_default(),
+                ),
                 Err(_) => (
                     "timeout(10s)".into(),
                     "timeout(10s)".into(),
                     "timeout(10s)".into(),
-                    serde_json::Value::Null,
+                    match self.storage_db.info().await {
+                        Ok(info) => info,
+                        Err(e) => serde_json::Value::String(e.to_string()),
+                    },
                 ),
             };
 
@@ -459,11 +482,11 @@ impl Plugin for StoragePlugin {
 
 struct OfflineMessageHandler {
     cfg: Arc<PluginConfig>,
-    storage_db: DefaultStorageDB,
+    storage_db: StorageDb,
 }
 
 impl OfflineMessageHandler {
-    fn new(cfg: Arc<PluginConfig>, storage_db: DefaultStorageDB) -> Self {
+    fn new(cfg: Arc<PluginConfig>, storage_db: StorageDb) -> Self {
         Self { cfg, storage_db }
     }
 }
@@ -486,22 +509,16 @@ impl Handler for OfflineMessageHandler {
                 let p = (*p).clone();
                 let f = f.clone();
                 tokio::spawn(async move {
-                    match storage_db.list(list_stored_key.as_ref(), None).await {
-                        Ok(offlines_list) => {
-                            let res = offlines_list
-                                .push_limit::<OfflineMessageOptionType>(
-                                    &Some((id.client_id.clone(), f, p)),
-                                    max_mqueue_len,
-                                    true,
-                                )
-                                .await;
-                            if let Err(e) = res {
-                                log::warn!("{id:?} save offline messages error, {e}")
-                            }
-                        }
-                        Err(e) => {
-                            log::warn!("{id:?} save offline messages error, {e}")
-                        }
+                    let offlines_list = storage_db.list(list_stored_key.as_ref(), None).await;
+                    let res = offlines_list
+                        .push_limit::<OfflineMessageOptionType>(
+                            &Some((id.client_id.clone(), f, p)),
+                            max_mqueue_len,
+                            true,
+                        )
+                        .await;
+                    if let Err(e) = res {
+                        log::warn!("{id:?} save offline messages error, {e}")
                     }
                 });
             }
@@ -519,15 +536,9 @@ impl Handler for OfflineMessageHandler {
                 let inflight_messages = inflight_messages.clone();
                 let id = s.id.clone();
                 tokio::spawn(async move {
-                    match storage_db.map(map_stored_key.as_ref(), None).await {
-                        Ok(m) => {
-                            if let Err(e) = m.insert(INFLIGHT_MESSAGES, &inflight_messages).await {
-                                log::warn!("{id:?} save offline inflight messages error, {e}")
-                            }
-                        }
-                        Err(e) => {
-                            log::warn!("{id:?} save offline inflight messages error, {e}")
-                        }
+                    let m = storage_db.map(map_stored_key.as_ref(), None).await;
+                    if let Err(e) = m.insert(INFLIGHT_MESSAGES, &inflight_messages).await {
+                        log::warn!("{id:?} save offline inflight messages error, {e}")
                     }
                 });
             }
@@ -542,7 +553,7 @@ impl Handler for OfflineMessageHandler {
 
 struct StorageHandler {
     scx: ServerContext,
-    storage_db: DefaultStorageDB,
+    storage_db: StorageDb,
     cfg: Arc<PluginConfig>,
     stored_session_infos: StoredSessionInfos,
     rebuild_tx: mpsc::Sender<RebuildChanType>,
@@ -551,7 +562,7 @@ struct StorageHandler {
 impl StorageHandler {
     fn new(
         scx: ServerContext,
-        storage_db: DefaultStorageDB,
+        storage_db: StorageDb,
         cfg: Arc<PluginConfig>,
         stored_session_infos: StoredSessionInfos,
         rebuild_tx: mpsc::Sender<RebuildChanType>,

--- a/rmqtt-plugins/rmqtt-session-storage/src/session.rs
+++ b/rmqtt-plugins/rmqtt-session-storage/src/session.rs
@@ -6,7 +6,7 @@
 //! external storage backend.
 
 use std::ops::Deref;
-use std::sync::atomic::{AtomicI64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -28,7 +28,8 @@ use rmqtt::{
     utils::timestamp_millis,
     Result,
 };
-use rmqtt_storage::{DefaultStorageDB, List, Map, StorageList, StorageMap};
+
+use super::{List, Map, StorageDB, StorageDb, StorageList, StorageMap};
 
 use crate::{make_list_stored_key, make_map_stored_key, OfflineMessageOptionType};
 
@@ -40,13 +41,13 @@ pub(crate) const INFLIGHT_MESSAGES: &[u8] = b"5";
 
 #[derive(Clone)]
 pub(crate) struct StorageSessionManager {
-    storage_db: DefaultStorageDB,
+    storage_db: StorageDb,
     _stored_session_infos: StoredSessionInfos,
 }
 
 impl StorageSessionManager {
     pub(crate) fn new(
-        storage_db: DefaultStorageDB,
+        storage_db: StorageDb,
         _stored_session_infos: StoredSessionInfos,
     ) -> StorageSessionManager {
         Self { storage_db, _stored_session_infos }
@@ -97,9 +98,9 @@ impl SessionManager for StorageSessionManager {
             Ok(Arc::new(inner))
         } else {
             let id_str = inner.id().to_string();
-            let session_info_map = self.storage_db.map(make_map_stored_key(id_str.as_str()), None).await?;
+            let session_info_map = self.storage_db.map(make_map_stored_key(id_str.as_str()), None).await;
             let offline_messages_list =
-                self.storage_db.list(make_list_stored_key(id_str.as_str()), None).await?;
+                self.storage_db.list(make_list_stored_key(id_str.as_str()), None).await;
 
             //Only when 'clean_session' is equal to false or 'clean_start' is equal to false, the
             // session information persistence feature will be initiated.
@@ -122,20 +123,16 @@ impl SessionManager for StorageSessionManager {
                         let map = s1.storage_db.map(make_map_stored_key(last_id.to_string()), None).await;
                         let list = s1.storage_db.list(make_list_stored_key(last_id.to_string()), None).await;
 
-                        if let Ok(map) = map {
-                            if let Err(e) = map.clear().await {
-                                log::warn!(
-                                    "Remove last offline session info error from db, last_id: {last_id:?}, {e}"
-                                );
-                            }
+                        if let Err(e) = map.clear().await {
+                            log::warn!(
+                                "Remove last offline session info error from db, last_id: {last_id:?}, {e}"
+                            );
                         }
 
-                        if let Ok(list) = list {
-                            if let Err(e) = list.clear().await {
-                                log::warn!(
-                                    "Remove last offline session info error from db, last_id: {last_id:?}, {e}"
-                                );
-                            }
+                        if let Err(e) = list.clear().await {
+                            log::warn!(
+                                "Remove last offline session info error from db, last_id: {last_id:?}, {e}"
+                            );
                         }
                     }
                 });
@@ -179,10 +176,12 @@ pub struct StorageSession {
     inner: DefaultSession,
     fitter: FitterType,
     //----------------------------------
-    storage_db: DefaultStorageDB,
+    storage_db: StorageDb,
     session_info_map: StorageMap,
     offline_messages_list: StorageList,
-    last_time: AtomicI64,
+    last_time: Arc<AtomicI64>,
+    /// Tracks consecutive write failures. Used to detect backend recovery and trigger full resync.
+    write_failures: Arc<AtomicU64>,
 }
 
 impl StorageSession {
@@ -190,7 +189,7 @@ impl StorageSession {
     fn new(
         inner: DefaultSession,
         fitter: FitterType,
-        storage_db: DefaultStorageDB,
+        storage_db: StorageDb,
         session_info_map: StorageMap,
         offline_messages_list: StorageList,
     ) -> Self {
@@ -200,7 +199,38 @@ impl StorageSession {
             storage_db,
             session_info_map,
             offline_messages_list,
-            last_time: AtomicI64::new(timestamp_millis()),
+            last_time: Arc::new(AtomicI64::new(timestamp_millis())),
+            write_failures: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    #[inline]
+    async fn _update_last_time(
+        id: Id,
+        basic: &Basic,
+        subs: &SessionSubMap,
+        last_time: Arc<AtomicI64>,
+        session_info_map: StorageMap,
+        write_failures: Arc<AtomicU64>,
+    ) {
+        let now = last_time.load(Ordering::SeqCst);
+        match session_info_map.insert(LAST_TIME, &now).await {
+            Ok(()) => {
+                // Check if we were in a write-failure state — atomically reset and detect recovery
+                if write_failures.swap(0, Ordering::AcqRel) > 0 {
+                    log::info!("{:?} backend recovered, resyncing session data", id);
+                    // Full resync: rewrite all critical session data
+                    Self::_full_sync(&id, &session_info_map, basic, subs, write_failures.as_ref()).await;
+                    if write_failures.load(Ordering::Acquire) > 0 {
+                        log::warn!("{:?} partial resync failure, will retry", id);
+                    }
+                }
+                log::debug!("{:?} update last time", id);
+            }
+            Err(e) => {
+                log::warn!("{:?} save last time to db error, {e}", id);
+                write_failures.store(1, Ordering::Release);
+            }
         }
     }
 
@@ -209,18 +239,36 @@ impl StorageSession {
         let now = timestamp_millis();
         let old = self.last_time.swap(now, Ordering::SeqCst);
         if save_enable || (now - old) > (1000 * 60) {
+            let basic = match self.make_basic_info().await {
+                Ok(b) => b,
+                Err(e) => {
+                    log::error!("{}", e);
+                    return;
+                }
+            };
+            let subs = self.inner.subscriptions.read().await.clone();
             let id = self.id().clone();
+            let last_time = self.last_time.clone();
             let session_info_map = self.session_info_map.clone();
-            tokio::spawn(async move { Self::_update_last_time(&id, session_info_map, now).await });
-            log::debug!("{:?} update last time", self.id());
+            let write_failures = self.write_failures.clone();
+
+            tokio::spawn(async move {
+                Self::_update_last_time(id, &basic, &subs, last_time, session_info_map, write_failures).await;
+            });
         }
     }
 
     #[inline]
-    async fn _update_last_time(id: &Id, session_info_map: StorageMap, now: TimestampMillis) {
-        if let Err(e) = session_info_map.insert(LAST_TIME, &now).await {
-            log::warn!("{id:?} save last time to db error, {e}");
-        }
+    async fn _full_sync(
+        id: &Id,
+        session_info_map: &StorageMap,
+        basic: &Basic,
+        subs: &SessionSubMap,
+        write_failures: &AtomicU64,
+    ) {
+        log::info!("{:?} full_sync ...", id);
+        Self::_save_basic_info(session_info_map, basic, write_failures).await;
+        Self::_save_subscriptions(session_info_map, subs, write_failures).await;
     }
 
     #[inline]
@@ -246,55 +294,61 @@ impl StorageSession {
     #[inline]
     pub(crate) async fn save_to_db(&self) -> Result<()> {
         self.update_last_time(true).await;
-        self.save_basic_info().await;
-        self.save_subscriptions().await;
+        self.save_basic_info().await?;
+        let subs = self.inner.subscriptions.read().await.clone();
+        Self::_save_subscriptions(&self.session_info_map, &subs, self.write_failures.as_ref()).await;
         log::debug!("{:?} save to db ...", self.id());
         Ok(())
     }
 
     #[inline]
-    async fn save_basic_info(&self) {
-        if let Err(e) = self._save_basic_info().await {
-            log::error!("save basic info error, {e}");
-        }
-    }
-
-    #[inline]
-    async fn _save_basic_info(&self) -> Result<()> {
-        let basic = Basic {
+    async fn make_basic_info(&self) -> Result<Basic> {
+        Ok(Basic {
             id: self.id().clone(),
             conn_info: self.connect_info().await?,
             created_at: self.created_at().await?,
             connected_at: self.connected_at().await?,
-        };
-        self.session_info_map.insert(BASIC, &basic).await?;
+        })
+    }
+
+    #[inline]
+    async fn save_basic_info(&self) -> Result<()> {
+        let basic = self.make_basic_info().await?;
+        Self::_save_basic_info(&self.session_info_map, &basic, self.write_failures.as_ref()).await;
         Ok(())
+    }
+
+    #[inline]
+    async fn _save_basic_info(session_info_map: &StorageMap, basic: &Basic, write_failures: &AtomicU64) {
+        if let Err(e) = session_info_map.insert(BASIC, basic).await {
+            log::error!("save basic info error, {e}");
+            write_failures.store(1, Ordering::Release);
+        }
     }
 
     #[inline]
     async fn save_subscriptions(&self) {
         let subs = self.inner.subscriptions.clone();
         let session_info_map = self.session_info_map.clone();
+        let write_failures = self.write_failures.clone();
         tokio::spawn(async move {
             let subs = subs.read().await.clone();
-            match tokio::time::timeout(
-                Duration::from_secs(8),
-                Self::_save_subscriptions(&session_info_map, &subs),
-            )
-            .await
-            {
-                Ok(()) => {}
-                Err(e) => {
-                    log::error!("save subscriptions error, {e}");
-                }
-            }
+            Self::_save_subscriptions(&session_info_map, &subs, &write_failures).await;
         });
     }
 
     #[inline]
-    async fn _save_subscriptions(session_info_map: &StorageMap, subs: &SessionSubMap) {
-        if let Err(e) = session_info_map.insert(SESSION_SUB_MAP, subs).await {
-            log::error!("save subscriptions error, {e}");
+    async fn _save_subscriptions(
+        session_info_map: &StorageMap,
+        subs: &SessionSubMap,
+        write_failures: &AtomicU64,
+    ) {
+        match session_info_map.insert(SESSION_SUB_MAP, subs).await {
+            Ok(()) => {} // success
+            Err(e) => {
+                log::error!("save subscriptions error, {e}");
+                write_failures.fetch_add(1, Ordering::Release);
+            }
         }
     }
 
@@ -308,9 +362,11 @@ impl StorageSession {
     async fn save_disconnect_info(&self) {
         let session_info_map = self.session_info_map.clone();
         let disconnect_info = self.inner.disconnect_info.read().await.clone();
+        let write_failures = self.write_failures.clone();
         tokio::spawn(async move {
             if let Err(e) = Self::_save_disconnect_info(session_info_map, &disconnect_info).await {
                 log::error!("save disconnect info error, {e}");
+                write_failures.fetch_add(1, Ordering::Release);
             }
         });
     }
@@ -555,6 +611,7 @@ impl SessionLike for StorageSession {
         let offline_messages_list = self.offline_messages_list.clone();
         let session_info_map = self.session_info_map.clone();
         let disconnect_info = self._disconnect_info().await;
+        let write_failures = self.write_failures.clone();
 
         tokio::spawn(async move {
             if let Err(e) = Self::_disconnected_set(
@@ -566,7 +623,8 @@ impl SessionLike for StorageSession {
             )
             .await
             {
-                log::error!("{id:?} disconnected set error, {e}")
+                log::error!("{id:?} disconnected set error, {e}");
+                write_failures.fetch_add(1, Ordering::Release);
             }
         });
 
@@ -588,6 +646,10 @@ impl SessionLike for StorageSession {
     async fn keepalive(&self, ping: IsPing) {
         log::debug!("ping: {ping}");
         if ping {
+            // tokio::spawn(async move {
+            //     Self::_update_last_time(id, &basic, &subs, ping, last_time, session_info_map, write_failures)
+            //         .await;
+            // });
             self.update_last_time(true).await;
         } else {
             self.update_last_time(false).await;


### PR DESCRIPTION
**Problem**
The circuit breaker implementation was refactored in rmqtt-storage 0.10.2 to use a single shared breaker for DB/Map/List operations. However, the message-storage, retainer, and session-storage plugins still used the old configuration schema and manually managed circuit breaker state.

**Solution**
- Update all three plugins to use the new unified circuit breaker from rmqtt-storage
- Replace ad-hoc circuit breaker config fields with `CircuitBreakerPluginConfig` (optional, with per-field defaults)
- Remove manual circuit breaker handling from plugin code
- Delegate all failure tracking to `CircuitBrokenDB` wrapper

**Key Changes**

Configuration:
- Add `CircuitBreakerPluginConfig` struct with all tunable parameters
- Remove old config fields (`circuit_breaker_enabled`, `failure_threshold`, etc.)
- Add `circuit_breaker` section to TOML configs with detailed comments
- Support `CountBased` and `TimeBased` sliding window types
- Default: TimeBased with 45s window, 0.25 failure rate threshold

Message Storage:
- Wrap storage DB with `CircuitBrokenDB` when `circuit-breaker` feature enabled
- Remove `CircuitBreaker` field from `StorageMessageManagerInner`
- Remove explicit `is_blocked()` checks (delegated to storage layer)
- Simplify worker loop (storage layer handles fast-fail)

Retainer:
- Wrap storage DB with `CircuitBrokenDB` when `circuit-breaker` feature enabled
- Remove `CircuitBreaker` field from `RetainerInner`
- Remove all manual success/failure recording
- Delegate circuit state to `CircuitBrokenDB::info()`
- Remove circuit breaker info from plugin attrs (now in storage_info)

Session Storage:
- Wrap storage DB with `CircuitBrokenDB` when `circuit-breaker` feature enabled
- Remove `Result` from `map()`/`list()` calls (no longer fallible)
- Add write failure tracking with automatic recovery detection
- Add `full_sync` on recovery to resync session data

Dependencies:
- Enable `circuit-breaker` feature in message-storage, retainer, session-storage
- Update rmqtt-storage dependency from 0.9 to 0.10.2

**Benefits**
- Unified circuit breaker behavior across all storage-backed plugins
- Consistent configuration schema
- Automatic failure tracking and recovery
- Reduced code duplication
- Better observability via `CircuitBrokenDB::info()`