### PR TITLE
feat: add rmqtt-cluster-raft dynamic grpc peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5070,10 +5070,12 @@ dependencies = [
  "lz4",
  "lz4_flex",
  "postcard",
+ "prost",
  "rand 0.9.4",
  "rayon",
  "rmqtt",
  "rmqtt-raft",
+ "rmqtt-raft-core",
  "rust-box",
  "serde",
  "serde_json",
@@ -5082,6 +5084,7 @@ dependencies = [
  "slog-term",
  "snap",
  "tokio",
+ "tonic",
  "zstd",
 ]
 

--- a/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
+++ b/rmqtt-plugins/rmqtt-cluster-raft/Cargo.toml
@@ -21,6 +21,7 @@ log.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true
 bytes.workspace = true
+prost.workspace = true
 bytestring.workspace = true
 futures.workspace = true
 rand.workspace = true
@@ -28,6 +29,8 @@ dashmap.workspace = true
 ahash.workspace = true
 postcard.workspace = true
 rayon.workspace = true
+tikv-raft = { version = "0.8.1", package = "rmqtt-raft-core", default-features = false, features = ["prost-codec"] }
+tonic = "0.13"
 
 slog = "2.7"
 slog-term = "2.9"

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/lib.rs
@@ -29,6 +29,7 @@
 //!
 #![deny(unsafe_code)]
 use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -41,9 +42,9 @@ use rust_box::task_exec_queue::TaskExecQueue;
 use serde_json::{self, json};
 use tokio::time::sleep;
 
+use nodes::ClusterNodeManager;
 use rmqtt::{
     context::ServerContext,
-    grpc::GrpcClients,
     hook::{Register, Type},
     macros::Plugin,
     plugin::{PackageInfo, Plugin},
@@ -58,6 +59,8 @@ use shared::ClusterShared;
 mod config;
 mod handler;
 mod message;
+mod nodes;
+mod raft_admin;
 mod router;
 mod shared;
 
@@ -74,10 +77,11 @@ struct ClusterPlugin {
     scx: ServerContext,
     register: Box<dyn Register>,
     cfg: Arc<PluginConfig>,
-    grpc_clients: GrpcClients,
+    nodes: ClusterNodeManager,
     shared: ClusterShared,
     router: ClusterRouter,
     raft_mailbox: Option<Mailbox>,
+    draining: Arc<AtomicBool>,
     exec: TaskExecQueue,
     backoff_strategy: ExponentialBackoff,
 }
@@ -94,59 +98,33 @@ impl ClusterPlugin {
         let exec = scx.get_exec(("RAFT_EXEC", cfg.task_exec_queue_workers, cfg.task_exec_queue_max));
 
         let register = scx.extends.hook_mgr().register();
-        let mut grpc_clients = HashMap::default();
-        let mut node_names = HashMap::default();
-
-        let node_grpc_addrs = cfg.node_grpc_addrs.clone();
-        log::info!("node_grpc_addrs: {node_grpc_addrs:?}");
-
-        // Read circuit-breaker config from ServerContext.
-        let cb_config = &scx.circuit_breaker_config;
-
-        for node_addr in &node_grpc_addrs {
-            if node_addr.id != scx.node.id() {
-                let batch_size = cfg.node_grpc_batch_size;
-                let client_concurrency_limit = cfg.node_grpc_client_concurrency_limit;
-                let client_timeout = cfg.node_grpc_client_timeout;
-                grpc_clients.insert(
-                    node_addr.id,
-                    (
-                        node_addr.addr.clone(),
-                        scx.node
-                            .new_grpc_client(
-                                &node_addr.addr,
-                                client_timeout,
-                                client_concurrency_limit,
-                                batch_size,
-                                cb_config,
-                            )
-                            .await?,
-                    ),
-                );
-            }
-            node_names.insert(node_addr.id, format!("{}@{}", node_addr.id, node_addr.addr));
-        }
-        let grpc_clients = Arc::new(grpc_clients);
+        let nodes = ClusterNodeManager::new(scx.clone(), &cfg);
+        nodes.seed_from_config(&cfg.node_grpc_addrs, &cfg.raft_peer_addrs).await?;
         let backoff_strategy = ExponentialBackoffBuilder::new()
             .with_max_elapsed_time(Some(Duration::from_secs(60)))
             .with_multiplier(2.5)
             .build();
-        let router =
-            ClusterRouter::new(scx.clone(), backoff_strategy.clone(), cfg.try_lock_timeout, cfg.compression);
+        let router = ClusterRouter::new(
+            scx.clone(),
+            backoff_strategy.clone(),
+            nodes.clone(),
+            cfg.try_lock_timeout,
+            cfg.compression,
+        );
         let shared = ClusterShared::new(
             scx.clone(),
             exec.clone(),
             router.clone(),
-            grpc_clients.clone(),
-            node_names,
+            nodes.clone(),
             cfg.message_type,
             cfg.task_exec_queue_max,
             cfg.task_exec_queue_workers,
             cfg.node_grpc_client_timeout,
         );
         let raft_mailbox = None;
+        let draining = Arc::new(AtomicBool::new(false));
         let cfg = Arc::new(cfg);
-        Ok(Self { scx, register, cfg, grpc_clients, shared, router, raft_mailbox, exec, backoff_strategy })
+        Ok(Self { scx, register, cfg, nodes, shared, router, raft_mailbox, draining, exec, backoff_strategy })
     }
 
     //raft init ...
@@ -404,6 +382,11 @@ impl Plugin for ClusterPlugin {
                 Ok(reply) => match message::MessageReply::decode(&reply)? {
                     message::MessageReply::Ping => {
                         log::info!("ping ok");
+                        let local_node = self
+                            .nodes
+                            .local_node_from_config(&self.cfg.node_grpc_addrs, &self.cfg.raft_peer_addrs)?;
+                        let node_up = message::Message::NodeUp { node: local_node }.encode()?;
+                        raft_mailbox.send_proposal(node_up).await.map_err(anyhow::Error::new)?;
                         return Ok(());
                     }
                     message::MessageReply::Error(e) => {
@@ -444,7 +427,8 @@ impl Plugin for ClusterPlugin {
         }
 
         let mut nodes = HashMap::default();
-        for (node_id, (_, c)) in self.grpc_clients.iter() {
+        let grpc_clients = self.nodes.grpc_clients();
+        for (node_id, (_, c)) in grpc_clients.iter() {
             let stats = json!({
                 "transfer_queue_len": c.transfer_queue_len(),
                 "active_tasks_count": c.active_tasks().count(),
@@ -456,6 +440,7 @@ impl Plugin for ClusterPlugin {
 
         json!({
             "grpc_clients": nodes,
+            "cluster_nodes": self.nodes.to_json(),
             "raft_status": raft_status,
             "raft_pears": pears,
             "client_states": self.router.states_count(),
@@ -465,6 +450,190 @@ impl Plugin for ClusterPlugin {
                 "completed_count": self.exec.completed_count().await,
             }
         })
+    }
+
+    #[inline]
+    async fn send(&self, msg: serde_json::Value) -> Result<serde_json::Value> {
+        let action = msg.get("action").and_then(|v| v.as_str()).ok_or_else(|| anyhow!("missing action"))?;
+        let raft_mailbox = self.raft_mailbox();
+        match action {
+            "node_up" => {
+                let node: message::ClusterNode =
+                    serde_json::from_value(msg.get("node").cloned().unwrap_or_else(|| {
+                        json!({
+                            "id": msg.get("id").cloned().unwrap_or_default(),
+                            "grpc_addr": msg.get("grpc_addr").cloned().unwrap_or_default(),
+                            "raft_addr": msg.get("raft_addr").cloned().unwrap_or_default(),
+                        })
+                    }))?;
+                let proposal = message::Message::NodeUp { node }.encode()?;
+                raft_mailbox.send_proposal(proposal).await.map_err(anyhow::Error::new)?;
+                Ok(json!({"ok": true}))
+            }
+            "node_down" => {
+                let id = msg.get("id").and_then(|v| v.as_u64()).ok_or_else(|| anyhow!("missing id"))?;
+                let proposal = message::Message::NodeDown { id }.encode()?;
+                raft_mailbox.send_proposal(proposal).await.map_err(anyhow::Error::new)?;
+                Ok(json!({"ok": true, "id": id, "raft_membership_changed": false}))
+            }
+            "node_remove" => {
+                let id = msg.get("id").and_then(|v| v.as_u64()).unwrap_or_else(|| self.scx.node.id());
+                if id != self.scx.node.id() {
+                    return Err(anyhow!(
+                        "node_remove must be sent to target node {id}; \
+                         use action=force_node_remove for business-only cleanup of an unreachable node"
+                    ));
+                }
+                self.leave_cluster(&raft_mailbox).await
+            }
+            "force_node_remove" => {
+                let id = msg.get("id").and_then(|v| v.as_u64()).ok_or_else(|| anyhow!("missing id"))?;
+                if id == self.scx.node.id() {
+                    return Err(anyhow!("force_node_remove cannot remove the local node; use action=leave"));
+                }
+                let proposal = message::Message::NodeRemove { id }.encode()?;
+                raft_mailbox.send_proposal(proposal).await.map_err(anyhow::Error::new)?;
+                Ok(json!({"ok": true, "id": id, "raft_membership_changed": false}))
+            }
+            "drain" | "node_drain" => self.drain_node(&raft_mailbox).await,
+            "undrain" | "resume" | "node_up_local" => self.undrain_node(&raft_mailbox).await,
+            "drain_status" => Ok(self.drain_status(&raft_mailbox).await),
+            "leave" | "node_leave" => self.leave_cluster(&raft_mailbox).await,
+            "nodes" => Ok(self.nodes.to_json()),
+            other => Err(anyhow!("unknown action: {other}")),
+        }
+    }
+}
+
+impl ClusterPlugin {
+    async fn drain_node(&self, raft_mailbox: &Mailbox) -> Result<serde_json::Value> {
+        let id = self.scx.node.id();
+        let proposal = message::Message::NodeDown { id }.encode()?;
+        raft_mailbox.send_proposal(proposal).await.map_err(anyhow::Error::new)?;
+        self.draining.store(true, Ordering::SeqCst);
+        Ok(json!({
+            "ok": true,
+            "id": id,
+            "draining": true,
+            "raft_membership_changed": false,
+            "note": "node is removed from the business gRPC peer table; operator should remove external traffic and wait for drain_status.safe_to_leave"
+        }))
+    }
+
+    async fn undrain_node(&self, raft_mailbox: &Mailbox) -> Result<serde_json::Value> {
+        let node = self.nodes.local_node_from_config(&self.cfg.node_grpc_addrs, &self.cfg.raft_peer_addrs)?;
+        let id = node.id;
+        let proposal = message::Message::NodeUp { node }.encode()?;
+        raft_mailbox.send_proposal(proposal).await.map_err(anyhow::Error::new)?;
+        self.draining.store(false, Ordering::SeqCst);
+        Ok(json!({
+            "ok": true,
+            "id": id,
+            "draining": false,
+            "raft_membership_changed": false,
+        }))
+    }
+
+    async fn drain_status(&self, raft_mailbox: &Mailbox) -> serde_json::Value {
+        let stats = &self.scx.stats;
+        let connections = stats.connections.count();
+        let sessions = stats.sessions.count();
+        let handshakings_active = stats.handshakings_active.count();
+        let message_queues = stats.message_queues.count();
+        let out_inflights = stats.out_inflights.count();
+        let in_inflights = stats.in_inflights.count();
+        let forwards = stats.forwards.count();
+        let message_storages = stats.message_storages.count();
+        let delayed_publishs = stats.delayed_publishs.count();
+        let safe_to_leave = connections == 0
+            && sessions == 0
+            && handshakings_active == 0
+            && message_queues == 0
+            && out_inflights == 0
+            && in_inflights == 0
+            && forwards == 0;
+        let raft_status = raft_mailbox.status().await.ok();
+
+        json!({
+            "id": self.scx.node.id(),
+            "draining": self.draining.load(Ordering::SeqCst),
+            "safe_to_leave": safe_to_leave,
+            "raft_membership_present": raft_status
+                .as_ref()
+                .map(|status| status.peers.contains_key(&self.scx.node.id()))
+                .unwrap_or(false),
+            "raft_leader_id": raft_status.as_ref().map(|status| status.leader_id),
+            "counts": {
+                "connections": connections,
+                "sessions": sessions,
+                "handshakings_active": handshakings_active,
+                "message_queues": message_queues,
+                "out_inflights": out_inflights,
+                "in_inflights": in_inflights,
+                "forwards": forwards,
+                "message_storages": message_storages,
+                "delayed_publishs": delayed_publishs,
+            },
+            "operator_next_step": if safe_to_leave { "leave" } else { "wait" },
+        })
+    }
+
+    async fn leave_cluster(&self, raft_mailbox: &Mailbox) -> Result<serde_json::Value> {
+        let id = self.scx.node.id();
+        let local_node =
+            self.nodes.local_node_from_config(&self.cfg.node_grpc_addrs, &self.cfg.raft_peer_addrs)?;
+
+        let proposal = message::Message::NodeRemove { id }.encode()?;
+        raft_mailbox.send_proposal(proposal).await.map_err(anyhow::Error::new)?;
+
+        if let Err(e) = self.remove_self_from_raft(raft_mailbox).await {
+            let restore = message::Message::NodeUp { node: local_node }.encode()?;
+            if let Err(restore_err) = raft_mailbox.send_proposal(restore).await {
+                log::error!(
+                    "raft leave failed and failed to restore business node metadata, id: {id}, \
+                     leave_error: {e}, restore_error: {restore_err}"
+                );
+            }
+            return Err(e);
+        }
+
+        Ok(json!({"ok": true, "id": id, "raft_membership_changed": true}))
+    }
+
+    async fn remove_self_from_raft(&self, raft_mailbox: &Mailbox) -> Result<()> {
+        let status = raft_mailbox.status().await.map_err(anyhow::Error::new)?;
+        if status.is_leader() {
+            return raft_mailbox.leave().await.map_err(anyhow::Error::new);
+        }
+
+        let leader_id = status.leader_id;
+        let leader_addr = status
+            .peers
+            .get(&leader_id)
+            .and_then(|peer| peer.as_ref().map(|peer| peer.addr.to_string()))
+            .or_else(|| {
+                self.cfg
+                    .raft_peer_addrs
+                    .iter()
+                    .find(|peer| peer.id == leader_id)
+                    .map(|peer| peer.addr.to_string())
+            })
+            .ok_or_else(|| anyhow!("raft leader address not found, leader_id: {leader_id}"))?;
+
+        log::info!(
+            "request raft leader to remove local node, node_id: {}, leader_id: {}, leader_addr: {}",
+            self.scx.node.id(),
+            leader_id,
+            leader_addr
+        );
+        raft_admin::remove_node(
+            &leader_addr,
+            self.scx.node.id(),
+            self.cfg.raft.grpc_timeout.unwrap_or(Duration::from_secs(6)),
+            self.cfg.raft.grpc_concurrency_limit.unwrap_or(200),
+            self.cfg.raft.grpc_message_size.unwrap_or(50 * 1024 * 1024),
+        )
+        .await
     }
 }
 

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/message.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/message.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use rmqtt::types::{Id, NodeHealthStatus, NodeId, SubscriptionOptions};
+use rmqtt::types::{Addr, Id, NodeHealthStatus, NodeId, SubscriptionOptions};
 use rmqtt::Result;
 
 use super::Mailbox;
@@ -23,6 +23,17 @@ pub enum Message<'a> {
     //get client node id
     GetClientNodeId { client_id: &'a str },
     Ping,
+    NodeUp { node: ClusterNode },
+    NodeDown { id: NodeId },
+    NodeRemove { id: NodeId },
+}
+
+/// Business-layer cluster node metadata replicated through Raft.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ClusterNode {
+    pub id: NodeId,
+    pub grpc_addr: Addr,
+    pub raft_addr: Addr,
 }
 
 impl<'a> Message<'a> {

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/nodes.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/nodes.rs
@@ -1,0 +1,172 @@
+//! Runtime cluster node registry for business gRPC peers.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use dashmap::DashMap;
+use serde_json::json;
+
+use rmqtt::{
+    context::ServerContext,
+    grpc::{GrpcClient, GrpcClients},
+    types::{Addr, NodeId, NodeName},
+    utils::NodeAddr,
+};
+
+use super::config::PluginConfig;
+use super::message::ClusterNode;
+use super::HashMap;
+
+#[derive(Clone)]
+pub(crate) struct ClusterNodeManager {
+    scx: ServerContext,
+    nodes: Arc<DashMap<NodeId, ClusterNode, ahash::RandomState>>,
+    clients: Arc<DashMap<NodeId, (Addr, GrpcClient), ahash::RandomState>>,
+    options: Arc<ClientOptions>,
+}
+
+#[derive(Clone)]
+struct ClientOptions {
+    batch_size: usize,
+    concurrency_limit: usize,
+    timeout: Duration,
+}
+
+impl ClientOptions {
+    fn from_config(cfg: &PluginConfig) -> Self {
+        Self {
+            batch_size: cfg.node_grpc_batch_size,
+            concurrency_limit: cfg.node_grpc_client_concurrency_limit,
+            timeout: cfg.node_grpc_client_timeout,
+        }
+    }
+}
+
+impl ClusterNodeManager {
+    pub(crate) fn new(scx: ServerContext, cfg: &PluginConfig) -> Self {
+        Self {
+            scx,
+            nodes: Arc::new(DashMap::default()),
+            clients: Arc::new(DashMap::default()),
+            options: Arc::new(ClientOptions::from_config(cfg)),
+        }
+    }
+
+    pub(crate) async fn seed_from_config(
+        &self,
+        node_grpc_addrs: &[NodeAddr],
+        raft_peer_addrs: &[NodeAddr],
+    ) -> Result<()> {
+        for grpc_addr in node_grpc_addrs {
+            let raft_addr = raft_peer_addrs
+                .iter()
+                .find(|addr| addr.id == grpc_addr.id)
+                .map(|addr| addr.addr.clone())
+                .unwrap_or_default();
+            self.upsert(ClusterNode { id: grpc_addr.id, grpc_addr: grpc_addr.addr.clone(), raft_addr })
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn local_node_from_config(
+        &self,
+        node_grpc_addrs: &[NodeAddr],
+        raft_peer_addrs: &[NodeAddr],
+    ) -> Result<ClusterNode> {
+        let id = self.scx.node.id();
+        let grpc_addr = node_grpc_addrs
+            .iter()
+            .find(|addr| addr.id == id)
+            .map(|addr| addr.addr.clone())
+            .ok_or_else(|| anyhow::anyhow!("node_grpc_addrs does not contain local node id {}", id))?;
+        let raft_addr = raft_peer_addrs
+            .iter()
+            .find(|addr| addr.id == id)
+            .map(|addr| addr.addr.clone())
+            .ok_or_else(|| anyhow::anyhow!("raft_peer_addrs does not contain local node id {}", id))?;
+        Ok(ClusterNode { id, grpc_addr, raft_addr })
+    }
+
+    pub(crate) async fn upsert(&self, node: ClusterNode) -> Result<()> {
+        let id = node.id;
+        let grpc_addr = node.grpc_addr.clone();
+        self.nodes.insert(id, node);
+
+        if id == self.scx.node.id() {
+            self.clients.remove(&id);
+            return Ok(());
+        }
+
+        let client_current = self.clients.get(&id).map(|entry| entry.value().0.clone());
+        if client_current.as_ref() == Some(&grpc_addr) {
+            return Ok(());
+        }
+
+        let client = self
+            .scx
+            .node
+            .new_grpc_client(
+                &grpc_addr,
+                self.options.timeout,
+                self.options.concurrency_limit,
+                self.options.batch_size,
+                &self.scx.circuit_breaker_config,
+            )
+            .await?;
+        self.clients.insert(id, (grpc_addr, client));
+        Ok(())
+    }
+
+    pub(crate) fn remove(&self, node_id: NodeId) {
+        self.nodes.remove(&node_id);
+        self.clients.remove(&node_id);
+    }
+
+    pub(crate) fn grpc_client(&self, node_id: NodeId) -> Option<GrpcClient> {
+        self.clients.get(&node_id).map(|entry| entry.value().1.clone())
+    }
+
+    pub(crate) fn grpc_clients(&self) -> GrpcClients {
+        let mut clients = HashMap::default();
+        for entry in self.clients.iter() {
+            clients.insert(*entry.key(), entry.value().clone());
+        }
+        Arc::new(clients)
+    }
+
+    pub(crate) fn node_name(&self, id: NodeId) -> NodeName {
+        self.nodes.get(&id).map(|node| format!("{}@{}", node.id, node.grpc_addr)).unwrap_or_default()
+    }
+
+    pub(crate) fn snapshot_nodes(&self) -> Vec<ClusterNode> {
+        self.nodes.iter().map(|entry| entry.value().clone()).collect()
+    }
+
+    pub(crate) async fn restore_nodes(&self, nodes: Vec<ClusterNode>) -> Result<()> {
+        self.nodes.clear();
+        self.clients.clear();
+        for node in nodes {
+            self.upsert(node).await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn to_json(&self) -> serde_json::Value {
+        let nodes = self
+            .nodes
+            .iter()
+            .map(|entry| {
+                let node = entry.value();
+                json!({
+                    "id": node.id,
+                    "grpc_addr": node.grpc_addr,
+                    "raft_addr": node.raft_addr,
+                    "has_grpc_client": self.clients.contains_key(&node.id),
+                })
+            })
+            .collect::<Vec<_>>();
+        json!(nodes)
+    }
+}

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/raft_admin.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/raft_admin.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use prost::Message;
+use serde::Deserialize;
+use tikv_raft::eraftpb::{ConfChange, ConfChangeType};
+use tonic::codec::ProstCodec;
+use tonic::transport::Channel;
+
+use rmqtt::types::NodeId;
+use rmqtt_raft::Status;
+
+#[derive(Clone, PartialEq, Message)]
+struct RaftConfChange {
+    #[prost(bytes = "vec", tag = "1")]
+    inner: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct RaftResponseMessage {
+    #[prost(bytes = "vec", tag = "2")]
+    inner: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+enum RaftResponse {
+    WrongLeader { leader_id: u64, leader_addr: Option<String> },
+    JoinSuccess { assigned_id: u64, peer_addrs: HashMap<u64, String> },
+    RequestId { leader_id: u64 },
+    Error(String),
+    Busy,
+    Response { data: Vec<u8> },
+    Status(Status),
+    Ok,
+}
+
+pub(crate) async fn remove_node(
+    leader_addr: &str,
+    node_id: NodeId,
+    timeout: Duration,
+    concurrency_limit: usize,
+    message_size: usize,
+) -> Result<()> {
+    let mut change = ConfChange::default();
+    change.set_node_id(node_id);
+    change.set_change_type(ConfChangeType::RemoveNode);
+
+    let endpoint = Channel::from_shared(format!("http://{leader_addr}"))?
+        .concurrency_limit(concurrency_limit)
+        .connect_timeout(timeout)
+        .timeout(timeout);
+    let channel = endpoint.connect().await?;
+    let mut grpc = tonic::client::Grpc::new(channel)
+        .max_decoding_message_size(message_size)
+        .max_encoding_message_size(message_size);
+
+    grpc.ready().await?;
+    let path = tonic::codegen::http::uri::PathAndQuery::from_static("/raftservice.RaftService/ChangeConfig");
+    let codec = ProstCodec::<RaftConfChange, RaftResponseMessage>::default();
+    let response = grpc
+        .unary(tonic::Request::new(RaftConfChange { inner: change.encode_to_vec() }), path, codec)
+        .await?;
+
+    let response: RaftResponse = postcard::from_bytes(&response.into_inner().inner)?;
+    match response {
+        RaftResponse::Ok => Ok(()),
+        RaftResponse::WrongLeader { leader_id, leader_addr } => Err(anyhow!(
+            "raft remove_node sent to wrong leader, actual leader_id: {leader_id}, leader_addr: {leader_addr:?}"
+        )),
+        RaftResponse::Error(e) => Err(anyhow!(e)),
+        RaftResponse::Busy => Err(anyhow!("raft leader is busy")),
+        other => Err(anyhow!("unexpected raft remove_node response: {other:?}")),
+    }
+}

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/router.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/router.rs
@@ -31,7 +31,8 @@ use rmqtt_raft::{Error, Mailbox, Result as RaftResult, Store};
 use tokio::task::{block_in_place, spawn_blocking};
 
 use super::config::Compression;
-use super::message::{Message, MessageReply};
+use super::message::{ClusterNode, Message, MessageReply};
+use super::nodes::ClusterNodeManager;
 
 type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;
 type DashMap<K, V> = dashmap::DashMap<K, V, ahash::RandomState>;
@@ -62,6 +63,7 @@ pub(crate) struct ClusterRouter {
     add_exec: TaskExecQueue,
     remove_exec: TaskExecQueue,
     backoff_strategy: ExponentialBackoff,
+    nodes: ClusterNodeManager,
     raft_mailbox: Arc<RwLock<Option<Mailbox>>>,
     client_states: Arc<DashMap<ClientId, ClientStatus>>,
     pub try_lock_timeout: Duration,
@@ -73,6 +75,7 @@ impl ClusterRouter {
     pub(crate) fn new(
         scx: ServerContext,
         backoff_strategy: ExponentialBackoff,
+        nodes: ClusterNodeManager,
         try_lock_timeout: Duration,
         compression: Option<Compression>,
     ) -> Self {
@@ -83,6 +86,7 @@ impl ClusterRouter {
             add_exec,
             remove_exec,
             backoff_strategy,
+            nodes,
             raft_mailbox: Arc::new(RwLock::new(None)),
             client_states: Arc::new(DashMap::default()),
             try_lock_timeout,
@@ -137,6 +141,49 @@ impl ClusterRouter {
     #[inline]
     pub(crate) fn get_target_node_id(&self, target_clientid: &str) -> Option<NodeId> {
         self.client_states.get(target_clientid).map(|entry| entry.id.node_id)
+    }
+
+    async fn remove_node_state(&self, node_id: NodeId) {
+        let client_ids =
+            self.client_states
+                .iter()
+                .filter_map(|entry| {
+                    if entry.value().id.node_id == node_id {
+                        Some(entry.key().clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+        for client_id in client_ids {
+            self.client_states.remove(&client_id);
+        }
+
+        let removals = self
+            .inner
+            .relations
+            .iter()
+            .flat_map(|entry| {
+                let topic_filter = entry.key().clone();
+                entry
+                    .value()
+                    .iter()
+                    .filter_map(move |(_, (id, _))| {
+                        if id.node_id == node_id {
+                            Some((topic_filter.clone(), id.clone()))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        for (topic_filter, id) in removals {
+            if let Err(e) = self.inner.remove(&topic_filter, id).await {
+                log::warn!("remove node route failed, node_id: {node_id}, topic_filter: {topic_filter}, {e}");
+            }
+        }
     }
 }
 
@@ -355,6 +402,19 @@ impl Store for ClusterRouter {
                 log::debug!("[Router.remove] topic_filter: {topic_filter:?}, id: {id:?}",);
                 self.inner.remove(topic_filter, id).await?;
             }
+            Message::NodeUp { node } => {
+                log::info!("[Router.NodeUp] node: {node:?}");
+                self.nodes.upsert(node).await.map_err(|e| Error::Anyhow(e.into()))?;
+            }
+            Message::NodeDown { id } => {
+                log::info!("[Router.NodeDown] id: {id}");
+                self.nodes.remove(id);
+            }
+            Message::NodeRemove { id } => {
+                log::info!("[Router.NodeRemove] id: {id}");
+                self.nodes.remove(id);
+                self.remove_node_state(id).await;
+            }
             Message::GetClientNodeId { client_id } => {
                 let node_id = self._client_node_id(client_id);
                 let data = postcard::to_stdvec(&node_id).map_err(|e| Error::Other(Box::new(e)))?;
@@ -423,6 +483,7 @@ impl Store for ClusterRouter {
         let client_states = self.client_states.clone();
         let topics_count = self.inner.topics_count.clone();
         let relations_count = self.inner.relations_count.clone();
+        let cluster_nodes = self.nodes.snapshot_nodes();
         let snapshot: Vec<u8> = spawn_blocking(move || {
             let relations = relations
                 .iter()
@@ -444,12 +505,14 @@ impl Store for ClusterRouter {
             let client_states_bin = client_states_bin??;
             let topics_count_bin = postcard::to_stdvec(&topics_count.as_ref())?;
             let relations_count_bin = postcard::to_stdvec(&relations_count.as_ref())?;
+            let cluster_nodes_bin = postcard::to_stdvec(&cluster_nodes)?;
 
             let mut snapshot = Vec::new();
             encode_with_length_prefix(&relations_bin, &mut snapshot);
             encode_with_length_prefix(&client_states_bin, &mut snapshot);
             encode_with_length_prefix(&topics_count_bin, &mut snapshot);
             encode_with_length_prefix(&relations_count_bin, &mut snapshot);
+            encode_with_length_prefix(&cluster_nodes_bin, &mut snapshot);
 
             Ok(snapshot)
         })
@@ -526,6 +589,14 @@ impl Store for ClusterRouter {
 
             let relations_count_len = read_len(snapshot, topics_count_start + topics_count_len)?;
             let relations_count_start = size_of::<usize>() + topics_count_start + topics_count_len;
+            let cluster_nodes_len_start = relations_count_start + relations_count_len;
+            let (cluster_nodes_start, cluster_nodes_len) =
+                if snapshot.len() >= cluster_nodes_len_start + size_of::<usize>() {
+                    let len = read_len(snapshot, cluster_nodes_len_start)?;
+                    (cluster_nodes_len_start + size_of::<usize>(), len)
+                } else {
+                    (snapshot.len(), 0)
+                };
 
             let (relations, client_states) = rayon::join(
                 || decode_with_length_prefix(snapshot, relations_start, relations_len, true, compression),
@@ -545,16 +616,22 @@ impl Store for ClusterRouter {
                 decode_with_length_prefix(snapshot, topics_count_start, topics_count_len, false, None)?;
             let relations_count: Counter =
                 decode_with_length_prefix(snapshot, relations_count_start, relations_count_len, false, None)?;
+            let cluster_nodes: Vec<ClusterNode> = if cluster_nodes_len > 0 {
+                decode_with_length_prefix(snapshot, cluster_nodes_start, cluster_nodes_len, false, None)?
+            } else {
+                Vec::new()
+            };
 
             log::info!("relations: {:?}", relations.len());
             log::info!("client_states: {:?}", client_states.len());
             log::info!("topics_count: {topics_count:?}",);
             log::info!("relations_count: {relations_count:?}");
+            log::info!("cluster_nodes: {:?}", cluster_nodes.len());
 
-            Ok((relations, client_states, topics_count, relations_count))
+            Ok((relations, client_states, topics_count, relations_count, cluster_nodes))
         });
 
-        let (relations, client_states, topics_count, relations_count) = res?;
+        let (relations, client_states, topics_count, relations_count, cluster_nodes) = res?;
 
         self.inner.topics_count.set(&topics_count);
         let mut topics = self.inner.topics.write().await;
@@ -569,6 +646,9 @@ impl Store for ClusterRouter {
         self.client_states.clear();
         for (client_id, content) in client_states {
             self.client_states.insert(client_id, content);
+        }
+        if !cluster_nodes.is_empty() {
+            self.nodes.restore_nodes(cluster_nodes).await.map_err(|e| Error::Anyhow(e.into()))?;
         }
 
         log::info!(

--- a/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
+++ b/rmqtt-plugins/rmqtt-cluster-raft/src/shared.rs
@@ -30,8 +30,8 @@ use rmqtt::{
     session::Session,
     shared::{DefaultShared, Entry, MessageLoadCallback, Shared},
     types::{
-        ForwardedCount, ForwardedRecipients, From, Id, IsAdmin, NodeId, NodeName, OfflineSession, Publish,
-        Reason, SessionStatus, SubRelations, SubRelationsMap, SubsSearchParams, SubsSearchResult, Subscribe,
+        ForwardedCount, ForwardedRecipients, From, Id, IsAdmin, NodeId, OfflineSession, Publish, Reason,
+        SessionStatus, SubRelations, SubRelationsMap, SubsSearchParams, SubsSearchResult, Subscribe,
         SubscribeReturn, To, Tx, Unsubscribe,
     },
     types::{HealthInfo, MsgID, NodeHealthStatus, SharedGroup},
@@ -42,7 +42,8 @@ use super::message::{
     get_client_node_id, Message as RaftMessage, MessageReply as RaftMessageReply, RaftGrpcMessage,
     RaftGrpcMessageReply,
 };
-use super::{ClusterRouter, HashMap};
+use super::nodes::ClusterNodeManager;
+use super::ClusterRouter;
 
 pub struct ClusterLockEntry {
     scx: ServerContext,
@@ -310,8 +311,7 @@ pub struct ClusterShared {
     retainer_exec: TaskExecQueue,
     inner: DefaultShared,
     router: ClusterRouter,
-    grpc_clients: GrpcClients,
-    node_names: Arc<HashMap<NodeId, NodeName>>,
+    nodes: ClusterNodeManager,
     pub(crate) message_type: MessageType,
     exec_queue_busy_limit: isize,
     exec_queue_workers_busy_limit: isize,
@@ -325,8 +325,7 @@ impl ClusterShared {
         scx: ServerContext,
         exec: TaskExecQueue,
         router: ClusterRouter,
-        grpc_clients: GrpcClients,
-        node_names: HashMap<NodeId, NodeName>,
+        nodes: ClusterNodeManager,
         message_type: MessageType,
         exec_queue_max: usize,
         exec_queue_workers: usize,
@@ -342,8 +341,7 @@ impl ClusterShared {
             retainer_exec,
             inner: DefaultShared::new(Some(scx1)),
             router,
-            grpc_clients,
-            node_names: Arc::new(node_names),
+            nodes,
             message_type,
             exec_queue_busy_limit: (exec_queue_max as f64 * 0.7) as isize,
             exec_queue_workers_busy_limit: (exec_queue_workers as f64 * 0.9) as isize,
@@ -358,7 +356,7 @@ impl ClusterShared {
 
     #[inline]
     pub(crate) fn grpc_client(&self, node_id: u64) -> Option<GrpcClient> {
-        self.grpc_clients.get(&node_id).map(|(_, c)| c.clone())
+        self.nodes.grpc_client(node_id)
     }
 
     /// Converts [`SubRelations`] to [`ForwardedRecipients`].
@@ -672,12 +670,12 @@ impl Shared for ClusterShared {
         if message_mgr.merge_on_read() {
             log::debug!(
                 "message_load start, client_id: {client_id}, grpc_clients: {}, rw_timeout: {:?}",
-                self.grpc_clients.len(),
+                self.nodes.grpc_clients().len(),
                 self.rw_timeout
             );
             let mut msgs = message_mgr.get(client_id, topic_filter, group).await?;
-            if !self.grpc_clients.is_empty() {
-                let grpc_clients = self.grpc_clients.clone();
+            let grpc_clients = self.nodes.grpc_clients();
+            if !grpc_clients.is_empty() {
                 let message_type = self.message_type;
                 let rw_timeout = self.rw_timeout;
                 let client_id = ClientId::from(client_id);
@@ -733,14 +731,14 @@ impl Shared for ClusterShared {
         if message_mgr.merge_on_read() {
             log::debug!(
                 "message_load_with start, client_id: {client_id}, grpc_clients: {}, rw_timeout: {:?}",
-                self.grpc_clients.len(),
+                self.nodes.grpc_clients().len(),
                 self.rw_timeout
             );
             let msgs = message_mgr.get(client_id, topic_filter, group).await?;
             cb.on_messages(msgs).await?;
 
-            if !self.grpc_clients.is_empty() {
-                let grpc_clients = self.grpc_clients.clone();
+            let grpc_clients = self.nodes.grpc_clients();
+            if !grpc_clients.is_empty() {
                 let message_type = self.message_type;
                 let rw_timeout = self.rw_timeout;
                 let client_id = ClientId::from(client_id);
@@ -802,13 +800,13 @@ impl Shared for ClusterShared {
         if retain_mgr.merge_on_read() {
             log::debug!(
                 "retain_load_with start, topic_filter: {topic_filter}, grpc_clients: {}, rw_timeout: {:?}",
-                self.grpc_clients.len(),
+                self.nodes.grpc_clients().len(),
                 self.rw_timeout
             );
             let mut all_retains = retain_mgr.get(topic_filter).await?;
 
-            if !self.grpc_clients.is_empty() {
-                let grpc_clients = self.grpc_clients.clone();
+            let grpc_clients = self.nodes.grpc_clients();
+            if !grpc_clients.is_empty() {
                 let message_type = self.message_type;
                 let rw_timeout = self.rw_timeout;
                 let topic_filter = topic_filter.clone();
@@ -865,14 +863,15 @@ impl Shared for ClusterShared {
         retain: &Retain,
         expiry_interval: Option<Duration>,
     ) -> Result<()> {
-        if self.grpc_clients.is_empty() {
+        let grpc_clients = self.nodes.grpc_clients();
+        if grpc_clients.is_empty() {
             return Ok(());
         }
 
         match self.scx.extends.retain().await.retain_sync_mode() {
             RetainSyncMode::Full => {
                 let msg = Message::SetRetain(topic.clone(), retain.clone(), expiry_interval);
-                for (node_id, (_, client)) in self.grpc_clients.iter() {
+                for (node_id, (_, client)) in grpc_clients.iter() {
                     let sender = MessageSender::new(
                         client.clone(),
                         self.message_type,
@@ -891,7 +890,7 @@ impl Shared for ClusterShared {
                 } else {
                     Message::SetRetainTopicRemove(topic.clone())
                 };
-                for (node_id, (_, client)) in self.grpc_clients.iter() {
+                for (node_id, (_, client)) in grpc_clients.iter() {
                     let sender = MessageSender::new(
                         client.clone(),
                         self.message_type,
@@ -939,12 +938,12 @@ impl Shared for ClusterShared {
     }
     #[inline]
     fn get_grpc_clients(&self) -> GrpcClients {
-        self.grpc_clients.clone()
+        self.nodes.grpc_clients()
     }
 
     #[inline]
     fn node_name(&self, id: NodeId) -> String {
-        self.node_names.get(&id).cloned().unwrap_or_default()
+        self.nodes.node_name(id)
     }
 
     #[inline]
@@ -962,7 +961,7 @@ impl Shared for ClusterShared {
 
         let data = RaftGrpcMessage::GetNodeHealthStatus.encode()?;
         let replys = MessageBroadcaster::new(
-            self.grpc_clients.clone(),
+            self.nodes.grpc_clients(),
             self.message_type,
             Message::Data(data),
             Some(Duration::from_secs(5)),
@@ -1039,7 +1038,8 @@ impl ClusterShared {
     /// Called once at startup (with a small delay) so a new or restarted node
     /// catches up on retains that were published while it was offline.
     pub(crate) async fn sync_retains_from_peers(&self) {
-        if self.grpc_clients.is_empty() {
+        let grpc_clients = self.nodes.grpc_clients();
+        if grpc_clients.is_empty() {
             return;
         }
         let retain_mgr = self.scx.extends.retain().await;
@@ -1051,7 +1051,7 @@ impl ClusterShared {
         const CHUNK: usize = 5000;
         let shared = self.clone();
         let peers: Vec<_> =
-            self.grpc_clients.iter().map(|(node_id, (_, client))| (*node_id, client.clone())).collect();
+            grpc_clients.iter().map(|(node_id, (_, client))| (*node_id, client.clone())).collect();
 
         let handles: Vec<_> = peers
             .into_iter()

--- a/rmqtt-plugins/rmqtt-http-api/src/api.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/api.rs
@@ -123,7 +123,8 @@ fn route(
                 .push(Router::with_path("{node}/{plugin}/config").get(node_plugin_config))
                 .push(Router::with_path("{node}/{plugin}/config/reload").put(node_plugin_config_reload))
                 .push(Router::with_path("{node}/{plugin}/load").put(node_plugin_load))
-                .push(Router::with_path("{node}/{plugin}/unload").put(node_plugin_unload)),
+                .push(Router::with_path("{node}/{plugin}/unload").put(node_plugin_unload))
+                .push(Router::with_path("{node}/{plugin}/send").post(node_plugin_send)),
         )
         .push(
             Router::with_path("stats")
@@ -1892,6 +1893,79 @@ async fn _node_plugin_unload(
             reply => {
                 log::info!("Unload GrpcMessage::UnloadPlugin from other node({node_id}), reply: {reply:?}");
                 Ok(false)
+            }
+        }
+    }
+}
+
+#[handler]
+async fn node_plugin_send(
+    req: &mut Request,
+    depot: &mut Depot,
+    res: &mut Response,
+) -> std::result::Result<(), salvo::Error> {
+    let (scx, cfg) = get_scx_cfg(depot)?;
+    let message_type = cfg.read().await.message_type;
+    let node_id = if let Some(node_id) = req.param::<NodeId>("node") {
+        node_id
+    } else {
+        res.status_code(StatusCode::NOT_FOUND);
+        return Ok(());
+    };
+    let name = if let Some(name) = req.param::<String>("plugin") {
+        name
+    } else {
+        res.status_code(StatusCode::NOT_FOUND);
+        return Ok(());
+    };
+    if name != "rmqtt-cluster-raft" {
+        res.render(StatusError::bad_request().detail("plugin send is only supported for rmqtt-cluster-raft"));
+        return Ok(());
+    }
+    let msg = match req.parse_json::<serde_json::Value>().await {
+        Ok(msg) => msg,
+        Err(e) => {
+            res.render(StatusError::bad_request().detail(e.to_string()));
+            return Ok(());
+        }
+    };
+
+    match _node_plugin_send(scx, node_id, &name, msg, message_type).await {
+        Ok(r) => res.render(Json(r)),
+        Err(e) => res.render(StatusError::service_unavailable().detail(e.to_string())),
+    }
+    Ok(())
+}
+
+async fn _node_plugin_send(
+    scx: &ServerContext,
+    node_id: NodeId,
+    name: &str,
+    msg: serde_json::Value,
+    message_type: MessageType,
+) -> Result<serde_json::Value> {
+    if node_id == scx.node.id() {
+        scx.plugins.send(name, msg).await
+    } else {
+        let c = get_grpc_client(scx, node_id).await?;
+        let msg = Message::SendPluginMessage { name, msg }.encode()?;
+        let reply =
+            MessageSender::new_quick(c, message_type, GrpcMessage::Data(msg), Some(Duration::from_secs(10)))
+                .send()
+                .await?;
+        match reply {
+            GrpcMessageReply::Data(msg) => match MessageReply::decode(&msg)? {
+                MessageReply::SendPluginMessage(reply) => Ok(reply),
+                _ => {
+                    log::error!("unreachable!(), msg: {msg:?}");
+                    Err(anyhow!("unreachable!()"))
+                }
+            },
+            reply => {
+                log::info!(
+                    "Send GrpcMessage::SendPluginMessage from other node({node_id}), reply: {reply:?}"
+                );
+                Err(anyhow!("invalid reply"))
             }
         }
     }

--- a/rmqtt-plugins/rmqtt-http-api/src/handler.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/handler.rs
@@ -256,6 +256,21 @@ impl Handler for HookHandler {
                                     HookResult::GrpcMessageReply(Ok(GrpcMessageReply::Error(e.to_string())))
                                 }
                             },
+                            Ok(Message::SendPluginMessage { name, msg }) => {
+                                match self.scx.plugins.send(name, msg).await {
+                                    Ok(reply) => match MessageReply::SendPluginMessage(reply).encode() {
+                                        Ok(ress) => {
+                                            HookResult::GrpcMessageReply(Ok(GrpcMessageReply::Data(ress)))
+                                        }
+                                        Err(e) => HookResult::GrpcMessageReply(Ok(GrpcMessageReply::Error(
+                                            e.to_string(),
+                                        ))),
+                                    },
+                                    Err(e) => HookResult::GrpcMessageReply(Ok(GrpcMessageReply::Error(
+                                        e.to_string(),
+                                    ))),
+                                }
+                            }
                         };
                         return (false, Some(new_acc));
                     }

--- a/rmqtt-plugins/rmqtt-http-api/src/types.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/types.rs
@@ -43,6 +43,7 @@ pub enum Message<'a> {
     ReloadPluginConfig { name: &'a str },
     LoadPlugin { name: &'a str },
     UnloadPlugin { name: &'a str },
+    SendPluginMessage { name: &'a str, msg: serde_json::Value },
 }
 
 impl Message<'_> {
@@ -77,6 +78,7 @@ pub enum MessageReply {
     ReloadPluginConfig,
     LoadPlugin,
     UnloadPlugin(bool),
+    SendPluginMessage(serde_json::Value),
 }
 
 impl MessageReply {


### PR DESCRIPTION
## Summary

This PR adds dynamic scale-out/scale-in support for `rmqtt-cluster-raft` without requiring existing nodes to update their static `node_grpc_addrs` config.

## Changes

- Add dynamic cluster node metadata propagation through raft messages.
- Add NodeUp/NodeDown/NodeRemove handling for business gRPC peer discovery.
- Add `nodes`, `drain_status`, `drain`, `leave`, and `undrain/resume` plugin actions.
- Allow a newly added node to join raft membership and publish its gRPC/raft addresses to existing nodes.
- Allow a leaving node to be drained and removed from raft membership.
- Restrict HTTP plugin `/send` API to `rmqtt-cluster-raft`.

## Test

- `cargo fmt --check`
- `cargo check -p rmqtt-cluster-raft -p rmqtt-http-api`
- `cargo test -p rmqtt-cluster-raft -p rmqtt-http-api`
- Docker test with official `Dockerfile.amd64` image: PASS

Docker test covered:

1. Start node1/node2/node3.
2. Dynamically add node4.
3. Verify all nodes can see node4 in dynamic gRPC peers.
4. Run `drain_status` on node4.
5. Run `drain` on node4.
6. Run `leave` on node4.
7. Verify node1/node2/node3 no longer see node4.