### PR TITLE
docs: update circuit breaker documentation for all storage and cluster plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to RMQTT are documented in this file.
 
+## [Unreleased]
+
+### New Features
+
+- **Unified Circuit Breaker**: Integrated a sliding-window circuit breaker (`CircuitBreakerConfig`) across all storage plugins — `rmqtt-retainer`, `rmqtt-message-storage`, and `rmqtt-session-storage`. When the storage backend failure rate exceeds the threshold, the circuit opens and all operations fast-fail, preventing cascading failures. Configurable via `circuit_breaker.*` settings in each plugin's TOML.
+- **gRPC Client Circuit Breaker**: Added per-peer-node circuit breaker to `GrpcClient`, covering `send_message`, `quick_send_message`, `notify`, and `quick_notify`. Configurable via `node_grpc_circuit_breaker_enabled`, `node_grpc_circuit_failure_threshold`, `node_grpc_circuit_reset_timeout`, and `node_grpc_circuit_half_open_success_threshold` in cluster plugin configs.
+- **Retainer Cluster Synchronization**: Implemented cluster-wide retain message synchronization with two modes — `Full` (broadcast full payload, used by ram/sled) and `TopicOnly` (broadcast topic name only, used by redis). New `RetainStorage` trait methods: `retain_sync_mode()` and `sync_retain_topic()`.
+- **gRPC Quick Path**: Added `quick_send_message` / `quick_notify` fast paths that bypass request-queue-full checks for higher-priority operations. All HTTP API cross-node gRPC calls now use the quick path.
+- **Retainer In-Memory Topic Trie**: Built a `RetainTree` index in memory on startup for O(1) exact-topic lookups and fast wildcard matching, replacing the previous SCAN+MATCH approach.
+- **Retainer Batch Storage**: Messages are collected into a channel and processed in batches via `batch_insert` / `batch_remove`, controlled by `batch_messages_limit`.
+- **Rate Counter**: Added `rmqtt-utils::RateCounter` (lock-free `AtomicU64`) for tracking message processing throughput. Enabled by default via the `rate-counter` feature.
+- **Message Storage Timeout**: Added configurable `timeout` for storage I/O operations in `rmqtt-message-storage`.
+- **Cluster Broadcast Exec Queues**: Added `exec` and `forwards_exec` `TaskExecQueue` to `rmqtt-cluster-broadcast` for queue back-pressure management and busyness detection, aligning with `rmqtt-cluster-raft`.
+- **Retainer Enabled by Default**: `rmqtt-retainer` is now included in `plugins.default_startups` by default.
+
+### Refactoring
+
+- **Circuit Breaker Simplification**: Simplified `CircuitBreaker` in `rmqtt-utils` — consolidated configuration into `CircuitBreakerConfig` with sliding-window semantics (failure rate, slow call detection, per-operation timeout).
+- **Message Storage Refactor**: Removed `merge_on_read` and `TaskExecQueue` from `rmqtt-message-storage`; added `with_timeout` wrapper for storage operations; introduced async callback support and back-pressure limits.
+- **Session Storage Improvements**: Added detailed timing metrics for rebuild operations; improved init timing and timeout handling.
+- **Error Logging Normalization**: Normalized error logging across the workspace to use `Display` instead of `Debug` formatting.
+- **Cluster Retain Exec Queue**: Added a dedicated `retainer_exec` `TaskExecQueue` in `rmqtt-cluster-raft` for retain operations, separating from the main `exec` queue.
+
+### Configuration Changes
+
+- `rmqtt-retainer.toml`: Circuit breaker config changed from flat fields (`circuit_breaker_enabled`, `circuit_failure_threshold`, `circuit_reset_timeout`, `circuit_half_open_success_threshold`) to nested `circuit_breaker.*` sliding-window format. `retained_message_ttl` and `batch_messages_limit` are now uncommented by default.
+- `rmqtt-message-storage.toml`: `storage.ram.encode` default changed from `true` to `false`. Added `circuit_breaker.*` section.
+- `rmqtt-session-storage.toml`: Added `circuit_breaker.*` section.
+- `rmqtt-cluster-broadcast.toml` / `rmqtt-cluster-raft.toml`: Added gRPC circuit breaker settings (`node_grpc_circuit_breaker_enabled`, etc.). `rmqtt-cluster-raft.toml`: `node_grpc_client_timeout` default changed from `"60s"` to `"10s"`. `raft.snapshot_interval` default changed from `"600s"` to `"300s"`.
+
+---
+
 ## [0.22.0] - 2026-05
 
 ### Major Changes

--- a/docs/en_US/cluster-raft.md
+++ b/docs/en_US/cluster-raft.md
@@ -113,7 +113,12 @@ node_grpc_batch_size = 128
 ##Client concurrent request limit
 node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
-node_grpc_client_timeout = "60s"
+node_grpc_client_timeout = "10s"
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3
 
 # The list of Raft peer addresses for the nodes in the cluster.
 # Each entry contains the node ID and the corresponding IP address and port for Raft consensus communication.
@@ -167,7 +172,7 @@ raft.grpc_breaker_threshold = 5
 raft.grpc_breaker_retry_interval = "2500ms"
 raft.proposal_batch_size = 60
 raft.proposal_batch_timeout = "200ms"
-raft.snapshot_interval = "600s"
+raft.snapshot_interval = "300s"
 raft.heartbeat = "100ms"
 
 raft.election_tick = 10
@@ -187,6 +192,8 @@ raft.priority = 0
 
 - `'node_grpc_addrs'` is primarily used for message forwarding during publish, while `'raft_peer_addrs'` is used for 
    synchronizing raft cluster messages.
+
+- `'node_grpc_circuit_breaker_enabled'` and related settings configure the gRPC client circuit breaker. Each peer node has an independent breaker. When gRPC calls to a node fail consecutively more than `node_grpc_circuit_failure_threshold` (default: 10) times, the breaker opens and subsequent requests to that node fast-fail. After `node_grpc_circuit_reset_timeout` (default: `"15s"`) the breaker enters half-open state, requiring `node_grpc_circuit_half_open_success_threshold` (default: 3) consecutive successes to close.
 
 - `'laddr'` specifies the Raft listening address. If not specified, it will default to the address configured in `'raft_peer_addrs'`.
 

--- a/docs/en_US/retainer.md
+++ b/docs/en_US/retainer.md
@@ -56,24 +56,49 @@ max_payload_size = "1MB"
 
 # TTL for retained messages. Set to 0 for no expiration.
 # If not specified, the message expiration time will be used by default.
-#retained_message_ttl = "0m"
+retained_message_ttl = "0m"
 
 # Maximum number of messages per batch (default: 500).
-#batch_messages_limit = 500
+batch_messages_limit = 500
 
 ##─── Circuit breaker ──────────────────────────────────────────────
-##Enable circuit breaker. When storage fails consecutively beyond the threshold,
-##all retain operations fast-fail without touching the storage backend.
-#circuit_breaker_enabled = true
-
-##Consecutive storage failures before tripping the circuit to OPEN (fast-fail).
-#circuit_failure_threshold = 10
-
+##Optional circuit-breaker tuning.
+##When this section is absent (or commented out), the built-in
+##CircuitBreakerConfig::default() is used verbatim.
+##Only the fields you explicitly set override the defaults.
+##
+##Failure rate threshold (0.0 – 1.0). Default: 0.25
+#circuit_breaker.failure_rate_threshold = 0.25
+##
+##Sliding window type: "CountBased" or "TimeBased". Default: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+##
+##Sliding window size (number of calls). Default: 20
+#circuit_breaker.sliding_window_size = 20
+##
+##Sliding window duration for TimeBased mode.
+##Only used when sliding_window_type is "TimeBased".
+##Calls older than this duration are excluded from the failure rate.
+##Default: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+##
+##Minimum number of calls before the breaker can trip.
+##Prevents premature tripping during low-traffic periods.
+##Default: 10
+#circuit_breaker.minimum_number_of_calls = 10
+##
 ##Duration in OPEN state before transitioning to HALF_OPEN (probe).
-#circuit_reset_timeout = "15s"
-
-##Consecutive probe successes needed to close the circuit.
-#circuit_half_open_success_threshold = 3
+##Default: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+##
+##Slow call duration threshold. Default: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+##
+##Slow call rate threshold (0.0 – 1.0). 1.0 = disabled. Default: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+##
+##Per-operation timeout. Set to "0s" to disable. Default: "8s"
+#circuit_breaker.operation_timeout = "8s"
 ```
 
 Currently, three storage modes are supported: "ram", "sled", and "redis".
@@ -89,7 +114,7 @@ time for retained messages. A value of `"0m"` means no expiration. If not specif
 "batch_messages_limit" limits the maximum number of messages processed in a single batch store operation (default: 500).
 When a large number of retained messages arrive at once, they are grouped into batches of this size for efficient processing.
 
-The **Circuit Breaker** prevents cascading failures when the storage backend becomes unavailable. When the number of consecutive storage failures exceeds `circuit_failure_threshold` (default: 10), the circuit trips to **OPEN** state and all retain operations (set/get) fast-fail without touching the storage. After `circuit_reset_timeout` (default: `"15s"`), the circuit transitions to **HALF_OPEN** and allows a probe request. If the probe succeeds, the circuit closes; otherwise it re-opens. `circuit_half_open_success_threshold` (default: 3) controls how many consecutive probe successes are needed to close the circuit.
+The **Circuit Breaker** prevents cascading failures when the storage backend becomes unavailable. The breaker uses a sliding window to track the call failure rate. When the failure rate exceeds `circuit_breaker.failure_rate_threshold` (default: 0.25, i.e. 25%) and the minimum number of calls `circuit_breaker.minimum_number_of_calls` (default: 10) has been reached, the circuit trips to **OPEN** state and all retain operations fast-fail without touching the storage. After `circuit_breaker.wait_duration_in_open` (default: `"30s"`), the circuit transitions to **HALF_OPEN** and allows a probe request. If the probe succeeds, the circuit closes; otherwise it re-opens. Additionally, `circuit_breaker.slow_call_duration_threshold` (default: `"2s"`) combined with `circuit_breaker.slow_call_rate_threshold` can detect slow calls, and `circuit_breaker.operation_timeout` (default: `"8s"`) sets a per-operation timeout. The sliding window type can be `CountBased` (by call count) or `TimeBased` (by time, default), configured via `circuit_breaker.sliding_window_type`.
 
 If RMQTT is deployed in single-node mode, then "ram", "sled", and "redis" are all supported storage modes. 
 In cluster mode, all three storage modes are also supported; for "redis" mode, a lightweight topic-only 

--- a/docs/en_US/store-message.md
+++ b/docs/en_US/store-message.md
@@ -30,7 +30,7 @@ storage.type = "ram"
 ##ram
 storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
-storage.ram.encode = true
+storage.ram.encode = false
 
 ##Maximum pending messages in the in-memory channel (back-pressure limit).
 ##Default: 300000
@@ -49,12 +49,57 @@ cleanup_count = 5000
 
 ##Timeout for storage I/O operations. 0 = no timeout.
 timeout = "5s"
+
+##─── Circuit breaker ─────────────────────────────────────────────────────────
+##Optional circuit-breaker tuning.
+##When this section is absent (or commented out), the built-in
+##CircuitBreakerConfig::default() is used verbatim.
+##Only the fields you explicitly set override the defaults.
+##
+##Failure rate threshold (0.0 – 1.0). Default: 0.25
+##When the sliding-window failure rate exceeds this value, the
+##circuit trips to OPEN and all storage operations fast-fail.
+#circuit_breaker.failure_rate_threshold = 0.25
+##
+##Sliding window type: "CountBased" or "TimeBased". Default: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+##
+##Sliding window size (number of calls). Default: 20
+#circuit_breaker.sliding_window_size = 20
+##
+##Sliding window duration for TimeBased mode.
+##Only used when sliding_window_type is "TimeBased".
+##Calls older than this duration are excluded from the failure rate.
+##Default: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+##
+##Minimum number of calls before the breaker can trip.
+##Prevents premature tripping during low-traffic periods.
+##Default: 10
+#circuit_breaker.minimum_number_of_calls = 10
+##
+##Duration in OPEN state before transitioning to HALF_OPEN (probe).
+##Default: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+##
+##Slow call duration threshold. Default: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+##
+##Slow call rate threshold (0.0 – 1.0). 1.0 = disabled. Default: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+##
+##Per-operation timeout. Set to "0s" to disable. Default: "8s"
+#circuit_breaker.operation_timeout = "8s"
 ```
 
 Currently, three storage engines are supported: "ram," "redis," and "redis-cluster." "ram" is stored in local memory and 
 can be configured with maximum memory usage or maximum message count, and it can specify whether messages should be encoded 
 before storage. Prefix configuration allows different rmqtt nodes to use the same Redis storage service. `{node}` will be 
 replaced by the identifier of the current node.
+
+`timeout` configures the timeout for storage I/O operations. Set to `0` for no timeout.
+
+The **Circuit Breaker** prevents cascading failures when the storage backend becomes unavailable. The breaker uses a sliding window to track the call failure rate. When the failure rate exceeds `circuit_breaker.failure_rate_threshold` (default: 0.25) and the minimum number of calls `circuit_breaker.minimum_number_of_calls` (default: 10) has been reached, the circuit trips to **OPEN** state and all storage operations fast-fail. After `circuit_breaker.wait_duration_in_open` (default: `"30s"`) the circuit transitions to **HALF_OPEN** for probe testing. `circuit_breaker.slow_call_duration_threshold` (default: `"2s"`) can detect slow calls, and `circuit_breaker.operation_timeout` (default: `"8s"`) sets a per-operation timeout.
 
 
 By default, this plugin is not enabled. To activate it, you must add the `rmqtt-message-storage` entry to the

--- a/docs/en_US/store-session.md
+++ b/docs/en_US/store-session.md
@@ -46,12 +46,58 @@ storage.redis.prefix = "session-{node}"
 ##redis-cluster
 storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
 storage.redis-cluster.prefix = "session-{node}"
+
+##─── Circuit breaker ─────────────────────────────────────────────────────────
+##Uncomment the following section to customize circuit-breaker behaviour.
+##When the whole section is absent, the upstream default is used verbatim.
+
+##Failure rate threshold (0.0 – 1.0). When exceeded, circuit opens.
+##Default: 0.25
+#circuit_breaker.failure_rate_threshold = 0.25
+
+##Sliding window type: "CountBased" or "TimeBased".
+##  CountBased — window slides after N calls (sliding_window_size).
+##  TimeBased  — window slides after a fixed duration (e.g. 45s).
+##Default: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+
+##Sliding window size (number of calls) for CountBased type.
+##For TimeBased, this value sets the max tracked calls (fallback for minimum_number_of_calls).
+##Default: 20
+#circuit_breaker.sliding_window_size = 20
+
+##Sliding window duration for TimeBased type (e.g. "45s").
+##Only used when sliding_window_type is "TimeBased".
+##Default: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+
+##Minimum calls before the breaker can trip.
+##Default: 10
+#circuit_breaker.minimum_number_of_calls = 10
+
+##Duration in OPEN state before transitioning to HALF_OPEN (probe).
+##Default: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+
+##Slow call duration threshold.
+##Default: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+
+##Slow call rate threshold (0.0 – 1.0). 1.0 = disabled.
+##Default: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+
+##Per-operation timeout. Set to "0s" to disable.
+##Default: "15s"
+#circuit_breaker.operation_timeout = "15s"
 ```
 
 Currently, three storage engines are supported: "sled," "redis," and "redis-cluster." "sled" is stored locally, requiring 
 configuration for the storage location and in-memory cache size, with an appropriate size improving read and write efficiency.
 Prefix configuration enables different rmqtt nodes to use the same Redis storage service. `{node}` will be replaced with 
 the current node identifier.
+
+The **Circuit Breaker** prevents cascading failures when the storage backend becomes unavailable. The breaker uses a sliding window to track the call failure rate. When the failure rate exceeds `circuit_breaker.failure_rate_threshold` (default: 0.25) and the minimum number of calls `circuit_breaker.minimum_number_of_calls` (default: 10) has been reached, the circuit trips to **OPEN** state and all session storage operations fast-fail. After `circuit_breaker.wait_duration_in_open` (default: `"30s"`) the circuit transitions to **HALF_OPEN** for probe testing. `circuit_breaker.operation_timeout` (default: `"15s"`) sets a per-operation timeout.
 
 
 By default, this plugin is not enabled. To activate it, you must add the `rmqtt-session-storage` entry to the

--- a/docs/zh_CN/cluster-raft.md
+++ b/docs/zh_CN/cluster-raft.md
@@ -100,7 +100,12 @@ node_grpc_batch_size = 128
 ##Client concurrent request limit
 node_grpc_client_concurrency_limit = 128
 ##Connect and send to server timeout
-node_grpc_client_timeout = "60s"
+node_grpc_client_timeout = "10s"
+##gRPC circuit breaker settings
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3
 
 # The list of Raft peer addresses for the nodes in the cluster.
 # Each entry contains the node ID and the corresponding IP address and port for Raft consensus communication.
@@ -151,7 +156,7 @@ raft.grpc_breaker_threshold = 5
 raft.grpc_breaker_retry_interval = "2500ms"
 raft.proposal_batch_size = 60
 raft.proposal_batch_timeout = "200ms"
-raft.snapshot_interval = "600s"
+raft.snapshot_interval = "300s"
 raft.heartbeat = "100ms"
 
 raft.election_tick = 10
@@ -170,6 +175,8 @@ raft.priority = 0
 ```
 
 - 'node_grpc_addrs' 主要用于Publish消息转发，'raft_peer_addrs'用于raft集群消息的同步。
+
+- 'node_grpc_circuit_breaker_enabled' 等配置项用于 gRPC 客户端熔断器。每个 peer 节点拥有独立的熔断器，当 gRPC 调用连续失败超过 `node_grpc_circuit_failure_threshold`（默认值：10）次时，熔断器打开，后续对该节点的请求快速失败。经过 `node_grpc_circuit_reset_timeout`（默认值：`"15s"`）后进入半开状态，需要 `node_grpc_circuit_half_open_success_threshold`（默认值：3）次连续成功才能关闭熔断器。
 
 - 'laddr' 用于指定Raft监听地址，如果不指定，将默认使用'raft_peer_addrs'中配置的地址。
 

--- a/docs/zh_CN/retainer.md
+++ b/docs/zh_CN/retainer.md
@@ -52,24 +52,49 @@ max_payload_size = "1MB"
 
 # TTL for retained messages. Set to 0 for no expiration.
 # If not specified, the message expiration time will be used by default.
-#retained_message_ttl = "0m"
+retained_message_ttl = "0m"
 
 # Maximum number of messages per batch (default: 500).
-#batch_messages_limit = 500
+batch_messages_limit = 500
 
 ##─── Circuit breaker ──────────────────────────────────────────────
-##Enable circuit breaker. When storage fails consecutively beyond the threshold,
-##all retain operations fast-fail without touching the storage backend.
-#circuit_breaker_enabled = true
-
-##Consecutive storage failures before tripping the circuit to OPEN (fast-fail).
-#circuit_failure_threshold = 10
-
+##Optional circuit-breaker tuning.
+##When this section is absent (or commented out), the built-in
+##CircuitBreakerConfig::default() is used verbatim.
+##Only the fields you explicitly set override the defaults.
+##
+##Failure rate threshold (0.0 – 1.0). Default: 0.25
+#circuit_breaker.failure_rate_threshold = 0.25
+##
+##Sliding window type: "CountBased" or "TimeBased". Default: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+##
+##Sliding window size (number of calls). Default: 20
+#circuit_breaker.sliding_window_size = 20
+##
+##Sliding window duration for TimeBased mode.
+##Only used when sliding_window_type is "TimeBased".
+##Calls older than this duration are excluded from the failure rate.
+##Default: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+##
+##Minimum number of calls before the breaker can trip.
+##Prevents premature tripping during low-traffic periods.
+##Default: 10
+#circuit_breaker.minimum_number_of_calls = 10
+##
 ##Duration in OPEN state before transitioning to HALF_OPEN (probe).
-#circuit_reset_timeout = "15s"
-
-##Consecutive probe successes needed to close the circuit.
-#circuit_half_open_success_threshold = 3
+##Default: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+##
+##Slow call duration threshold. Default: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+##
+##Slow call rate threshold (0.0 – 1.0). 1.0 = disabled. Default: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+##
+##Per-operation timeout. Set to "0s" to disable. Default: "8s"
+#circuit_breaker.operation_timeout = "8s"
 ```
 
 当前支持 "ram"、"sled" 和 "redis" 三种存储模式。"ram" 是存储在内存。"sled" 是存储在本地磁盘，需要配置存储位置和在内存中的缓存容量，适当大小可以提高读写效率。
@@ -80,7 +105,7 @@ max_payload_size = "1MB"
 
 "batch_messages_limit" 限制单次批量存储操作处理的最大消息数（默认值：500）。当大量保留消息同时到达时，会按此大小分组进行批量处理以提高效率。
 
-**熔断器（Circuit Breaker）** 防止存储后端不可用时发生级联故障。当连续存储失败次数超过 `circuit_failure_threshold`（默认值：10）时，熔断器进入 **OPEN** 状态，所有保留消息操作（set/get）快速失败，不再访问存储后端。经过 `circuit_reset_timeout`（默认值：`"15s"`）后，熔断器进入 **HALF_OPEN** 状态并允许探针请求。如果探针成功，熔断器关闭；否则重新打开。`circuit_half_open_success_threshold`（默认值：3）控制关闭熔断器所需的连续探针成功次数。
+**熔断器（Circuit Breaker）** 防止存储后端不可用时发生级联故障。熔断器使用滑动窗口统计调用失败率，当失败率超过 `circuit_breaker.failure_rate_threshold`（默认值：0.25，即 25%）且达到 `circuit_breaker.minimum_number_of_calls`（默认值：10）最小调用次数时，熔断器进入 **OPEN** 状态，所有保留消息操作快速失败，不再访问存储后端。经过 `circuit_breaker.wait_duration_in_open`（默认值：`"30s"`）后，熔断器进入 **HALF_OPEN** 状态并允许探针请求。如果探针成功，熔断器关闭；否则重新打开。此外，`circuit_breaker.slow_call_duration_threshold`（默认值：`"2s"`）配合 `circuit_breaker.slow_call_rate_threshold` 可检测慢调用，`circuit_breaker.operation_timeout`（默认值：`"8s"`）为每个操作设置超时。滑动窗口类型可选 `CountBased`（按调用次数）或 `TimeBased`（按时间，默认），通过 `circuit_breaker.sliding_window_type` 配置。
 
 如果 RMQTT 部署为单机模式，"ram"、"sled" 和 "redis" 都是支持的。集群模式下同样支持所有三种存储模式；
 对于 "redis" 模式，使用轻量级的仅主题同步机制来减少节点间流量。

--- a/docs/zh_CN/store-message.md
+++ b/docs/zh_CN/store-message.md
@@ -29,7 +29,7 @@ storage.type = "ram"
 ##ram
 storage.ram.cache_capacity = "3G"
 storage.ram.cache_max_count = 1_000_000
-storage.ram.encode = true
+storage.ram.encode = false
 
 ##Maximum pending messages in the in-memory channel (back-pressure limit).
 ##默认值: 300000
@@ -48,10 +48,53 @@ cleanup_count = 5000
 
 ##存储 I/O 操作超时。0 = 不超时。
 timeout = "5s"
+
+##─── Circuit breaker ─────────────────────────────────────────────────────────
+##可选熔断器调优。
+##当此段落缺失（或注释掉）时，直接使用内置 CircuitBreakerConfig::default() 默认值。
+##仅显式设置的字段会覆盖默认值。
+##
+##失败率阈值 (0.0 – 1.0)。默认值: 0.25
+##当滑动窗口内失败率超过此值时，熔断器跳转到 OPEN 状态，所有存储操作快速失败。
+#circuit_breaker.failure_rate_threshold = 0.25
+##
+##滑动窗口类型："CountBased" 或 "TimeBased"。默认值: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+##
+##滑动窗口大小（调用次数）。默认值: 20
+#circuit_breaker.sliding_window_size = 20
+##
+##TimeBased 模式下的滑动窗口持续时间。
+##仅当 sliding_window_type 为 "TimeBased" 时使用。
+##超过此时间的调用将从失败率计算中排除。
+##默认值: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+##
+##熔断器跳闸前的最小调用次数。
+##防止低流量时段过早跳闸。
+##默认值: 10
+#circuit_breaker.minimum_number_of_calls = 10
+##
+##OPEN 状态持续时间，过后转入 HALF_OPEN（探针）状态。
+##默认值: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+##
+##慢调用持续时间阈值。默认值: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+##
+##慢调用率阈值 (0.0 – 1.0)。1.0 = 禁用。默认值: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+##
+##单次操作超时。设为 "0s" 禁用。默认值: "8s"
+#circuit_breaker.operation_timeout = "8s"
 ```
 
-当前支持“ram”、“redis”和“redis-cluster”三种存储引擎。“ram”是存储在本地内存，可以配置最大使用内存容量或最大消息数量，以及可以指示消息是否编码后再存储。
+当前支持"ram"、"redis"和"redis-cluster"三种存储引擎。"ram"是存储在本地内存，可以配置最大使用内存容量或最大消息数量，以及可以指示消息是否编码后再存储。
 前缀配置方便不同rmqtt节点使用同一套redis存储服务。{node}将被替换为当前节点标识。
+
+`timeout` 配置存储 I/O 操作的超时时间，设为 `0` 表示不超时。
+
+**熔断器（Circuit Breaker）** 防止存储后端不可用时发生级联故障。熔断器使用滑动窗口统计调用失败率，当失败率超过 `circuit_breaker.failure_rate_threshold`（默认值：0.25）且达到 `circuit_breaker.minimum_number_of_calls`（默认值：10）最小调用次数时，熔断器进入 **OPEN** 状态，所有存储操作快速失败。经过 `circuit_breaker.wait_duration_in_open`（默认值：`"30s"`）后进入 **HALF_OPEN** 状态进行探针探测。`circuit_breaker.slow_call_duration_threshold`（默认值：`"2s"`）可检测慢调用，`circuit_breaker.operation_timeout`（默认值：`"8s"`）为每个操作设置超时。
 
 默认情况下并没有启动此插件，如果要开启此插件，必须在主配置文件“rmqtt.toml”中的“plugins.default_startups”配置中添加“rmqtt-message-storage”项，如：
 ```bash

--- a/docs/zh_CN/store-session.md
+++ b/docs/zh_CN/store-session.md
@@ -42,10 +42,56 @@ storage.redis.prefix = "session-{node}"
 ##redis-cluster
 storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
 storage.redis-cluster.prefix = "session-{node}"
+
+##─── Circuit breaker ─────────────────────────────────────────────────────────
+##可选熔断器调优。当此段落缺失时，直接使用上游默认值。
+##仅显式设置的字段会覆盖默认值。
+
+##失败率阈值 (0.0 – 1.0)。超过此值时熔断器打开。
+##默认值: 0.25
+#circuit_breaker.failure_rate_threshold = 0.25
+
+##滑动窗口类型："CountBased" 或 "TimeBased"。
+##  CountBased — 窗口在 N 次调用后滑动 (sliding_window_size)。
+##  TimeBased  — 窗口在固定持续时间后滑动 (如 45s)。
+##默认值: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+
+##CountBased 类型的滑动窗口大小（调用次数）。
+##对于 TimeBased，此值设置最大跟踪调用数。
+##默认值: 20
+#circuit_breaker.sliding_window_size = 20
+
+##TimeBased 类型的滑动窗口持续时间 (如 "45s")。
+##仅当 sliding_window_type 为 "TimeBased" 时使用。
+##默认值: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+
+##熔断器跳闸前的最小调用次数。
+##默认值: 10
+#circuit_breaker.minimum_number_of_calls = 10
+
+##OPEN 状态持续时间，过后转入 HALF_OPEN（探针）状态。
+##默认值: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+
+##慢调用持续时间阈值。
+##默认值: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+
+##慢调用率阈值 (0.0 – 1.0)。1.0 = 禁用。
+##默认值: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+
+##单次操作超时。设为 "0s" 禁用。
+##默认值: "15s"
+#circuit_breaker.operation_timeout = "15s"
 ```
 
-当前支持“sled”、“redis”和“redis-cluster”三种存储引擎。“sled”是存储在本地，需要配置存储位置和在内存中的缓存容量，适当大小可以提高读写效率。
+当前支持"sled"、"redis"和"redis-cluster"三种存储引擎。"sled"是存储在本地，需要配置存储位置和在内存中的缓存容量，适当大小可以提高读写效率。
 前缀配置方便不同rmqtt节点使用同一套redis存储服务。{node}将被替换为当前节点标识。
+
+**熔断器（Circuit Breaker）** 防止存储后端不可用时发生级联故障。熔断器使用滑动窗口统计调用失败率，当失败率超过 `circuit_breaker.failure_rate_threshold`（默认值：0.25）且达到 `circuit_breaker.minimum_number_of_calls`（默认值：10）最小调用次数时，熔断器进入 **OPEN** 状态，所有会话存储操作快速失败。经过 `circuit_breaker.wait_duration_in_open`（默认值：`"30s"`）后进入 **HALF_OPEN** 状态进行探针探测。`circuit_breaker.operation_timeout`（默认值：`"15s"`）为每个操作设置超时。
 
 默认情况下并没有启动此插件，如果要开启此插件，必须在主配置文件“rmqtt.toml”中的“plugins.default_startups”配置中添加“rmqtt-session-storage”项，如：
 ```bash

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/README-CN.md
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/README-CN.md
@@ -27,7 +27,11 @@ rmqtt_cluster_broadcast::register(&scx, true, false).await?;
 | `node_grpc_addrs` | array of string | `["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]` | 集群节点 gRPC 地址 |
 | `node_grpc_batch_size` | integer | `128` | 批量发送的最大消息数 |
 | `node_grpc_client_concurrency_limit` | integer | `128` | 客户端并发请求限制 |
-| `node_grpc_client_timeout` | string | `"60s"` | 连接和发送超时 |
+| `node_grpc_client_timeout` | string | `"15s"` | 连接和发送超时 |
+| `node_grpc_circuit_breaker_enabled` | boolean | `true` | 启用 gRPC 熔断器 |
+| `node_grpc_circuit_failure_threshold` | integer | `10` | 连续失败次数超过此值后跳闸到 OPEN |
+| `node_grpc_circuit_reset_timeout` | string | `"15s"` | OPEN 状态持续时间，之后进入探测（HALF_OPEN） |
+| `node_grpc_circuit_half_open_success_threshold` | integer | `3` | HALF_OPEN 状态下连续成功次数达到此值后关闭电路 |
 | `task_exec_queue_workers` | integer | `500` | 任务执行队列工作线程数 |
 | `task_exec_queue_max` | integer | `100_000` | 任务执行队列最大容量 |
 

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/README.md
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/README.md
@@ -27,7 +27,11 @@ File: `rmqtt-cluster-broadcast.toml`
 | `node_grpc_addrs` | array of string | `["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]` | Cluster node gRPC addresses |
 | `node_grpc_batch_size` | integer | `128` | Maximum messages sent in batch |
 | `node_grpc_client_concurrency_limit` | integer | `128` | Client concurrent request limit |
-| `node_grpc_client_timeout` | string | `"60s"` | Connect and send timeout |
+| `node_grpc_client_timeout` | string | `"15s"` | Connect and send timeout |
+| `node_grpc_circuit_breaker_enabled` | boolean | `true` | Enable gRPC circuit breaker |
+| `node_grpc_circuit_failure_threshold` | integer | `10` | Consecutive failures before tripping to OPEN |
+| `node_grpc_circuit_reset_timeout` | string | `"15s"` | Duration in OPEN before probing (HALF_OPEN) |
+| `node_grpc_circuit_half_open_success_threshold` | integer | `3` | Consecutive probe successes to close the circuit |
 | `task_exec_queue_workers` | integer | `500` | Task execution queue workers |
 | `task_exec_queue_max` | integer | `100_000` | Task execution queue max capacity |
 

--- a/rmqtt-plugins/rmqtt-cluster-raft/README-CN.md
+++ b/rmqtt-plugins/rmqtt-cluster-raft/README-CN.md
@@ -56,7 +56,11 @@ rmqttd --id 1 --plugins-default-startups "rmqtt-cluster-raft" \
 | `node_grpc_addrs` | array of string | `["1@127.0.0.1:5363", ...]` | 集群节点 gRPC 地址 |
 | `node_grpc_batch_size` | integer | `128` | 批量发送的最大消息数 |
 | `node_grpc_client_concurrency_limit` | integer | `128` | 客户端并发请求限制 |
-| `node_grpc_client_timeout` | string | `"60s"` | 连接和发送超时 |
+| `node_grpc_client_timeout` | string | `"10s"` | 连接和发送超时 |
+| `node_grpc_circuit_breaker_enabled` | boolean | `true` | 启用 gRPC 熔断器 |
+| `node_grpc_circuit_failure_threshold` | integer | `10` | 连续失败次数超过此值后跳闸到 OPEN |
+| `node_grpc_circuit_reset_timeout` | string | `"15s"` | OPEN 状态持续时间，之后进入探测（HALF_OPEN） |
+| `node_grpc_circuit_half_open_success_threshold` | integer | `3` | HALF_OPEN 状态下连续成功次数达到此值后关闭电路 |
 | `laddr` | string | — | Raft 集群监听地址（可选） |
 
 ### Raft 对端

--- a/rmqtt-plugins/rmqtt-cluster-raft/README.md
+++ b/rmqtt-plugins/rmqtt-cluster-raft/README.md
@@ -56,7 +56,11 @@ Compression algorithms: `lz4_flex`, `lz4`, `zstd`, `snap`, `flate2`
 | `node_grpc_addrs` | array of string | `["1@127.0.0.1:5363", ...]` | Cluster node gRPC addresses |
 | `node_grpc_batch_size` | integer | `128` | Maximum messages sent in batch |
 | `node_grpc_client_concurrency_limit` | integer | `128` | Client concurrent request limit |
-| `node_grpc_client_timeout` | string | `"60s"` | Connect and send timeout |
+| `node_grpc_client_timeout` | string | `"10s"` | Connect and send timeout |
+| `node_grpc_circuit_breaker_enabled` | boolean | `true` | Enable gRPC circuit breaker |
+| `node_grpc_circuit_failure_threshold` | integer | `10` | Consecutive failures before tripping to OPEN |
+| `node_grpc_circuit_reset_timeout` | string | `"15s"` | Duration in OPEN before probing (HALF_OPEN) |
+| `node_grpc_circuit_half_open_success_threshold` | integer | `3` | Consecutive probe successes to close the circuit |
 | `laddr` | string | — | Raft cluster listening address (optional) |
 
 ### Raft Peers

--- a/rmqtt-plugins/rmqtt-message-storage/README-CN.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README-CN.md
@@ -60,27 +60,33 @@ rmqtt_message_storage::register(&scx, true, false).await?;
 
 ### 熔断器
 
-保护 Broker 在 Redis 后端不可用时不会被阻塞。电路 OPEN 时，
-store/mark_forwarded/get 会立即返回，不碰 Redis。熔断器会自动探测恢复。
+保护 Broker 在存储后端不可用时不会被阻塞。熔断器使用滑动窗口统计调用失败率，
+当失败率超过阈值且达到最小调用次数时，熔断器跳转到 OPEN 状态，所有存储操作快速
+失败。熔断器会自动探测恢复。
 
 | 选项 | 类型 | 默认值 | 描述 |
 |------|------|--------|------|
-| `circuit_breaker_enabled` | boolean | `true` | 启用熔断器 |
-| `circuit_failure_threshold` | integer | `10` | 连续失败次数超过此值后跳闸到 OPEN |
-| `circuit_reset_timeout` | string | `"15s"` | OPEN 状态下等待多久后进入探测（HALF_OPEN） |
-| `circuit_half_open_success_threshold` | integer | `3` | HALF_OPEN 状态下连续成功次数达到此值后关闭电路 |
+| `circuit_breaker.failure_rate_threshold` | `f64` | `0.25` | 失败率阈值 (0.0–1.0)，超过后跳闸到 OPEN |
+| `circuit_breaker.sliding_window_type` | `string` | `"TimeBased"` | 滑动窗口类型：`CountBased` 或 `TimeBased` |
+| `circuit_breaker.sliding_window_size` | `usize` | `20` | 滑动窗口大小（调用次数） |
+| `circuit_breaker.sliding_window_duration` | `string` | `"45s"` | 滑动窗口持续时间（仅 TimeBased 模式） |
+| `circuit_breaker.minimum_number_of_calls` | `usize` | `10` | 熔断器跳闸前的最小调用次数 |
+| `circuit_breaker.wait_duration_in_open` | `string` | `"30s"` | OPEN 状态下等待多久后进入探测（HALF_OPEN） |
+| `circuit_breaker.slow_call_duration_threshold` | `string` | `"2s"` | 慢调用持续时间阈值 |
+| `circuit_breaker.slow_call_rate_threshold` | `f64` | `1.0` | 慢调用率阈值（1.0 = 禁用） |
+| `circuit_breaker.operation_timeout` | `string` | `"8s"` | 单次操作超时（`"0s"` 禁用） |
 
 #### 状态机
 
 ```
-CLOSED ── 失败次数 ≥ 阈值 ──► OPEN ── 超时 ──► HALF_OPEN
-  ▲                                                    │
-  └─────────── 成功次数 ≥ 阈值 ◄────────────────────────┘
+CLOSED ── 失败率 ≥ 阈值 (满足最小调用数) ──► OPEN ── 等待时间 ──► HALF_OPEN
+  ▲                                                                     │
+  └─────────────────── 探测成功 ◄───────────────────────────────────────┘
 ```
 
-- **CLOSED**：正常运行，统计失败次数。
-- **OPEN**：所有操作跳过 Redis；worker 直接丢弃积压消息不等待。
-- **HALF_OPEN**：允许探测请求；连续成功达到阈值后关闭，任意失败立即回到 OPEN。
+- **CLOSED**：正常运行；调用在滑动窗口中被跟踪。
+- **OPEN**：所有操作快速失败，不访问存储后端。
+- **HALF_OPEN**：允许有限数量的探测请求；成功则关闭熔断器，失败则重新打开。
 
 ## 依赖
 

--- a/rmqtt-plugins/rmqtt-message-storage/README.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README.md
@@ -60,29 +60,36 @@ File: `rmqtt-message-storage.toml`
 
 ### Circuit Breaker
 
-Protects the broker from blocking when the Redis backend becomes unreachable.
-When the circuit is OPEN, store/mark_forwarded/get return immediately without
-touching Redis. The circuit automatically probes for recovery.
+Protects the broker from blocking when the storage backend becomes unreachable.
+The breaker uses a sliding window to track the call failure rate. When the failure
+rate exceeds the threshold and the minimum number of calls has been reached, the
+circuit trips to OPEN and all storage operations fast-fail. The circuit automatically
+probes for recovery.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `circuit_breaker_enabled` | boolean | `true` | Enable circuit breaker |
-| `circuit_failure_threshold` | integer | `10` | Consecutive failures before tripping to OPEN |
-| `circuit_reset_timeout` | string | `"15s"` | Wait duration in OPEN before probing (HALF_OPEN) |
-| `circuit_half_open_success_threshold` | integer | `3` | Consecutive probe successes to close the circuit |
+| `circuit_breaker.failure_rate_threshold` | `f64` | `0.25` | Failure rate threshold (0.0–1.0) for tripping to OPEN |
+| `circuit_breaker.sliding_window_type` | `string` | `"TimeBased"` | Sliding window type: `CountBased` or `TimeBased` |
+| `circuit_breaker.sliding_window_size` | `usize` | `20` | Sliding window size (number of calls) |
+| `circuit_breaker.sliding_window_duration` | `string` | `"45s"` | Sliding window duration (TimeBased mode only) |
+| `circuit_breaker.minimum_number_of_calls` | `usize` | `10` | Minimum calls before the breaker can trip |
+| `circuit_breaker.wait_duration_in_open` | `string` | `"30s"` | Duration in OPEN before probing (HALF_OPEN) |
+| `circuit_breaker.slow_call_duration_threshold` | `string` | `"2s"` | Slow call duration threshold |
+| `circuit_breaker.slow_call_rate_threshold` | `f64` | `1.0` | Slow call rate threshold (1.0 = disabled) |
+| `circuit_breaker.operation_timeout` | `string` | `"8s"` | Per-operation timeout (`"0s"` to disable) |
 
 #### State Machine
 
 ```
-CLOSED ── failure_count ≥ threshold ──► OPEN ── timeout ──► HALF_OPEN
-  ▲                                                               │
-  └────────────── success × threshold ◄───────────────────────────┘
+CLOSED ── failure_rate ≥ threshold (min_calls met) ──► OPEN ── wait_duration ──► HALF_OPEN
+  ▲                                                                            │
+  └────────────────── probe success ◄──────────────────────────────────────────┘
 ```
 
-- **CLOSED**: normal operation, failures are counted.
-- **OPEN**: all operations skip Redis immediately; workers drain backlog without waiting.
-- **HALF_OPEN**: probe requests are allowed; if enough succeed the circuit closes,
-  if any fails it re-opens.
+- **CLOSED**: normal operation; calls are tracked in the sliding window.
+- **OPEN**: all operations fast-fail without touching the storage backend.
+- **HALF_OPEN**: a limited number of probe requests are allowed; if they succeed the
+  circuit closes, if any fail it re-opens.
 
 ## Dependencies
 

--- a/rmqtt-plugins/rmqtt-retainer/README-CN.md
+++ b/rmqtt-plugins/rmqtt-retainer/README-CN.md
@@ -20,6 +20,7 @@
 - **RetainSyncMode**：
   - `Full`：完整保留消息广播（ram、sled）。
   - `TopicOnly`：仅主题名称同步（共享存储的 Redis）。
+- **熔断器（Circuit Breaker）**：内置滑动窗口熔断器，检测存储后端故障并自动快速失败降级和恢复。参见下方配置说明。
 
 ## 使用方法
 
@@ -74,10 +75,15 @@ rmqtt_retainer::register_named(&scx, "rmqtt-retainer", true, false).await?;
 | `max_payload_size` | `string` | `"1MB"` | 保留消息的最大 Payload 大小。超出后该消息将被视为普通消息处理。 |
 | `retained_message_ttl` | `string` | `"0m"`（不过期） | 保留消息的 TTL。未设置时默认使用消息过期时间。 |
 | `batch_messages_limit` | `usize` | `500` | 单次批量存储操作的最大消息数 |
-| `circuit_breaker_enabled` | `bool` | `true` | 启用熔断器，检测存储后端故障 |
-| `circuit_failure_threshold` | `usize` | `10` | 触发熔断器 OPEN 所需的连续失败次数 |
-| `circuit_reset_timeout` | `string` | `"15s"` | OPEN 状态持续时间，之后进入 HALF_OPEN 状态探针 |
-| `circuit_half_open_success_threshold` | `usize` | `3` | 关闭熔断器所需的连续探针成功次数 |
+| `circuit_breaker.failure_rate_threshold` | `f64` | `0.25` | 失败率阈值 (0.0–1.0)，超过后熔断器跳闸到 OPEN |
+| `circuit_breaker.sliding_window_type` | `string` | `"TimeBased"` | 滑动窗口类型：`CountBased` 或 `TimeBased` |
+| `circuit_breaker.sliding_window_size` | `usize` | `20` | 滑动窗口大小（调用次数） |
+| `circuit_breaker.sliding_window_duration` | `string` | `"45s"` | 滑动窗口持续时间（仅 TimeBased 模式） |
+| `circuit_breaker.minimum_number_of_calls` | `usize` | `10` | 熔断器跳闸前的最小调用次数 |
+| `circuit_breaker.wait_duration_in_open` | `string` | `"30s"` | OPEN 状态持续时间，之后进入 HALF_OPEN 状态 |
+| `circuit_breaker.slow_call_duration_threshold` | `string` | `"2s"` | 慢调用持续时间阈值 |
+| `circuit_breaker.slow_call_rate_threshold` | `f64` | `1.0` | 慢调用率阈值（1.0 = 禁用） |
+| `circuit_breaker.operation_timeout` | `string` | `"8s"` | 单次操作超时（`"0s"` 禁用） |
 
 ### 配置来源
 
@@ -109,11 +115,16 @@ max_payload_size = "1MB"
 retained_message_ttl = "24h"
 batch_messages_limit = 500
 
-# 熔断器（默认启用）
-#circuit_breaker_enabled = true
-#circuit_failure_threshold = 10
-#circuit_reset_timeout = "15s"
-#circuit_half_open_success_threshold = 3
+# 熔断器（滑动窗口模型，注释掉时使用默认值）
+#circuit_breaker.failure_rate_threshold = 0.25
+#circuit_breaker.sliding_window_type = "TimeBased"
+#circuit_breaker.sliding_window_size = 20
+#circuit_breaker.sliding_window_duration = "45s"
+#circuit_breaker.minimum_number_of_calls = 10
+#circuit_breaker.wait_duration_in_open = "30s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+#circuit_breaker.slow_call_rate_threshold = 1.0
+#circuit_breaker.operation_timeout = "8s"
 ```
 
 ## 依赖

--- a/rmqtt-plugins/rmqtt-retainer/README.md
+++ b/rmqtt-plugins/rmqtt-retainer/README.md
@@ -76,10 +76,15 @@ File: `rmqtt-retainer.toml` (in the plugin config directory). Loaded via `scx.pl
 | `max_payload_size` | `string` | `"1MB"` | Maximum payload size for retained messages. Exceeding this causes the message to be treated as a regular message. |
 | `retained_message_ttl` | `string` | `"0m"` (no expiry) | TTL for retained messages. If not set, defaults to the message expiry interval. |
 | `batch_messages_limit` | `usize` | `500` | Maximum number of messages per batch store operation |
-| `circuit_breaker_enabled` | `bool` | `true` | Enable circuit breaker for storage failure detection |
-| `circuit_failure_threshold` | `usize` | `10` | Consecutive failures before tripping the circuit to OPEN |
-| `circuit_reset_timeout` | `string` | `"15s"` | Duration in OPEN state before transitioning to HALF_OPEN |
-| `circuit_half_open_success_threshold` | `usize` | `3` | Consecutive probe successes needed to close the circuit |
+| `circuit_breaker.failure_rate_threshold` | `f64` | `0.25` | Failure rate threshold (0.0–1.0) for tripping the circuit to OPEN |
+| `circuit_breaker.sliding_window_type` | `string` | `"TimeBased"` | Sliding window type: `CountBased` or `TimeBased` |
+| `circuit_breaker.sliding_window_size` | `usize` | `20` | Sliding window size (number of calls) |
+| `circuit_breaker.sliding_window_duration` | `string` | `"45s"` | Sliding window duration (TimeBased mode only) |
+| `circuit_breaker.minimum_number_of_calls` | `usize` | `10` | Minimum calls before the breaker can trip |
+| `circuit_breaker.wait_duration_in_open` | `string` | `"30s"` | Duration in OPEN state before transitioning to HALF_OPEN |
+| `circuit_breaker.slow_call_duration_threshold` | `string` | `"2s"` | Slow call duration threshold |
+| `circuit_breaker.slow_call_rate_threshold` | `f64` | `1.0` | Slow call rate threshold (1.0 = disabled) |
+| `circuit_breaker.operation_timeout` | `string` | `"8s"` | Per-operation timeout (`"0s"` to disable) |
 
 ### Configuration Source
 
@@ -111,11 +116,16 @@ max_payload_size = "1MB"
 retained_message_ttl = "24h"
 batch_messages_limit = 500
 
-# Circuit breaker (enabled by default)
-#circuit_breaker_enabled = true
-#circuit_failure_threshold = 10
-#circuit_reset_timeout = "15s"
-#circuit_half_open_success_threshold = 3
+# Circuit breaker (sliding-window model, uses defaults if commented out)
+#circuit_breaker.failure_rate_threshold = 0.25
+#circuit_breaker.sliding_window_type = "TimeBased"
+#circuit_breaker.sliding_window_size = 20
+#circuit_breaker.sliding_window_duration = "45s"
+#circuit_breaker.minimum_number_of_calls = 10
+#circuit_breaker.wait_duration_in_open = "30s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+#circuit_breaker.slow_call_rate_threshold = 1.0
+#circuit_breaker.operation_timeout = "8s"
 ```
 
 ## Dependencies

--- a/rmqtt-plugins/rmqtt-session-storage/README-CN.md
+++ b/rmqtt-plugins/rmqtt-session-storage/README-CN.md
@@ -48,6 +48,23 @@ rmqtt_session_storage::register(&scx, true, false).await?;
 | `storage.redis-cluster.urls` | array of string | `["redis://127.0.0.1:6380/", ...]` | Redis 集群节点 URL |
 | `storage.redis-cluster.prefix` | string | `"session-{node}"` | 键前缀 |
 
+### 熔断器
+
+保护 Broker 在存储后端不可用时不会被阻塞。熔断器使用滑动窗口统计调用失败率，
+当失败率超过阈值且达到最小调用次数时，熔断器跳转到 OPEN 状态，所有会话存储操作快速失败。
+
+| 选项 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `circuit_breaker.failure_rate_threshold` | `f64` | `0.25` | 失败率阈值 (0.0–1.0)，超过后跳闸到 OPEN |
+| `circuit_breaker.sliding_window_type` | `string` | `"TimeBased"` | 滑动窗口类型：`CountBased` 或 `TimeBased` |
+| `circuit_breaker.sliding_window_size` | `usize` | `20` | 滑动窗口大小（调用次数） |
+| `circuit_breaker.sliding_window_duration` | `string` | `"45s"` | 滑动窗口持续时间（仅 TimeBased 模式） |
+| `circuit_breaker.minimum_number_of_calls` | `usize` | `10` | 熔断器跳闸前的最小调用次数 |
+| `circuit_breaker.wait_duration_in_open` | `string` | `"30s"` | OPEN 状态下等待多久后进入探测（HALF_OPEN） |
+| `circuit_breaker.slow_call_duration_threshold` | `string` | `"2s"` | 慢调用持续时间阈值 |
+| `circuit_breaker.slow_call_rate_threshold` | `f64` | `1.0` | 慢调用率阈值（1.0 = 禁用） |
+| `circuit_breaker.operation_timeout` | `string` | `"15s"` | 单次操作超时（`"0s"` 禁用） |
+
 ## 依赖
 
 `rmqtt`（feature `plugin`）、`sled`、`redis`、`tokio`

--- a/rmqtt-plugins/rmqtt-session-storage/README.md
+++ b/rmqtt-plugins/rmqtt-session-storage/README.md
@@ -48,6 +48,25 @@ File: `rmqtt-session-storage.toml`
 | `storage.redis-cluster.urls` | array of string | `["redis://127.0.0.1:6380/", ...]` | Redis cluster node URLs |
 | `storage.redis-cluster.prefix` | string | `"session-{node}"` | Key prefix |
 
+### Circuit Breaker
+
+Protects the broker from blocking when the storage backend becomes unreachable.
+The breaker uses a sliding window to track the call failure rate. When the failure
+rate exceeds the threshold and the minimum number of calls has been reached, the
+circuit trips to OPEN and all session storage operations fast-fail.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `circuit_breaker.failure_rate_threshold` | `f64` | `0.25` | Failure rate threshold (0.0–1.0) for tripping to OPEN |
+| `circuit_breaker.sliding_window_type` | `string` | `"TimeBased"` | Sliding window type: `CountBased` or `TimeBased` |
+| `circuit_breaker.sliding_window_size` | `usize` | `20` | Sliding window size (number of calls) |
+| `circuit_breaker.sliding_window_duration` | `string` | `"45s"` | Sliding window duration (TimeBased mode only) |
+| `circuit_breaker.minimum_number_of_calls` | `usize` | `10` | Minimum calls before the breaker can trip |
+| `circuit_breaker.wait_duration_in_open` | `string` | `"30s"` | Duration in OPEN before probing (HALF_OPEN) |
+| `circuit_breaker.slow_call_duration_threshold` | `string` | `"2s"` | Slow call duration threshold |
+| `circuit_breaker.slow_call_rate_threshold` | `f64` | `1.0` | Slow call rate threshold (1.0 = disabled) |
+| `circuit_breaker.operation_timeout` | `string` | `"15s"` | Per-operation timeout (`"0s"` to disable) |
+
 ## Dependencies
 
 `rmqtt` (feature `plugin`), `sled`, `redis`, `tokio`


### PR DESCRIPTION
**Summary**
Update all documentation to reflect the new unified circuit breaker configuration using sliding-window failure rate detection instead of the old consecutive-failure counter model.

**Key Changes**

Cluster Raft/Broadcast:
- Add gRPC circuit breaker configuration section
- Update `node_grpc_client_timeout` from 60s to 10s (raft) / 15s (broadcast)
- Document each breaker parameter with defaults and behavior
- Update both English and Chinese docs

Retainer Plugin:
- Replace old breaker config fields with new sliding-window model
- Add detailed table with all circuit_breaker.* options
- Update state machine diagram to reflect failure-rate-based tripping
- Add circuit breaker description in feature list

Message Storage:
- Replace old breaker config with sliding-window model
- Add comprehensive configuration table
- Update state machine diagram
- Set `storage.ram.encode = false` as default in examples

Session Storage:
- Add circuit breaker section with configuration table
- Document operation_timeout default (15s)

**Configuration Table Standardization**

All plugins now consistently document:
- `circuit_breaker.failure_rate_threshold` (0.25)
- `circuit_breaker.sliding_window_type` ("TimeBased")
- `circuit_breaker.sliding_window_size` (20)
- `circuit_breaker.sliding_window_duration` ("45s")
- `circuit_breaker.minimum_number_of_calls` (10)
- `circuit_breaker.wait_duration_in_open` ("30s")
- `circuit_breaker.slow_call_duration_threshold` ("2s")
- `circuit_breaker.slow_call_rate_threshold` (1.0)
- `circuit_breaker.operation_timeout` (varies: 8s for msg/retainer, 15s for session)

**Benefits**
- Consistent circuit breaker documentation across all plugins
- Clear explanation of sliding-window failure rate detection
- All examples use commented-out config sections for easy opt-in