### PR TITLE
fix(session-storage): ensure expired sessions are cleaned up on node restart

### DIFF
--- a/rmqtt-bin/src/server.rs
+++ b/rmqtt-bin/src/server.rs
@@ -117,7 +117,7 @@ async fn main() -> Result<()> {
     let mut builder = MqttServer::new(scx);
 
     //tcp
-    for (_, listen_cfg) in Settings::instance().listeners.tcps.iter() {
+    for listen_cfg in Settings::instance().listeners.tcps.values() {
         let listener = match config_builder(listen_cfg).bind() {
             Ok(l) => l.tcp()?,
             Err(e) => {
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
     }
 
     //tls
-    for (_, listen_cfg) in Settings::instance().listeners.tlss.iter() {
+    for listen_cfg in Settings::instance().listeners.tlss.values() {
         let listener = match config_builder(listen_cfg).bind() {
             Ok(l) => l.tls()?,
             Err(e) => {
@@ -141,7 +141,7 @@ async fn main() -> Result<()> {
     }
 
     //websocket
-    for (_, listen_cfg) in Settings::instance().listeners.wss.iter() {
+    for listen_cfg in Settings::instance().listeners.wss.values() {
         let listener = match config_builder(listen_cfg).bind() {
             Ok(l) => l.ws()?,
             Err(e) => {
@@ -153,7 +153,7 @@ async fn main() -> Result<()> {
     }
 
     //tls-websocket
-    for (_, listen_cfg) in Settings::instance().listeners.wsss.iter() {
+    for listen_cfg in Settings::instance().listeners.wsss.values() {
         let listener = match config_builder(listen_cfg).bind() {
             Ok(l) => l.wss()?,
             Err(e) => {
@@ -165,7 +165,7 @@ async fn main() -> Result<()> {
     }
 
     //MQTT over QUIC
-    for (_, listen_cfg) in Settings::instance().listeners.quics.iter() {
+    for listen_cfg in Settings::instance().listeners.quics.values() {
         let listener = match config_builder(listen_cfg).bind_quic() {
             Ok(l) => l,
             Err(e) => {

--- a/rmqtt-net/src/builder.rs
+++ b/rmqtt-net/src/builder.rs
@@ -970,11 +970,11 @@ fn handle_header_v1(addr: v1::ProxyAddresses) -> Option<(SocketAddr, SocketAddr)
             None
         }
         Ipv4 { source, destination } => {
-            log::debug!("[tcp]accept proxy-protocol-v1: {} => {}", &source, &destination);
+            log::debug!("[tcp]accept proxy-protocol-v1: {} => {}", source, destination);
             Some((SocketAddr::V4(source), SocketAddr::V4(destination)))
         }
         Ipv6 { source, destination } => {
-            log::debug!("[tcp]accept proxy-protocol-v1: {} => {}", &source, &destination);
+            log::debug!("[tcp]accept proxy-protocol-v1: {} => {}", source, destination);
             Some((SocketAddr::V6(source), SocketAddr::V6(destination)))
         }
     }
@@ -1014,11 +1014,11 @@ fn handle_header_v2(
 
     match addr {
         Address::Ipv4 { source, destination } => {
-            log::debug!("[tcp]accept proxy-protocol-v2: {} => {}", &source, &destination);
+            log::debug!("[tcp]accept proxy-protocol-v2: {} => {}", source, destination);
             Some((SocketAddr::V4(source), SocketAddr::V4(destination)))
         }
         Address::Ipv6 { source, destination } => {
-            log::debug!("[tcp]accept proxy-protocol-v2: {} => {}", &source, &destination);
+            log::debug!("[tcp]accept proxy-protocol-v2: {} => {}", source, destination);
             Some((SocketAddr::V6(source), SocketAddr::V6(destination)))
         }
         Address::Unspec => {

--- a/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/v4.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-mqtt/src/v4.rs
@@ -110,7 +110,7 @@ impl Client {
             "server_addr: {}, server_addr: {}, cfg.server: {:?}",
             client.server_addr,
             server_addr,
-            &client.cfg.server
+            client.cfg.server
         );
 
         let mut builder = v3::client::MqttConnector::new(client.cfg.server.addr.clone())

--- a/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/bridge.rs
+++ b/rmqtt-plugins/rmqtt-bridge-ingress-pulsar/src/bridge.rs
@@ -134,7 +134,7 @@ impl Message {
             PayloadFormat::Json => {
                 let payload_json: serde_json::Value =
                     serde_json::from_slice(payload.data.as_slice()).map_err(|e| anyhow!(e))?;
-                log::debug!("payload_topic_names: {:?}", &cfg_entry.local.payload_topic_names);
+                log::debug!("payload_topic_names: {:?}", cfg_entry.local.payload_topic_names);
                 let payload_topics = cfg_entry
                     .local
                     .payload_topic_names

--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/router.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/router.rs
@@ -69,7 +69,7 @@ impl Router for ClusterRouter {
     #[inline]
     async fn gets(&self, limit: usize) -> Vec<Route> {
         let mut routes = self.inner.gets(limit).await;
-        for (_id, (_addr, c)) in self.grpc_clients.iter() {
+        for (_addr, c) in self.grpc_clients.values() {
             if routes.len() < limit {
                 let reply = MessageSender::new(
                     c.clone(),
@@ -146,7 +146,7 @@ impl Router for ClusterRouter {
     #[inline]
     fn merge_topics(&self, topics_map: &HashMap<NodeId, Counter>) -> Counter {
         let topics = Counter::new();
-        for (_, counter) in topics_map.iter() {
+        for counter in topics_map.values() {
             topics.add(counter);
         }
         topics
@@ -155,7 +155,7 @@ impl Router for ClusterRouter {
     #[inline]
     fn merge_routes(&self, routes_map: &HashMap<NodeId, Counter>) -> Counter {
         let routes = Counter::new();
-        for (_, counter) in routes_map.iter() {
+        for counter in routes_map.values() {
             routes.add(counter);
         }
         routes

--- a/rmqtt-plugins/rmqtt-session-storage/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-session-storage/src/lib.rs
@@ -264,60 +264,59 @@ impl StoragePlugin {
 
     fn start_local_runtime(scx: ServerContext) -> mpsc::Sender<RebuildChanType> {
         let (tx, mut rx) = futures::channel::mpsc::channel::<RebuildChanType>(100_000);
-        std::thread::spawn(move || {
-            let local_rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("tokio runtime build failed");
-            let local_set = tokio::task::LocalSet::new();
+        let exec = scx.get_exec("SESSION_REBUILD_EXEC");
+        tokio::spawn(async move {
+            let now = std::time::Instant::now();
+            while let Some(msg) = rx.next().await {
+                match msg {
+                    RebuildChanType::Session(session, session_expiry_interval) => {
+                        match SessionState::offline_restart(session.clone(), session_expiry_interval).await {
+                            Err(e) => {
+                                log::warn!("Rebuild offline sessions error, {e}");
+                            }
+                            Ok(msg_tx) => {
+                                let mut session_entry = scx.extends.shared().await.entry(session.id.clone());
 
-            local_set.block_on(&local_rt, async {
-                let now = std::time::Instant::now();
-                let exec = scx.get_exec("SESSION_REBUILD_EXEC");
-                while let Some(msg) = rx.next().await {
-                    match msg {
-                        RebuildChanType::Session(session, session_expiry_interval)  => {
-                            match SessionState::offline_restart(session.clone(), session_expiry_interval).await {
-                                Err(e) => {
-                                    log::warn!("Rebuild offline sessions error, {e}");
-                                },
-                                Ok(msg_tx) => {
-                                    let mut session_entry =
-                                        scx.extends.shared().await.entry(session.id.clone());
-
-                                    let id = session_entry.id().clone();
-                                    let task_fut = async move {
-                                        if let Err(e) = session_entry.set(session, msg_tx).await {
-                                            log::warn!("{:?} Rebuild offline sessions error, {:?}", session_entry.id(), e);
-                                        }
-                                    };
-                                    if let Err(e) = exec.spawn(task_fut).await {
-                                        log::warn!("{:?} Rebuild offline sessions error, {:?}", id, e.to_string());
+                                let id = session_entry.id().clone();
+                                let task_fut = async move {
+                                    if let Err(e) = session_entry.set(session, msg_tx).await {
+                                        log::warn!(
+                                            "{:?} Rebuild offline sessions error, {:?}",
+                                            session_entry.id(),
+                                            e
+                                        );
                                     }
+                                };
+                                if let Err(e) = exec.spawn(task_fut).await {
+                                    log::warn!(
+                                        "{:?} Rebuild offline sessions error, {:?}",
+                                        id,
+                                        e.to_string()
+                                    );
+                                }
 
-                                    let completed_count = exec.completed_count().await;
-                                    if completed_count > 0 && completed_count % 5000 == 0 {
-                                        log::info!(
+                                let completed_count = exec.completed_count().await;
+                                if completed_count > 0 && completed_count % 5000 == 0 {
+                                    log::info!(
                                         "{:?} Rebuild offline sessions, completed_count: {}, active_count: {}, waiting_count: {}, rate: {:?}",
                                         id,
                                         exec.completed_count().await, exec.active_count(), exec.waiting_count(), exec.rate().await
                                     );
-                                    }
                                 }
                             }
-                        },
-                            RebuildChanType::Done(done_tx) => {
-                                let _ = exec.flush().await;
-                                let _ = done_tx.send(());
-                                log::info!(
+                        }
+                    }
+                    RebuildChanType::Done(done_tx) => {
+                        let _ = exec.flush().await;
+                        let _ = done_tx.send(());
+                        log::info!(
                                     "Rebuild offline sessions, completed_count: {}, active_count: {}, waiting_count: {}, rate: {:?}, cost: {:?}",
                                     exec.completed_count().await, exec.active_count(), exec.waiting_count(), exec.rate().await, now.elapsed()
                                 );
-                                break;
-                        }
+                        break;
                     }
                 }
-            });
+            }
             log::info!("Offline session rebuilding finished");
         });
         tx

--- a/rmqtt/src/grpc.rs
+++ b/rmqtt/src/grpc.rs
@@ -120,7 +120,7 @@ impl GrpcServer {
                     let interval = Duration::from_millis(1500);
                     loop {
                         tokio::time::sleep(interval).await;
-                        for (_, c) in counters.iter() {
+                        for c in counters.values() {
                             c.tick(interval);
                         }
                     }

--- a/rmqtt/src/shared.rs
+++ b/rmqtt/src/shared.rs
@@ -477,7 +477,7 @@ impl Entry for LockEntry {
             is_admin
         );
 
-        if let Some(peer_tx) = self.tx().and_then(|tx| if tx.is_closed() { None } else { Some(tx) }) {
+        if let Some(peer_tx) = self.tx().filter(|tx| !tx.is_closed()) {
             let (tx, rx) = oneshot::channel();
             if let Ok(()) = peer_tx.unbounded_send(Message::Kick(tx, self.id.clone(), clean_start, is_admin))
             {

--- a/rmqtt/src/stats.rs
+++ b/rmqtt/src/stats.rs
@@ -372,7 +372,7 @@ impl Stats {
         let routes = router.merge_routes(&self.routes_map);
 
         let grpc_clients_actives = Counter::new();
-        for (_, c) in self.grpc_clients_actives.iter() {
+        for c in self.grpc_clients_actives.values() {
             grpc_clients_actives.add(c);
         }
 
@@ -421,7 +421,7 @@ impl Stats {
     #[inline]
     pub async fn to_sys_json(&self, _scx: &ServerContext) -> serde_json::Value {
         let grpc_clients_actives = Counter::new();
-        for (_, c) in self.grpc_clients_actives.iter() {
+        for c in self.grpc_clients_actives.values() {
             grpc_clients_actives.add(c);
         }
 

--- a/rmqtt/src/types.rs
+++ b/rmqtt/src/types.rs
@@ -2187,7 +2187,7 @@ impl SessionSubs {
         {
             let subs = self.subs.read().await;
             #[allow(unused_variables)]
-            for (_, opts) in subs.iter() {
+            for opts in subs.values() {
                 #[cfg(feature = "stats")]
                 scx.stats.subscriptions.dec();
                 #[cfg(feature = "shared-subscription")]


### PR DESCRIPTION
**Problem**
When the session storage plugin is enabled and a node restarts, offline sessions are reloaded from storage. However, expired sessions were not being cleared because the rebuild runtime was destroyed before cleanup tasks could complete.

**Root Cause**
The rebuild loop ran in a custom `std::thread::spawn` with its own `tokio::runtime::Builder::new_current_thread()` and `LocalSet`. When the `block_on()` call completed, the entire thread exited and the runtime was destroyed, dropping all pending async tasks — including the expired session cleanup logic.

As a result, sessions with `expiry_interval <= 0` remained in memory indefinitely and were never removed from storage.

**Solution**
- Remove the custom `std::thread::spawn` + `LocalSet` wrapper
- Replace with direct `tokio::spawn` using the shared runtime
- This keeps the rebuild/cleanup tasks alive until completion
- Fix indentation of `RebuildChanType::Done` match arm

**Benefits**
- Expired sessions are properly cleared on node restart
- Stale session data no longer accumulates
- Cleaner, simpler implementation
- More reliable session expiration handling