### PR TITLE
docs(config): unify timeout and backend_timeout for message storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@ All notable changes to RMQTT are documented in this file.
 - **Retainer In-Memory Topic Trie**: Built a `RetainTree` index in memory on startup for O(1) exact-topic lookups and fast wildcard matching, replacing the previous SCAN+MATCH approach.
 - **Retainer Batch Storage**: Messages are collected into a channel and processed in batches via `batch_insert` / `batch_remove`, controlled by `batch_messages_limit`.
 - **Rate Counter**: Added `rmqtt-utils::RateCounter` (lock-free `AtomicU64`) for tracking message processing throughput. Enabled by default via the `rate-counter` feature.
-- **Message Storage Timeout**: Added configurable `timeout` for storage I/O operations in `rmqtt-message-storage`.
+- **Message Storage Timeout**: Added configurable `backend_timeout` for storage I/O operations, channel sends, and circuit breaker per-operation timeout in `rmqtt-message-storage`. Unified the previous separate `timeout` and `backend_timeout` fields into a single `backend_timeout` (default: `"15s"`).
 - **Cluster Broadcast Exec Queues**: Added `exec` and `forwards_exec` `TaskExecQueue` to `rmqtt-cluster-broadcast` for queue back-pressure management and busyness detection, aligning with `rmqtt-cluster-raft`.
 - **Retainer Enabled by Default**: `rmqtt-retainer` is now included in `plugins.default_startups` by default.
 
 ### Refactoring
 
 - **Circuit Breaker Simplification**: Simplified `CircuitBreaker` in `rmqtt-utils` — consolidated configuration into `CircuitBreakerConfig` with sliding-window semantics (failure rate, slow call detection, per-operation timeout).
-- **Message Storage Refactor**: Removed `merge_on_read` and `TaskExecQueue` from `rmqtt-message-storage`; added `with_timeout` wrapper for storage operations; introduced async callback support and back-pressure limits.
+- **Message Storage Refactor**: Removed `merge_on_read` and `TaskExecQueue` from `rmqtt-message-storage`; added `with_timeout` wrapper for storage operations; introduced async callback support and back-pressure limits. Unified `timeout` and `backend_timeout` into a single `backend_timeout` field.
 - **Session Storage Improvements**: Added detailed timing metrics for rebuild operations; improved init timing and timeout handling.
 - **Error Logging Normalization**: Normalized error logging across the workspace to use `Display` instead of `Debug` formatting.
 - **Cluster Retain Exec Queue**: Added a dedicated `retainer_exec` `TaskExecQueue` in `rmqtt-cluster-raft` for retain operations, separating from the main `exec` queue.
@@ -28,7 +28,7 @@ All notable changes to RMQTT are documented in this file.
 ### Configuration Changes
 
 - `rmqtt-retainer.toml`: Circuit breaker config changed from flat fields (`circuit_breaker_enabled`, `circuit_failure_threshold`, `circuit_reset_timeout`, `circuit_half_open_success_threshold`) to nested `circuit_breaker.*` sliding-window format. `retained_message_ttl` and `batch_messages_limit` are now uncommented by default.
-- `rmqtt-message-storage.toml`: `storage.ram.encode` default changed from `true` to `false`. Added `circuit_breaker.*` section.
+- `rmqtt-message-storage.toml`: `storage.ram.encode` default changed from `true` to `false`. Added `circuit_breaker.*` section. Unified `timeout` and `backend_timeout` into a single `backend_timeout` field (default: `"15s"`).
 - `rmqtt-session-storage.toml`: Added `circuit_breaker.*` section.
 - `rmqtt-cluster-broadcast.toml` / `rmqtt-cluster-raft.toml`: Added gRPC circuit breaker settings (`node_grpc_circuit_breaker_enabled`, etc.). `rmqtt-cluster-raft.toml`: `node_grpc_client_timeout` default changed from `"60s"` to `"10s"`. `raft.snapshot_interval` default changed from `"600s"` to `"300s"`.
 

--- a/docs/en_US/store-message.md
+++ b/docs/en_US/store-message.md
@@ -47,18 +47,15 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout.
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
 
+##─── Circuit breaker ────────────────────────────────────────────────────────
 ##All circuit-breaker parameters (failure rate, window, etc.) are inherited
 ##from the global `[circuit_breaker]` section in `rmqtt.toml`.
-##Only the backend operation timeout can be overridden here.
-##
-##Backend storage operation timeout. If a storage call exceeds this duration
-##it is aborted and counted as a failure by the circuit breaker.
-##Set to "0s" to disable.
-##Default: "8s"
-#backend_timeout = "8s"
+##The per-operation timeout uses `backend_timeout` above.
 ```
 
 Currently, three storage engines are supported: "ram," "redis," and "redis-cluster." "ram" is stored in local memory and 
@@ -66,9 +63,9 @@ can be configured with maximum memory usage or maximum message count, and it can
 before storage. Prefix configuration allows different rmqtt nodes to use the same Redis storage service. `{node}` will be 
 replaced by the identifier of the current node.
 
-`timeout` configures the timeout for storage I/O operations. Set to `0` for no timeout.
+`backend_timeout` (default: `"15s"`) configures the timeout for storage I/O operations, channel sends, and the circuit breaker per-operation timeout. Set to `"0s"` for no timeout.
 
-The Circuit Breaker parameters (failure rate threshold, sliding window type/size, minimum calls, OPEN duration, slow call threshold, etc.) are inherited from the global `[circuit_breaker]` section in `rmqtt.toml`. Only the backend storage operation timeout can be overridden via `backend_timeout` (default: `"8s"`, set to `"0s"` to disable).
+The Circuit Breaker parameters (failure rate threshold, sliding window type/size, minimum calls, OPEN duration, slow call threshold, etc.) are inherited from the global `[circuit_breaker]` section in `rmqtt.toml`. The per-operation timeout uses the `backend_timeout` setting.
 
 
 By default, this plugin is not enabled. To activate it, you must add the `rmqtt-message-storage` entry to the

--- a/docs/zh_CN/store-message.md
+++ b/docs/zh_CN/store-message.md
@@ -46,26 +46,23 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##存储 I/O 操作超时。0 = 不超时。
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
 
+##─── Circuit breaker ────────────────────────────────────────────────────────
 ##All circuit-breaker parameters (failure rate, window, etc.) are inherited
 ##from the global `[circuit_breaker]` section in `rmqtt.toml`.
-##Only the backend operation timeout can be overridden here.
-##
-##Backend storage operation timeout. If a storage call exceeds this duration
-##it is aborted and counted as a failure by the circuit breaker.
-##Set to "0s" to disable.
-##Default: "8s"
-#backend_timeout = "8s"
+##The per-operation timeout uses `backend_timeout` above.
 ```
 
 当前支持"ram"、"redis"和"redis-cluster"三种存储引擎。"ram"是存储在本地内存，可以配置最大使用内存容量或最大消息数量，以及可以指示消息是否编码后再存储。
 前缀配置方便不同rmqtt节点使用同一套redis存储服务。{node}将被替换为当前节点标识。
 
-`timeout` 配置存储 I/O 操作的超时时间，设为 `0` 表示不超时。
+`backend_timeout`（默认值：`"15s"`）配置存储 I/O 操作、channel 发送及熔断器单次操作的超时时间，设为 `"0s"` 表示不超时。
 
-熔断器（Circuit Breaker）参数继承自主配置文件 `rmqtt.toml` 中的全局 `[circuit_breaker]` 配置段（失败率阈值、滑动窗口类型/大小、最小调用次数、OPEN 持续时间、慢调用阈值等）。插件仅允许覆盖存储后端操作超时 `backend_timeout`（默认值：`"8s"`，设为 `"0s"` 可禁用超时）。
+熔断器（Circuit Breaker）参数继承自主配置文件 `rmqtt.toml` 中的全局 `[circuit_breaker]` 配置段（失败率阈值、滑动窗口类型/大小、最小调用次数、OPEN 持续时间、慢调用阈值等）。单次操作超时使用上述 `backend_timeout` 设置。
 
 默认情况下并没有启动此插件，如果要开启此插件，必须在主配置文件“rmqtt.toml”中的“plugins.default_startups”配置中添加“rmqtt-message-storage”项，如：
 ```bash

--- a/examples/cluster-broadcast/1/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-broadcast/1/plugins/rmqtt-message-storage.toml
@@ -26,5 +26,7 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"

--- a/examples/cluster-broadcast/2/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-broadcast/2/plugins/rmqtt-message-storage.toml
@@ -26,5 +26,7 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"

--- a/examples/cluster-broadcast/3/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-broadcast/3/plugins/rmqtt-message-storage.toml
@@ -26,5 +26,7 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"

--- a/examples/cluster-raft-3/1/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-message-storage.toml
@@ -26,5 +26,7 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"

--- a/examples/cluster-raft-3/2/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-message-storage.toml
@@ -26,5 +26,7 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"

--- a/examples/cluster-raft-3/3/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-message-storage.toml
@@ -26,5 +26,7 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"

--- a/examples/cluster-raft-5/1/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-message-storage.toml
@@ -22,6 +22,8 @@ storage.redis.prefix = "message-{node}"
 ##cleanup
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
 

--- a/examples/cluster-raft-5/2/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-message-storage.toml
@@ -22,6 +22,8 @@ storage.redis.prefix = "message-{node}"
 ##cleanup
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
 

--- a/examples/cluster-raft-5/3/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-message-storage.toml
@@ -22,6 +22,8 @@ storage.redis.prefix = "message-{node}"
 ##cleanup
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
 

--- a/examples/cluster-raft-5/4/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-message-storage.toml
@@ -22,6 +22,8 @@ storage.redis.prefix = "message-{node}"
 ##cleanup
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
 

--- a/examples/cluster-raft-5/5/plugins/rmqtt-message-storage.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-message-storage.toml
@@ -22,6 +22,8 @@ storage.redis.prefix = "message-{node}"
 ##cleanup
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
 

--- a/rmqtt-plugins/rmqtt-message-storage.toml
+++ b/rmqtt-plugins/rmqtt-message-storage.toml
@@ -26,16 +26,12 @@ storage.redis-cluster.prefix = "message-{node}"
 ##Quantity of expired messages cleared during each cleanup cycle.
 cleanup_count = 5000
 
-##Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-timeout = "5s"
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
 
-##─── Backend timeout (circuit breaker) ──────────────────────────────────────
+##─── Circuit breaker ────────────────────────────────────────────────────────
 ##All circuit-breaker parameters (failure rate, window, etc.) are inherited
 ##from the global `[circuit_breaker]` section in `rmqtt.toml`.
-##Only the backend operation timeout can be overridden here.
-##
-##Backend storage operation timeout. If a storage call (Redis)
-##exceeds this duration it is aborted and counted as a failure by the
-##circuit breaker. Set to "0s" to disable.
-##Default: "8s"
-#backend_timeout = "8s"
+##The per-operation timeout uses `backend_timeout` above.

--- a/rmqtt-plugins/rmqtt-message-storage/README-CN.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README-CN.md
@@ -56,7 +56,7 @@ rmqtt_message_storage::register(&scx, true, false).await?;
 | 选项 | 类型 | 默认值 | 描述 |
 |------|------|--------|------|
 | `cleanup_count` | integer | `5000` | 每轮清理的过期消息数量 |
-| `timeout` | string | `"5s"` | 存储 I/O 操作超时。`"0s"` = 不超时 |
+| `backend_timeout` | string | `"15s"` | 存储 I/O 操作、channel 发送及熔断器单次操作的超时。`"0s"` = 不超时 |
 
 ### 熔断器
 
@@ -64,9 +64,8 @@ rmqtt_message_storage::register(&scx, true, false).await?;
 当失败率超过阈值且达到最小调用次数时，熔断器跳转到 OPEN 状态，所有存储操作快速
 失败。熔断器会自动探测恢复。
 
-| 选项 | 类型 | 默认值 | 描述 |
-|------|------|--------|------|
-| `backend_timeout` | `string` | `"8s"` | Backend storage operation timeout (`"0s"` to disable) |
+单次操作超时使用上方清理部分的 `backend_timeout` 设置。其余熔断器参数（失败率阈值、
+滑动窗口等）继承自主配置文件 `rmqtt.toml` 中的全局 `[circuit_breaker]` 配置段。
 
 #### 状态机
 

--- a/rmqtt-plugins/rmqtt-message-storage/README.md
+++ b/rmqtt-plugins/rmqtt-message-storage/README.md
@@ -56,7 +56,7 @@ File: `rmqtt-message-storage.toml`
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `cleanup_count` | integer | `5000` | Expired messages cleaned per cycle |
-| `timeout` | string | `"5s"` | Timeout for storage I/O operations. `"0s"` = no timeout |
+| `backend_timeout` | string | `"15s"` | Timeout for storage I/O operations, channel sends, and circuit breaker per-operation timeout. `"0s"` = no timeout |
 
 ### Circuit Breaker
 
@@ -66,9 +66,9 @@ rate exceeds the threshold and the minimum number of calls has been reached, the
 circuit trips to OPEN and all storage operations fast-fail. The circuit automatically
 probes for recovery.
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `backend_timeout` | `string` | `"8s"` | Backend storage operation timeout (`"0s"` to disable) |
+The per-operation timeout uses the `backend_timeout` setting (see Cleanup section above).
+All other circuit-breaker parameters (failure rate threshold, sliding window, etc.) are
+inherited from the global `[circuit_breaker]` section in `rmqtt.toml`.
 
 #### State Machine
 

--- a/rmqtt-plugins/rmqtt-message-storage/src/config.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/config.rs
@@ -30,16 +30,10 @@ pub struct PluginConfig {
     pub storage: Option<Config>,
     #[serde(default = "PluginConfig::cleanup_count_default")]
     pub cleanup_count: usize,
-    /// Timeout for storage I/O operations. 0 = no timeout. Examples: "5s", "500ms".
-    #[serde(default = "PluginConfig::timeout_default", deserialize_with = "deserialize_duration")]
-    pub timeout: Duration,
-
-    // ─── Backend timeout (circuit breaker) ───────────────────────────────
-    /// Backend storage operation timeout (circuit breaker).
-    ///
-    /// Each storage call (Redis get/set/delete) that exceeds this
-    /// duration is aborted and counted as a failure by the circuit breaker.
-    /// Set to `"0s"` to disable. Default: `"8s"`.
+    /// Timeout for storage I/O operations and channel sends.
+    /// Also used as the circuit breaker's per-operation timeout when
+    /// the `circuit-breaker` feature is enabled.
+    /// `0` = no timeout. Examples: `"5s"`, `"500ms"`. Default: `"15s"`.
     #[serde(default = "PluginConfig::backend_timeout_default", deserialize_with = "deserialize_duration")]
     pub backend_timeout: Duration,
 }
@@ -56,12 +50,8 @@ impl PluginConfig {
         5000
     }
 
-    fn timeout_default() -> Duration {
-        Duration::from_millis(5000)
-    }
-
     fn backend_timeout_default() -> Duration {
-        Duration::from_secs(8)
+        Duration::from_secs(15)
     }
 
     #[inline]
@@ -114,7 +104,6 @@ impl PluginConfig {
         serde_json::json!({
             "storage": storage,
             "cleanup_count": self.cleanup_count,
-            "timeout": format!("{:?}", self.timeout),
             "backend_timeout": format!("{:?}", self.backend_timeout),
         })
     }

--- a/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/lib.rs
@@ -68,7 +68,7 @@ impl StoragePlugin {
             #[cfg(feature = "ram")]
             Some(config::Config::Ram(ram_cfg)) => {
                 let message_mgr =
-                    RamMessageManager::new(ram_cfg.clone(), cfg.cleanup_count, cfg.timeout).await?;
+                    RamMessageManager::new(ram_cfg.clone(), cfg.cleanup_count, cfg.backend_timeout).await?;
                 Ok((MessageMgr::Ram(message_mgr), Arc::new(cfg)))
             }
             #[cfg(any(feature = "redis", feature = "redis-cluster"))]

--- a/rmqtt-plugins/rmqtt-message-storage/src/ram.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/ram.rs
@@ -513,6 +513,10 @@ impl MessageManager for RamMessageManager {
     ) -> Result<()> {
         let timeout = self.inner.timeout;
         let mut tx = self.inner.msg_tx.clone();
+
+        // Increment BEFORE send so fetch_sub can never race ahead.
+        self.msg_queue_count.fetch_add(1, Ordering::Relaxed);
+
         let send_fut = tx.send(Msg::Store { from, publish: p, expiry_interval, msg_id, recipients });
         let res = if timeout > Duration::ZERO {
             send_fut
@@ -523,15 +527,14 @@ impl MessageManager for RamMessageManager {
             Ok(send_fut.await)
         };
         match res {
-            Ok(Ok(())) => {
-                self.msg_queue_count.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
+            Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => {
+                self.msg_queue_count.fetch_sub(1, Ordering::Relaxed);
                 log::warn!("RamMessageManager store error, {e}");
                 Err(anyhow!(e))
             }
             Err(e) => {
+                self.msg_queue_count.fetch_sub(1, Ordering::Relaxed);
                 log::warn!("RamMessageManager store timeout, {e}");
                 Err(e)
             }
@@ -568,6 +571,10 @@ impl MessageManager for RamMessageManager {
         // the same msg_id is already committed.
         let timeout = self.inner.timeout;
         let mut tx = self.inner.msg_tx.clone();
+
+        // Increment BEFORE send so fetch_sub can never race ahead.
+        self.msg_queue_count.fetch_add(1, Ordering::Relaxed);
+
         let send_fut = tx.send(Msg::MarkForwarded { msg_id, recipients: forwardeds });
         let res = if timeout > Duration::ZERO {
             send_fut.timeout(futures_time::time::Duration::from(timeout)).await.map_err(|e| anyhow!(e))
@@ -575,15 +582,14 @@ impl MessageManager for RamMessageManager {
             Ok(send_fut.await)
         };
         match res {
-            Ok(Ok(())) => {
-                self.msg_queue_count.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
+            Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => {
+                self.msg_queue_count.fetch_sub(1, Ordering::Relaxed);
                 log::warn!("RamMessageManager mark_forwarded error, {e}");
                 Err(anyhow!(e))
             }
             Err(e) => {
+                self.msg_queue_count.fetch_sub(1, Ordering::Relaxed);
                 log::warn!("RamMessageManager mark_forwarded timeout, {e}");
                 Err(e)
             }

--- a/rmqtt-plugins/rmqtt-message-storage/src/storage.rs
+++ b/rmqtt-plugins/rmqtt-message-storage/src/storage.rs
@@ -98,7 +98,7 @@ impl StorageMessageManager {
         log::info!("messages_received_max: {}", messages_received_max.load(Ordering::SeqCst));
 
         let msg_queue_count = Arc::new(AtomicIsize::new(0));
-        let timeout = cfg.timeout;
+        let timeout = cfg.backend_timeout;
 
         // Build the shared inner state first, so workers can clone it.
         let inner = Arc::new(StorageMessageManagerInner {
@@ -205,6 +205,14 @@ impl StorageMessageManager {
         };
         let idx = msg_id & (WORKER_COUNT - 1); // power-of-two fast modulo
         let mut tx = self.worker_txs[idx].clone();
+
+        // Increment BEFORE send so that the worker's fetch_sub can never
+        // race ahead of the corresponding fetch_add.  If send fails we roll
+        // the counter back.  This prevents msg_queue_count from going
+        // negative when workers drain the channel faster than route_msg
+        // tasks are rescheduled (e.g. circuit-breaker OPEN, fast-fail path).
+        self.msg_queue_count.fetch_add(1, Ordering::Relaxed);
+
         let fut = tx.send(msg);
         let timeout = self.timeout;
         let res = if timeout > Duration::ZERO {
@@ -215,18 +223,14 @@ impl StorageMessageManager {
             Ok(fut.await)
         };
         match res {
-            Ok(Ok(())) => {
-                // Count every message that successfully enters the channel.
-                // The worker will fetch_sub(1) for each message it processes,
-                // so increment and decrement are always balanced.
-                self.msg_queue_count.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
+            Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => {
+                self.msg_queue_count.fetch_sub(1, Ordering::Relaxed);
                 log::warn!("route_msg: send error (worker {}): {:?}", idx, e);
                 Err(anyhow::anyhow!(e))
             }
             Err(e) => {
+                self.msg_queue_count.fetch_sub(1, Ordering::Relaxed);
                 log::warn!("route_msg: send timeout (worker {}): {:?}", idx, e);
                 Err(e)
             }


### PR DESCRIPTION
**Problem**
The message storage plugin had two separate timeout configurations:
- `timeout` for storage I/O operations
- `backend_timeout` for circuit breaker operation timeout

This was redundant and confusing. With the global circuit breaker configuration now in rmqtt.toml, only a single timeout setting is needed.

**Solution**
- Remove separate `timeout` field, keep `backend_timeout` as the single timeout
- Default changed from 5s to 15s (more resilient for storage operations)
- `backend_timeout` now covers:
  - Storage I/O operations (Redis/Sled)
  - Channel sends (RAM/Storage backends)
  - Circuit breaker per-operation timeout (when feature enabled)
- Update all example cluster configs with new `backend_timeout` setting
- Update documentation to reflect unified timeout

**Additional Fixes**
- Fix msg_queue_count race condition: increment BEFORE send so fetch_sub never races ahead. Roll back on error/timeout.
- Apply same fix to RAM storage store/mark_forwarded operations

**Documentation Updates**
- Update store-message.md (EN/ZH) with `backend_timeout` description
- Update plugin README with timeout configuration
- Update all cluster example TOML files
- Remove duplicate `timeout` references

**Benefits**
- Single timeout configuration point
- Consistent timeout behavior across storage and circuit breaker
- Better default (15s vs 5s)
- Race-free msg_queue_count accounting