### PR TITLE
fix(cluster): handle MessageReply::Success in retain/message sync across all cluster plugins

### DIFF
--- a/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-broadcast/src/shared.rs
@@ -828,6 +828,10 @@ impl Shared for ClusterShared {
                 .join_all_with_async(move |reply| {
                     let msgs = match reply {
                         Ok(MessageReply::MessageGet(msgs)) => msgs,
+                        Ok(MessageReply::Success) => {
+                            log::debug!("unexpected reply: Success");
+                            vec![]
+                        }
                         Ok(other) => {
                             log::warn!("unexpected reply: {other:?}");
                             vec![]
@@ -873,6 +877,10 @@ impl Shared for ClusterShared {
                     .join_all_with_async(move |reply| async move {
                         match reply {
                             Ok(MessageReply::GetRetains(retains)) => Ok(retains),
+                            Ok(MessageReply::Success) => {
+                                log::debug!("unexpected reply: Success");
+                                Ok(vec![])
+                            }
                             Ok(other) => {
                                 log::warn!("unexpected reply: {other:?}");
                                 Ok(vec![])
@@ -1129,6 +1137,12 @@ impl ClusterShared {
                                     break;
                                 }
                                 offset += CHUNK;
+                            }
+                            Ok(MessageReply::Success) => {
+                                log::debug!(
+                                    "sync_retains_from_peers unexpected reply from {node_id}: Success"
+                                );
+                                break;
                             }
                             Ok(other) => {
                                 log::warn!(

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -757,6 +757,10 @@ impl Shared for ClusterShared {
                     .join_all_with_async(move |reply| {
                         let msgs = match reply {
                             Ok(MessageReply::MessageGet(msgs)) => msgs,
+                            Ok(MessageReply::Success) => {
+                                log::debug!("unexpected reply: Success");
+                                vec![]
+                            }
                             Ok(other) => {
                                 log::warn!("unexpected reply: {other:?}");
                                 vec![]
@@ -818,6 +822,10 @@ impl Shared for ClusterShared {
                     .join_all_with_async(move |reply| async move {
                         match reply {
                             Ok(MessageReply::GetRetains(retains)) => Ok(retains),
+                            Ok(MessageReply::Success) => {
+                                log::debug!("unexpected reply: Success");
+                                Ok(vec![])
+                            }
                             Ok(other) => {
                                 log::warn!("unexpected reply: {other:?}");
                                 Ok(vec![])


### PR DESCRIPTION
**Problem**
`MessageReply::Success` responses received during cluster retain synchronization and message loading were treated as errors and logged at `warn!` level, creating unnecessary noise in production logs.

**Solution**
Add explicit handling for `MessageReply::Success` in both cluster-broadcast and cluster-raft plugins:

- `message_load_with`: return empty vector, log at `debug!` level
- `retain_load_with`: return empty vector, log at `debug!` level
- `sync_retains_from_peers`: treat as end of sync (break loop)

**Files Changed**
- rmqtt-cluster-broadcast/src/shared.rs (3 locations)
- rmqtt-cluster-raft/src/shared.rs (2 locations)

**Benefits**
- Reduces log noise (warn → debug)
- Correctly handles Success responses without error
- Consistent behavior across both cluster plugins