### PR TITLE
feat(dashboard): add client detail page and cluster example configuration overhaul

### DIFF
--- a/examples/cluster-broadcast/1/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-broadcast/1/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-broadcast/1/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-broadcast/1/plugins/rmqtt-cluster-raft.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006"]
 

--- a/examples/cluster-broadcast/1/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-broadcast/1/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6060"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 1 -> port 6061.
+http_laddr = "0.0.0.0:6061"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-broadcast/1/rmqtt.toml
+++ b/examples/cluster-broadcast/1/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 1
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5363"
+rpc.server_addr = "0.0.0.0:5364"
 rpc.server_workers = 4
 #Maximum number of messages sent in batch
 rpc.batch_size = 128
@@ -41,6 +41,7 @@ plugins.dir = "./plugins"
 plugins.default_startups = [
     "rmqtt-retainer",
     "rmqtt-cluster-broadcast",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-message-storage",
     "rmqtt-shared-subscription",
@@ -54,7 +55,7 @@ plugins.default_startups = [
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1883"
+listener.tcp.external.addr = "0.0.0.0:1884"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-broadcast/2/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-broadcast/2/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-broadcast/2/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-broadcast/2/plugins/rmqtt-cluster-raft.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006"]
 

--- a/examples/cluster-broadcast/2/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-broadcast/2/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6061"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 2 -> port 6062.
+http_laddr = "0.0.0.0:6062"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-broadcast/2/rmqtt.toml
+++ b/examples/cluster-broadcast/2/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 2
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5364"
+rpc.server_addr = "0.0.0.0:5365"
 rpc.server_workers = 4
 #Maximum number of messages sent in batch
 rpc.batch_size = 128
@@ -41,6 +41,7 @@ plugins.dir = "./plugins"
 plugins.default_startups = [
     "rmqtt-retainer",
     "rmqtt-cluster-broadcast",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-message-storage",
     "rmqtt-shared-subscription",
@@ -54,7 +55,7 @@ plugins.default_startups = [
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1884"
+listener.tcp.external.addr = "0.0.0.0:1885"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-broadcast/3/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-broadcast/3/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-broadcast/3/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-broadcast/3/plugins/rmqtt-cluster-raft.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006"]
 

--- a/examples/cluster-broadcast/3/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-broadcast/3/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6062"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 3 -> port 6063.
+http_laddr = "0.0.0.0:6063"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-broadcast/3/rmqtt.toml
+++ b/examples/cluster-broadcast/3/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 3
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5365"
+rpc.server_addr = "0.0.0.0:5366"
 rpc.server_workers = 4
 #Maximum number of messages sent in batch
 rpc.batch_size = 128
@@ -41,6 +41,7 @@ plugins.dir = "./plugins"
 plugins.default_startups = [
     "rmqtt-retainer",
     "rmqtt-cluster-broadcast",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-message-storage",
     "rmqtt-shared-subscription",
@@ -54,7 +55,7 @@ plugins.default_startups = [
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1885"
+listener.tcp.external.addr = "0.0.0.0:1886"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-raft-3/1/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-raft-3/1/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-cluster-raft.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 #Maximum number of messages sent in batch
 node_grpc_batch_size = 128
 ##Client concurrent request limit
@@ -14,10 +14,10 @@ node_grpc_client_concurrency_limit = 128
 node_grpc_client_timeout = "10s"
 
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006"]
 
 #Raft cluster listening address
-laddr = "0.0.0.0:6003"
+laddr = "0.0.0.0:6004"
 
 #Specify a leader id, when the value is 0 or not specified, the first node
 #will be designated as the Leader. Default value: 0

--- a/examples/cluster-raft-3/1/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-raft-3/1/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6060"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 1 -> port 6061.
+http_laddr = "0.0.0.0:6061"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-raft-3/1/rmqtt.toml
+++ b/examples/cluster-raft-3/1/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 1
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5363"
+rpc.server_addr = "0.0.0.0:5364"
 rpc.server_workers = 4
 
 ##--------------------------------------------------------------------
@@ -34,6 +34,7 @@ plugins.dir = "./plugins/"
 plugins.default_startups = [
     "rmqtt-retainer",
     "rmqtt-cluster-raft",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",
     "rmqtt-message-storage",
@@ -66,7 +67,7 @@ mqtt.max_sessions = 0
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1883"
+listener.tcp.external.addr = "0.0.0.0:1884"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-raft-3/2/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-raft-3/2/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-cluster-raft.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 #Maximum number of messages sent in batch
 node_grpc_batch_size = 128
 ##Client concurrent request limit
@@ -14,10 +14,10 @@ node_grpc_client_concurrency_limit = 128
 node_grpc_client_timeout = "10s"
 
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006"]
 
 #Raft cluster listening address
-laddr = "0.0.0.0:6004"
+laddr = "0.0.0.0:6005"
 
 #Specify a leader id, when the value is 0 or not specified, the first node
 #will be designated as the Leader. Default value: 0

--- a/examples/cluster-raft-3/2/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-raft-3/2/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6061"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 2 -> port 6062.
+http_laddr = "0.0.0.0:6062"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-raft-3/2/rmqtt.toml
+++ b/examples/cluster-raft-3/2/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 2
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5364"
+rpc.server_addr = "0.0.0.0:5365"
 rpc.server_workers = 4
 
 
@@ -35,6 +35,7 @@ plugins.dir = "./plugins/"
 plugins.default_startups = [
     "rmqtt-retainer",
     "rmqtt-cluster-raft",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",
     "rmqtt-message-storage",
@@ -67,7 +68,7 @@ mqtt.max_sessions = 0
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1884"
+listener.tcp.external.addr = "0.0.0.0:1885"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-raft-3/3/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-raft-3/3/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-cluster-raft.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 #Maximum number of messages sent in batch
 node_grpc_batch_size = 128
 ##Client concurrent request limit
@@ -14,10 +14,10 @@ node_grpc_client_concurrency_limit = 128
 node_grpc_client_timeout = "10s"
 
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006"]
 
 #Raft cluster listening address
-laddr = "0.0.0.0:6005"
+laddr = "0.0.0.0:6006"
 
 #Specify a leader id, when the value is 0 or not specified, the first node
 #will be designated as the Leader. Default value: 0

--- a/examples/cluster-raft-3/3/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-raft-3/3/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6062"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 3 -> port 6063.
+http_laddr = "0.0.0.0:6063"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-raft-3/3/rmqtt.toml
+++ b/examples/cluster-raft-3/3/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 3
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5365"
+rpc.server_addr = "0.0.0.0:5366"
 rpc.server_workers = 4
 
 
@@ -35,6 +35,7 @@ plugins.dir = "./plugins/"
 plugins.default_startups = [
     "rmqtt-retainer",
     "rmqtt-cluster-raft",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",
     "rmqtt-message-storage",
@@ -67,7 +68,7 @@ mqtt.max_sessions = 0
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1885"
+listener.tcp.external.addr = "0.0.0.0:1886"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-raft-5/1/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-raft-5/1/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-cluster-raft.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365", "4@127.0.0.1:5366", "5@127.0.0.1:5367"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366", "4@127.0.0.1:5367", "5@127.0.0.1:5368"]
 #Maximum number of messages sent in batch
 node_grpc_batch_size = 128
 #Client concurrent request limit
@@ -13,10 +13,10 @@ node_grpc_client_concurrency_limit = 128
 #Connect and send to server timeout
 node_grpc_client_timeout = "10s"
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005", "4@127.0.0.1:6006", "5@127.0.0.1:6007"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006", "4@127.0.0.1:6007", "5@127.0.0.1:6008"]
 
 #Raft cluster listening address
-laddr = "0.0.0.0:6003"
+laddr = "0.0.0.0:6004"
 
 #Specify a leader id, when the value is 0 or not specified, the first node
 #will be designated as the Leader. Default value: 0

--- a/examples/cluster-raft-5/1/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-raft-5/1/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6060"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 1 -> port 6061.
+http_laddr = "0.0.0.0:6061"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-raft-5/1/rmqtt.toml
+++ b/examples/cluster-raft-5/1/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 1
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5363"
+rpc.server_addr = "0.0.0.0:5364"
 rpc.server_workers = 4
 #Maximum number of messages sent in batch
 rpc.batch_size = 128
@@ -40,6 +40,7 @@ plugins.dir = "./plugins/"
 plugins.default_startups = [
     #"rmqtt-retainer",
     "rmqtt-cluster-raft",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",
     #"rmqtt-message-storage",
@@ -70,7 +71,7 @@ mqtt.max_sessions = 0
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1883"
+listener.tcp.external.addr = "0.0.0.0:1884"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-raft-5/2/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-raft-5/2/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-cluster-raft.toml
@@ -5,12 +5,12 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365", "4@127.0.0.1:5366", "5@127.0.0.1:5367"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366", "4@127.0.0.1:5367", "5@127.0.0.1:5368"]
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005", "4@127.0.0.1:6006", "5@127.0.0.1:6007"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006", "4@127.0.0.1:6007", "5@127.0.0.1:6008"]
 
 #Raft cluster listening address
-laddr = "0.0.0.0:6004"
+laddr = "0.0.0.0:6005"
 
 #Specify a leader id, when the value is 0 or not specified, the first node
 #will be designated as the Leader. Default value: 0

--- a/examples/cluster-raft-5/2/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-raft-5/2/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6061"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 2 -> port 6062.
+http_laddr = "0.0.0.0:6062"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-raft-5/2/rmqtt.toml
+++ b/examples/cluster-raft-5/2/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 2
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5364"
+rpc.server_addr = "0.0.0.0:5365"
 rpc.server_workers = 4
 #Maximum number of messages sent in batch
 rpc.batch_size = 128
@@ -41,6 +41,7 @@ plugins.dir = "./plugins/"
 plugins.default_startups = [
     #"rmqtt-retainer",
     "rmqtt-cluster-raft",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",
     #"rmqtt-message-storage",
@@ -71,7 +72,7 @@ mqtt.max_sessions = 0
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1884"
+listener.tcp.external.addr = "0.0.0.0:1885"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-raft-5/3/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-raft-5/3/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-cluster-raft.toml
@@ -5,12 +5,12 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365", "4@127.0.0.1:5366", "5@127.0.0.1:5367"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366", "4@127.0.0.1:5367", "5@127.0.0.1:5368"]
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005", "4@127.0.0.1:6006", "5@127.0.0.1:6007"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006", "4@127.0.0.1:6007", "5@127.0.0.1:6008"]
 
 #Raft cluster listening address
-laddr = "0.0.0.0:6005"
+laddr = "0.0.0.0:6006"
 
 #Specify a leader id, when the value is 0 or not specified, the first node
 #will be designated as the Leader. Default value: 0

--- a/examples/cluster-raft-5/3/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-raft-5/3/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6062"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 3 -> port 6063.
+http_laddr = "0.0.0.0:6063"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-raft-5/3/rmqtt.toml
+++ b/examples/cluster-raft-5/3/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 3
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5365"
+rpc.server_addr = "0.0.0.0:5366"
 rpc.server_workers = 4
 #Maximum number of messages sent in batch
 rpc.batch_size = 128
@@ -41,6 +41,7 @@ plugins.dir = "./plugins/"
 plugins.default_startups = [
     #"rmqtt-retainer",
     "rmqtt-cluster-raft",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",
     #"rmqtt-message-storage",
@@ -71,7 +72,7 @@ mqtt.max_sessions = 0
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1885"
+listener.tcp.external.addr = "0.0.0.0:1886"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-raft-5/4/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-raft-5/4/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-cluster-raft.toml
@@ -5,12 +5,12 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365", "4@127.0.0.1:5366", "5@127.0.0.1:5367"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366", "4@127.0.0.1:5367", "5@127.0.0.1:5368"]
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005", "4@127.0.0.1:6006", "5@127.0.0.1:6007"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006", "4@127.0.0.1:6007", "5@127.0.0.1:6008"]
 
 #Raft cluster listening address
-laddr = "0.0.0.0:6006"
+laddr = "0.0.0.0:6007"
 
 #Specify a leader id, when the value is 0 or not specified, the first node
 #will be designated as the Leader. Default value: 0

--- a/examples/cluster-raft-5/4/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-raft-5/4/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6063"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 4 -> port 6064.
+http_laddr = "0.0.0.0:6064"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-raft-5/4/rmqtt.toml
+++ b/examples/cluster-raft-5/4/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 4
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5366"
+rpc.server_addr = "0.0.0.0:5367"
 rpc.server_workers = 4
 #Maximum number of messages sent in batch
 rpc.batch_size = 128
@@ -41,6 +41,7 @@ plugins.dir = "./plugins/"
 plugins.default_startups = [
     #"rmqtt-retainer",
     "rmqtt-cluster-raft",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",
     #"rmqtt-message-storage",
@@ -71,7 +72,7 @@ mqtt.max_sessions = 0
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1886"
+listener.tcp.external.addr = "0.0.0.0:1887"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/examples/cluster-raft-5/5/plugins/rmqtt-cluster-broadcast.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-cluster-broadcast.toml
@@ -5,7 +5,7 @@
 #grpc message type
 message_type = 98
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366"]
 ##gRPC circuit breaker settings
 node_grpc_circuit_breaker_enabled = true
 node_grpc_circuit_failure_threshold = 10

--- a/examples/cluster-raft-5/5/plugins/rmqtt-cluster-raft.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-cluster-raft.toml
@@ -5,12 +5,12 @@
 #grpc message type
 message_type = 198
 #Node GRPC service address list
-node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365", "4@127.0.0.1:5366", "5@127.0.0.1:5367"]
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365", "3@127.0.0.1:5366", "4@127.0.0.1:5367", "5@127.0.0.1:5368"]
 #Raft peer address list
-raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005", "4@127.0.0.1:6006", "5@127.0.0.1:6007"]
+raft_peer_addrs = ["1@127.0.0.1:6004", "2@127.0.0.1:6005", "3@127.0.0.1:6006", "4@127.0.0.1:6007", "5@127.0.0.1:6008"]
 
 #Raft cluster listening address
-laddr = "0.0.0.0:6007"
+laddr = "0.0.0.0:6008"
 
 #Specify a leader id, when the value is 0 or not specified, the first node
 #will be designated as the Leader. Default value: 0

--- a/examples/cluster-raft-5/5/plugins/rmqtt-http-api.toml
+++ b/examples/cluster-raft-5/5/plugins/rmqtt-http-api.toml
@@ -2,12 +2,106 @@
 ## rmqtt-http-api
 ##--------------------------------------------------------------------
 
-##Number of worker threads
-workers = 1
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
 ## Max Row Limit
 max_row_limit = 10_000
-## HTTP Listener
-http_laddr = "0.0.0.0:6064"
 
+## HTTP Listener address
+## NOTE: nodes within the same example cluster MUST use distinct ports
+## (no port conflicts). This is node 5 -> port 6065.
+http_laddr = "0.0.0.0:6065"
 
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
 
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory.
+##
+## When set, the Dashboard SPA is served from this external directory at
+## `/dashboard/` (and `/`) instead of the assets embedded in the binary,
+## which allows swapping the frontend build without recompiling.
+##
+## The path is resolved against the process working directory, which for
+## these examples is the node directory (e.g. `examples/cluster-broadcast/1`).
+## `../../../rmqtt-dashboard` therefore points to the workspace-level
+## `rmqtt-dashboard/` directory: examples/<cluster>/<node>/ -> <repo root>/rmqtt-dashboard
+dashboard_static_dir = "../../../rmqtt-dashboard"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##--- Redb backend -------------------------------------------------------
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##--- Sled backend (default) ----------------------------------------------
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##--- Redis backend -------------------------------------------------------
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##--- Redis Cluster backend -----------------------------------------------
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##--- Flush interval (how often to snapshot Stats/Metrics) ----------------
+## Default: "5s"
+# flush_interval = "5s"
+
+##--- History retention (TTL for each data point) -------------------------
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/examples/cluster-raft-5/5/rmqtt.toml
+++ b/examples/cluster-raft-5/5/rmqtt.toml
@@ -11,7 +11,7 @@ node.id = 5
 ##--------------------------------------------------------------------
 ## RPC
 ##--------------------------------------------------------------------
-rpc.server_addr = "0.0.0.0:5367"
+rpc.server_addr = "0.0.0.0:5368"
 rpc.server_workers = 4
 #Maximum number of messages sent in batch
 rpc.batch_size = 128
@@ -41,6 +41,7 @@ plugins.dir = "./plugins/"
 plugins.default_startups = [
     #"rmqtt-retainer",
     "rmqtt-cluster-raft",
+    "rmqtt-http-api",
     #"rmqtt-auth-http",
     #"rmqtt-sys-topic",
     #"rmqtt-message-storage",
@@ -71,7 +72,7 @@ mqtt.max_sessions = 0
 
 ##--------------------------------------------------------------------
 ## MQTT/TCP - External TCP Listener for MQTT Protocol
-listener.tcp.external.addr = "0.0.0.0:1887"
+listener.tcp.external.addr = "0.0.0.0:1888"
 #Number of worker threads
 listener.tcp.external.workers = 8
 #The maximum number of concurrent connections allowed by the listener.

--- a/rmqtt-dashboard/app.js
+++ b/rmqtt-dashboard/app.js
@@ -10,6 +10,7 @@ const pageRegistry = {
   '#/login':    { component: 'LoginPage',        titleKey: 'login.title',     isLogin: true },
   '#/':         { component: 'OverviewPage',     titleKey: 'nav.overview',    isLogin: false },
   '#/clients':  { component: 'ClientsPage',      titleKey: 'nav.clients',     isLogin: false },
+  '#/clients/detail': { component: 'ClientDetailPage', titleKey: 'clients.detail_title', isLogin: false },
   '#/subscriptions': { component: 'SubscriptionsPage', titleKey: 'nav.subscriptions', isLogin: false },
   '#/publish':  { component: 'PublishPage',      titleKey: 'nav.publish',     isLogin: false },
   '#/plugins':  { component: 'PluginsPage',      titleKey: 'nav.plugins',     isLogin: false },
@@ -24,6 +25,7 @@ const App = Vue.defineComponent({
     LoginPage,
     OverviewPage,
     ClientsPage,
+    ClientDetailPage: window.ClientDetailPage,
     SubscriptionsPage,
     PublishPage,
     PluginsPage,
@@ -53,7 +55,9 @@ const App = Vue.defineComponent({
   },
   computed: {
     currentPageSpec() {
-      return pageRegistry[this.currentHash] || pageRegistry['#/'];
+      // 路由按 ? 拆分：'#/clients/detail?clientid=xxx' → '#/clients/detail'
+      const path = (this.currentHash || '').split('?')[0];
+      return pageRegistry[path] || pageRegistry['#/'];
     },
     currentPage() {
       return this.currentPageSpec;
@@ -346,5 +350,6 @@ const App = Vue.defineComponent({
   app.use(window.i18n);
   app.component('pagination', window.Pagination);
   app.component('metric-card', window.MetricCard);
+  app.component('datetime-picker', window.DatetimePicker);
   app.mount('#app');
 })();

--- a/rmqtt-dashboard/components/datetime-picker.js
+++ b/rmqtt-dashboard/components/datetime-picker.js
@@ -1,0 +1,264 @@
+/* ============================================================
+   RMQTT Dashboard — 可国际化的日期时间选择器
+   替代原生 <input type="datetime-local">（原生控件跟随浏览器语言，
+   无法随页面 i18n 切换），本组件全部文案走 i18n，
+   月份/星期名由 Intl 按当前语言生成。
+   值格式：'YYYY-MM-DDTHH:mm'（与原生 datetime-local 一致），
+   空字符串表示未选择。
+   ============================================================ */
+window.DatetimePicker = Vue.defineComponent({
+  name: 'DatetimePicker',
+  props: {
+    modelValue: { type: String, default: '' },
+    placeholder: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup(props, ctx) {
+    function $t(key) { return window.i18n.$t(key); }
+    const pad = n => String(n).padStart(2, '0');
+
+    // ---- 状态 ----
+    const open = Vue.ref(false);
+    const viewYear = Vue.ref(0);   // 面板当前显示的年
+    const viewMonth = Vue.ref(0);  // 面板当前显示的月 0-11
+    const selYear = Vue.ref(0);    // 0 = 未选日期
+    const selMonth = Vue.ref(0);
+    const selDay = Vue.ref(0);
+    const selHour = Vue.ref(0);
+    const selMinute = Vue.ref(0);
+    const localeVer = Vue.ref(0);  // 语言切换时重建月份/星期文案
+    const root = Vue.ref(null);
+
+    // ---- 工具 ----
+    function parseModel(v) {
+      if (!v) return null;
+      const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(v);
+      if (!m) return null;
+      return { y: +m[1], mo: +m[2], d: +m[3], h: +m[4], mi: +m[5] };
+    }
+
+    // 一周起始日：优先 Intl.Locale.weekInfo（1=周一...7=周日，转成 0=周日...6=周六），缺省按语言习惯
+    function getFirstDay() {
+      try {
+        const loc = new Intl.Locale(window.i18n.locale);
+        if (loc.weekInfo && typeof loc.weekInfo.firstDay === 'number') {
+          return loc.weekInfo.firstDay >= 7 ? 0 : loc.weekInfo.firstDay;
+        }
+      } catch (e) { /* ignore */ }
+      const l = String(window.i18n.locale).toLowerCase();
+      if (l.indexOf('zh') === 0 || l === 'ar' || l === 'hi' || l === 'bn') return 1;
+      return 0;
+    }
+
+    // 星期表头（按当前语言 + 起始日重排）
+    function buildWeekdayLabels() {
+      const names = [];
+      try {
+        const fmt = new Intl.DateTimeFormat(window.i18n.locale, { weekday: 'short' });
+        // 2026-01-04 是周日，由此生成 周日..周六 的本地名
+        for (let i = 0; i < 7; i++) names.push(fmt.format(new Date(2026, 0, 4 + i)));
+      } catch (e) {
+        names.push('Sun','Mon','Tue','Wed','Thu','Fri','Sat');
+      }
+      const fd = getFirstDay();
+      const out = [];
+      for (let i = 0; i < 7; i++) out.push(names[(fd + i) % 7]);
+      return out;
+    }
+
+    // ---- 计算属性 ----
+    const weekdayLabels = Vue.computed(function() {
+      void localeVer.value;
+      return buildWeekdayLabels();
+    });
+
+    const monthTitle = Vue.computed(function() {
+      void localeVer.value;
+      const y = viewYear.value, m = viewMonth.value;
+      const l = window.i18n.locale;
+      if (l === 'zh-CN' || l === 'zh-TW') return y + '\u5E74' + (m + 1) + '\u6708';
+      try {
+        return new Intl.DateTimeFormat(l, { year: 'numeric', month: 'long' }).format(new Date(y, m, 1));
+      } catch (e) {
+        return y + '-' + pad(m + 1);
+      }
+    });
+
+    const cells = Vue.computed(function() {
+      const y = viewYear.value, m = viewMonth.value;
+      const first = new Date(y, m, 1);
+      const offset = (first.getDay() - getFirstDay() + 7) % 7;
+      const start = new Date(y, m, 1 - offset);
+      const now = new Date();
+      const list = [];
+      for (let i = 0; i < 42; i++) {
+        const d = new Date(start.getFullYear(), start.getMonth(), start.getDate() + i);
+        list.push({
+          y: d.getFullYear(), m: d.getMonth(), d: d.getDate(),
+          inMonth: d.getMonth() === m,
+          isToday: d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate(),
+          isSelected: selYear.value === d.getFullYear() && selMonth.value === d.getMonth() && selDay.value === d.getDate(),
+        });
+      }
+      return list;
+    });
+
+    const displayText = Vue.computed(function() {
+      const v = parseModel(props.modelValue);
+      if (!v) return '';
+      return pad(v.y) + '-' + pad(v.mo) + '-' + pad(v.d) + ' ' + pad(v.h) + ':' + pad(v.mi);
+    });
+
+    // ---- 行为 ----
+    function emitValue() {
+      if (!selYear.value) {
+        ctx.emit('update:modelValue', '');
+        return;
+      }
+      ctx.emit('update:modelValue',
+        pad(selYear.value) + '-' + pad(selMonth.value + 1) + '-' + pad(selDay.value) +
+        'T' + pad(selHour.value) + ':' + pad(selMinute.value));
+    }
+
+    function toggle() {
+      if (open.value) { open.value = false; return; }
+      const v = parseModel(props.modelValue);
+      const t = new Date();
+      if (v) {
+        selYear.value = v.y; selMonth.value = v.mo - 1; selDay.value = v.d;
+        selHour.value = v.h; selMinute.value = v.mi;
+        viewYear.value = v.y; viewMonth.value = v.mo - 1;
+      } else {
+        selYear.value = 0;
+        selHour.value = t.getHours(); selMinute.value = t.getMinutes();
+        viewYear.value = t.getFullYear(); viewMonth.value = t.getMonth();
+      }
+      open.value = true;
+    }
+
+    function prevMonth() {
+      viewMonth.value--;
+      if (viewMonth.value < 0) { viewMonth.value = 11; viewYear.value--; }
+    }
+    function nextMonth() {
+      viewMonth.value++;
+      if (viewMonth.value > 11) { viewMonth.value = 0; viewYear.value++; }
+    }
+    function jumpTodayView() {
+      const t = new Date();
+      viewYear.value = t.getFullYear();
+      viewMonth.value = t.getMonth();
+    }
+
+    function pickDay(cell) {
+      selYear.value = cell.y;
+      selMonth.value = cell.m;
+      selDay.value = cell.d;
+      emitValue();
+    }
+
+    // 修改时间时若无日期，自动补今天
+    function ensureDate() {
+      if (selYear.value) return;
+      const t = new Date();
+      selYear.value = t.getFullYear();
+      selMonth.value = t.getMonth();
+      selDay.value = t.getDate();
+      viewYear.value = t.getFullYear();
+      viewMonth.value = t.getMonth();
+    }
+    function onHourChange(e) {
+      ensureDate();
+      selHour.value = +e.target.value || 0;
+      emitValue();
+    }
+    function onMinuteChange(e) {
+      ensureDate();
+      selMinute.value = +e.target.value || 0;
+      emitValue();
+    }
+
+    function setNow() {
+      const t = new Date();
+      selYear.value = t.getFullYear();
+      selMonth.value = t.getMonth();
+      selDay.value = t.getDate();
+      selHour.value = t.getHours();
+      selMinute.value = t.getMinutes();
+      viewYear.value = t.getFullYear();
+      viewMonth.value = t.getMonth();
+      emitValue();
+    }
+
+    function clear() {
+      selYear.value = 0;
+      ctx.emit('update:modelValue', '');
+      open.value = false;
+    }
+
+    function onDocClick(e) {
+      if (open.value && root.value && !root.value.contains(e.target)) open.value = false;
+    }
+    function onKeydown(e) {
+      if (e.key === 'Escape') open.value = false;
+    }
+    function onLocaleChanged() { localeVer.value++; }
+
+    Vue.onMounted(function() {
+      document.addEventListener('click', onDocClick);
+      document.addEventListener('keydown', onKeydown);
+      window.addEventListener('locale-changed', onLocaleChanged);
+    });
+    Vue.onUnmounted(function() {
+      document.removeEventListener('click', onDocClick);
+      document.removeEventListener('keydown', onKeydown);
+      window.removeEventListener('locale-changed', onLocaleChanged);
+    });
+
+    return {
+      open, viewYear, viewMonth, selYear, selMonth, selDay, selHour, selMinute,
+      root, weekdayLabels, monthTitle, cells, displayText,
+      toggle, prevMonth, nextMonth, jumpTodayView, pickDay,
+      onHourChange, onMinuteChange, setNow, clear, pad, $t,
+    };
+  },
+  template: `
+    <div class="dtp" ref="root">
+      <div class="form-input dtp-input" :class="{ active: open }" @click.stop="toggle">
+        <span :class="{ 'dtp-placeholder': !displayText }">{{ displayText || placeholder }}</span>
+        <span class="dtp-caret">&#9660;</span>
+      </div>
+      <div class="dtp-popover" v-if="open" @click.stop>
+        <div class="dtp-head">
+          <button class="dtp-nav" type="button" :title="$t('datetime.prev_month')" @click="prevMonth">&#8249;</button>
+          <span class="dtp-title">{{ monthTitle }}</span>
+          <button class="dtp-nav" type="button" :title="$t('datetime.next_month')" @click="nextMonth">&#8250;</button>
+        </div>
+        <div class="dtp-week">
+          <span v-for="(w, i) in weekdayLabels" :key="i">{{ w }}</span>
+        </div>
+        <div class="dtp-grid">
+          <button type="button" class="dtp-cell"
+                  v-for="(c, i) in cells" :key="i"
+                  :class="{ out: !c.inMonth, today: c.isToday, sel: c.isSelected }"
+                  @click="pickDay(c)">{{ c.d }}</button>
+        </div>
+        <div class="dtp-time">
+          <span class="dtp-tlbl">{{ $t('datetime.hour') }}</span>
+          <select class="dtp-select" :value="pad(selHour)" @change="onHourChange">
+            <option v-for="n in 24" :key="n - 1" :value="n - 1">{{ pad(n - 1) }}</option>
+          </select>
+          <span class="dtp-colon">:</span>
+          <select class="dtp-select" :value="pad(selMinute)" @change="onMinuteChange">
+            <option v-for="n in 60" :key="n - 1" :value="n - 1">{{ pad(n - 1) }}</option>
+          </select>
+          <button type="button" class="dtp-today" @click="jumpTodayView" :title="$t('datetime.today')">&#9679;</button>
+        </div>
+        <div class="dtp-foot">
+          <button type="button" class="btn btn-sm" @click="clear">{{ $t('datetime.clear') }}</button>
+          <button type="button" class="btn btn-sm btn-primary" @click="setNow">{{ $t('datetime.now') }}</button>
+        </div>
+      </div>
+    </div>
+  `,
+});

--- a/rmqtt-dashboard/components/sidebar-nav.js
+++ b/rmqtt-dashboard/components/sidebar-nav.js
@@ -154,7 +154,9 @@
         return !!this.defaultExpanded[groupKey];
       },
       isActive: function(hash) {
-        return this.currentHash === hash;
+        // 忽略 query 参数：'#/clients/detail?clientid=x' 时 '客户端' 菜单保持高亮
+        const cur = (this.currentHash || '').split('?')[0];
+        return cur === hash;
       },
       isDisabled: function(item) {
         return item.disabled === true;

--- a/rmqtt-dashboard/i18n.js
+++ b/rmqtt-dashboard/i18n.js
@@ -28,7 +28,7 @@
       this.locale = FALLBACK;
       this._messages = {};
       this._cache = {};
-      this._localeVer = 3;  // 语言文件版本号，修改后递增以绕过浏览器缓存
+      this._localeVer = 6;  // 语言文件版本号，修改后递增以绕过浏览器缓存
     }
 
     /** 初始化：检测语言 → 预加载全部语言包 */

--- a/rmqtt-dashboard/index.html
+++ b/rmqtt-dashboard/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
   <title>RMQTT Dashboard</title>
-  <link rel="stylesheet" href="./style.css?v=23">
+  <link rel="stylesheet" href="./style.css?v=25">
 </head>
 <body>
   <div id="app"></div>
@@ -16,21 +16,23 @@
   <script src="https://unpkg.com/echarts@5/dist/echarts.min.js"></script>
   <script src="./http.js?v=3"></script>
   <script src="./store.js?v=3"></script>
-  <script src="./i18n.js?v=9"></script>
+  <script src="./i18n.js?v=12"></script>
   <script src="./components/app-layout.js?v=3"></script>
   <script src="./components/sidebar-nav.js?v=6"></script>
   <script src="./components/metric-card.js?v=5"></script>
   <script src="./components/pagination.js?v=3"></script>
+  <script src="./components/datetime-picker.js?v=1"></script>
   <script src="./components/gauge-chart.js?v=19"></script>
   <script src="./components/msg-rate-panel.js?v=13"></script>
   <script src="./components/ring-chart.js?v=3"></script>
   <script src="./components/node-detail.js?v=7"></script>
   <script src="./pages/login.js?v=3"></script>
-  <script src="./pages/overview.js?v=21"></script>
-  <script src="./pages/clients.js?v=8"></script>
+  <script src="./pages/overview.js?v=25"></script>
+  <script src="./pages/clients.js?v=11"></script>
+  <script src="./pages/client-detail.js?v=2"></script>
   <script src="./pages/subscriptions.js?v=6"></script>
   <script src="./pages/publish.js?v=4"></script>
   <script src="./pages/plugins.js?v=4"></script>
-  <script src="./app.js?v=17"></script>
+  <script src="./app.js?v=19"></script>
 </body>
 </html>

--- a/rmqtt-dashboard/locales/ar.json
+++ b/rmqtt-dashboard/locales/ar.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "جميع العقد",
+    "node_filter": "تصفية حسب العقدة"
   },
   "gauge": {
     "connections": "الاتصالات",
@@ -198,7 +200,22 @@
     "subs": "الاشتراكات",
     "expiry": "الانتهاء",
     "ka": "Keepalive",
-    "connected_at": "وقت الاتصال"
+    "connected_at": "وقت الاتصال",
+    "detail_title": "تفاصيل العميل",
+    "back": "رجوع",
+    "connection_info": "الاتصال",
+    "session_info": "الجلسة",
+    "current_subs": "الاشتراكات الحالية",
+    "superuser": "مستخدم متميز",
+    "address": "العنوان",
+    "disconnected_at": "انقطع الاتصال في",
+    "disconnect_reason": "سبب الانقطاع",
+    "last_will": "الوصية الأخيرة",
+    "session_expiry": "انتهاء الجلسة",
+    "session_created": "تاريخ إنشاء الجلسة",
+    "subs_count": "الاشتراكات",
+    "keepalive": "الإبقاء على الاتصال",
+    "not_found": "العميل {clientId} غير موجود أو تمت إزالته"
   },
   "subscriptions": {
     "title": "الاشتراكات",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "تحديد التاريخ والوقت",
+    "now": "الآن",
+    "clear": "مسح",
+    "hour": "ساعة",
+    "minute": "دقيقة",
+    "today": "الانتقال إلى اليوم",
+    "prev_month": "الشهر السابق",
+    "next_month": "الشهر التالي"
   }
 }

--- a/rmqtt-dashboard/locales/bn.json
+++ b/rmqtt-dashboard/locales/bn.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "সব নোড",
+    "node_filter": "নোড ফিল্টার"
   },
   "gauge": {
     "connections": "সংযোগ",
@@ -198,7 +200,22 @@
     "subs": "Subs",
     "expiry": "Expiry",
     "ka": "KA",
-    "connected_at": "Connected at"
+    "connected_at": "Connected at",
+    "detail_title": "ক্লায়েন্ট বিবরণ",
+    "back": "ফিরে যান",
+    "connection_info": "সংযোগ",
+    "session_info": "সেশন",
+    "current_subs": "বর্তমান সাবস্ক্রিপশন",
+    "superuser": "সুপারইউজার",
+    "address": "ঠিকানা",
+    "disconnected_at": "সংযোগ বিচ্ছিন্ন হয়েছে",
+    "disconnect_reason": "সংযোগ বিচ্ছিন্ন হওয়ার কারণ",
+    "last_will": "শেষ ইচ্ছা",
+    "session_expiry": "সেশন মেয়াদ",
+    "session_created": "সেশন তৈরি হয়েছে",
+    "subs_count": "সাবস্ক্রিপশন",
+    "keepalive": "কিপঅ্যালাইভ",
+    "not_found": "ক্লায়েন্ট {clientId} পাওয়া যায়নি বা সরানো হয়েছে"
   },
   "subscriptions": {
     "title": "সাবস্ক্রিপশন",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "তারিখ এবং সময় নির্বাচন করুন",
+    "now": "এখন",
+    "clear": "মুছুন",
+    "hour": "ঘণ্টা",
+    "minute": "মিনিট",
+    "today": "আজকে যান",
+    "prev_month": "আগের মাস",
+    "next_month": "পরের মাস"
   }
 }

--- a/rmqtt-dashboard/locales/de.json
+++ b/rmqtt-dashboard/locales/de.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "Alle Knoten",
+    "node_filter": "Knotenfilter"
   },
   "gauge": {
     "connections": "Verbindungen",
@@ -198,7 +200,22 @@
     "subs": "Subs",
     "expiry": "Expiry",
     "ka": "KA",
-    "connected_at": "Connected at"
+    "connected_at": "Connected at",
+    "detail_title": "Client-Details",
+    "back": "Zurück",
+    "connection_info": "Verbindung",
+    "session_info": "Sitzung",
+    "current_subs": "Aktuelle Abonnements",
+    "superuser": "Superuser",
+    "address": "Adresse",
+    "disconnected_at": "Getrennt um",
+    "disconnect_reason": "Trennungsgrund",
+    "last_will": "Letzter Wille",
+    "session_expiry": "Sitzungsablauf",
+    "session_created": "Sitzung erstellt",
+    "subs_count": "Abonnements",
+    "keepalive": "Keepalive",
+    "not_found": "Client {clientId} nicht gefunden oder entfernt"
   },
   "subscriptions": {
     "title": "Abonnements",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "Datum und Uhrzeit auswählen",
+    "now": "Jetzt",
+    "clear": "Löschen",
+    "hour": "Stunde",
+    "minute": "Minute",
+    "today": "Zu heute",
+    "prev_month": "Vorheriger Monat",
+    "next_month": "Nächster Monat"
   }
 }

--- a/rmqtt-dashboard/locales/en.json
+++ b/rmqtt-dashboard/locales/en.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "All Nodes",
+    "node_filter": "Node filter"
   },
   "gauge": {
     "connections": "Connections",
@@ -198,7 +200,22 @@
     "disconnect": "Kick",
     "disconnect_confirm": "Kick out client {clientId}?",
     "disconnect_fail": "Kick out failed: {msg}",
-    "no_results": "No data"
+    "no_results": "No data",
+    "detail_title": "Client Detail",
+    "back": "Back",
+    "connection_info": "Connection",
+    "session_info": "Session",
+    "current_subs": "Current Subscriptions",
+    "superuser": "Superuser",
+    "address": "Address",
+    "disconnected_at": "Disconnected at",
+    "disconnect_reason": "Disconnect reason",
+    "last_will": "Last Will",
+    "session_expiry": "Session Expiry",
+    "session_created": "Session created",
+    "subs_count": "Subscriptions",
+    "keepalive": "Keepalive",
+    "not_found": "Client {clientId} not found or has been removed"
   },
   "subscriptions": {
     "title": "Subscriptions",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "Select Date & Time",
+    "now": "Now",
+    "clear": "Clear",
+    "hour": "Hour",
+    "minute": "Minute",
+    "today": "Go to today",
+    "prev_month": "Previous month",
+    "next_month": "Next month"
   }
 }

--- a/rmqtt-dashboard/locales/es.json
+++ b/rmqtt-dashboard/locales/es.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "Todos los nodos",
+    "node_filter": "Filtro de nodo"
   },
   "gauge": {
     "connections": "Conexiones",
@@ -198,7 +200,22 @@
     "subs": "Subs",
     "expiry": "Expiry",
     "ka": "KA",
-    "connected_at": "Connected at"
+    "connected_at": "Connected at",
+    "detail_title": "Detalles del cliente",
+    "back": "Volver",
+    "connection_info": "Conexión",
+    "session_info": "Sesión",
+    "current_subs": "Suscripciones actuales",
+    "superuser": "Superusuario",
+    "address": "Dirección",
+    "disconnected_at": "Desconectado a las",
+    "disconnect_reason": "Motivo de desconexión",
+    "last_will": "Última voluntad",
+    "session_expiry": "Caducidad de sesión",
+    "session_created": "Sesión creada",
+    "subs_count": "Suscripciones",
+    "keepalive": "Keepalive",
+    "not_found": "Cliente {clientId} no encontrado o eliminado"
   },
   "subscriptions": {
     "title": "Suscripciones",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "Seleccionar fecha y hora",
+    "now": "Ahora",
+    "clear": "Limpiar",
+    "hour": "Hora",
+    "minute": "Minuto",
+    "today": "Ir a hoy",
+    "prev_month": "Mes anterior",
+    "next_month": "Mes siguiente"
   }
 }

--- a/rmqtt-dashboard/locales/fr.json
+++ b/rmqtt-dashboard/locales/fr.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "Tous les nœuds",
+    "node_filter": "Filtre par nœud"
   },
   "gauge": {
     "connections": "Connexions",
@@ -198,7 +200,22 @@
     "subs": "Subs",
     "expiry": "Expiry",
     "ka": "KA",
-    "connected_at": "Connected at"
+    "connected_at": "Connected at",
+    "detail_title": "Détails du client",
+    "back": "Retour",
+    "connection_info": "Connexion",
+    "session_info": "Session",
+    "current_subs": "Abonnements actuels",
+    "superuser": "Superutilisateur",
+    "address": "Adresse",
+    "disconnected_at": "Déconnecté à",
+    "disconnect_reason": "Raison de déconnexion",
+    "last_will": "Dernière volonté",
+    "session_expiry": "Expiration de session",
+    "session_created": "Session créée",
+    "subs_count": "Abonnements",
+    "keepalive": "Keepalive",
+    "not_found": "Client {clientId} introuvable ou supprimé"
   },
   "subscriptions": {
     "title": "Abonnements",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "Sélectionner la date et l’heure",
+    "now": "Maintenant",
+    "clear": "Effacer",
+    "hour": "Heure",
+    "minute": "Minute",
+    "today": "Aller à aujourd’hui",
+    "prev_month": "Mois précédent",
+    "next_month": "Mois suivant"
   }
 }

--- a/rmqtt-dashboard/locales/hi.json
+++ b/rmqtt-dashboard/locales/hi.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "सभी नोड",
+    "node_filter": "नोड फ़िल्टर"
   },
   "gauge": {
     "connections": "कनेक्शन",
@@ -198,7 +200,22 @@
     "subs": "Subs",
     "expiry": "Expiry",
     "ka": "KA",
-    "connected_at": "Connected at"
+    "connected_at": "Connected at",
+    "detail_title": "क्लाइंट विवरण",
+    "back": "वापस",
+    "connection_info": "कनेक्शन",
+    "session_info": "सत्र",
+    "current_subs": "वर्तमान सदस्यताएँ",
+    "superuser": "सुपरयूज़र",
+    "address": "पता",
+    "disconnected_at": "डिस्कनेक्ट हुआ",
+    "disconnect_reason": "डिस्कनेक्ट कारण",
+    "last_will": "अंतिम इच्छा",
+    "session_expiry": "सत्र समाप्ति",
+    "session_created": "सत्र बनाया गया",
+    "subs_count": "सदस्यताएँ",
+    "keepalive": "कीपअलाइव",
+    "not_found": "क्लाइंट {clientId} नहीं मिला या हटा दिया गया"
   },
   "subscriptions": {
     "title": "सब्सक्रिप्शन",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "दिनांक और समय चुनें",
+    "now": "अभी",
+    "clear": "साफ़ करें",
+    "hour": "घंटा",
+    "minute": "मिनट",
+    "today": "आज पर जाएँ",
+    "prev_month": "पिछला महीना",
+    "next_month": "अगला महीना"
   }
 }

--- a/rmqtt-dashboard/locales/it.json
+++ b/rmqtt-dashboard/locales/it.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "Tutti i nodi",
+    "node_filter": "Filtro nodo"
   },
   "gauge": {
     "connections": "Connessioni",
@@ -198,7 +200,22 @@
     "subs": "Subs",
     "expiry": "Expiry",
     "ka": "KA",
-    "connected_at": "Connected at"
+    "connected_at": "Connected at",
+    "detail_title": "Dettagli cliente",
+    "back": "Indietro",
+    "connection_info": "Connessione",
+    "session_info": "Sessione",
+    "current_subs": "Sottoscrizioni attuali",
+    "superuser": "Superutente",
+    "address": "Indirizzo",
+    "disconnected_at": "Disconnesso alle",
+    "disconnect_reason": "Motivo della disconnessione",
+    "last_will": "Ultima volontà",
+    "session_expiry": "Scadenza sessione",
+    "session_created": "Sessione creata",
+    "subs_count": "Sottoscrizioni",
+    "keepalive": "Keepalive",
+    "not_found": "Client {clientId} non trovato o rimosso"
   },
   "subscriptions": {
     "title": "Sottoscrizioni",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "Seleziona data e ora",
+    "now": "Adesso",
+    "clear": "Cancella",
+    "hour": "Ora",
+    "minute": "Minuto",
+    "today": "Vai a oggi",
+    "prev_month": "Mese precedente",
+    "next_month": "Mese successivo"
   }
 }

--- a/rmqtt-dashboard/locales/pt.json
+++ b/rmqtt-dashboard/locales/pt.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "Todos os nós",
+    "node_filter": "Filtro de nó"
   },
   "gauge": {
     "connections": "Conexões",
@@ -198,7 +200,22 @@
     "subs": "Subs",
     "expiry": "Expiry",
     "ka": "KA",
-    "connected_at": "Connected at"
+    "connected_at": "Connected at",
+    "detail_title": "Detalhes do cliente",
+    "back": "Voltar",
+    "connection_info": "Conexão",
+    "session_info": "Sessão",
+    "current_subs": "Assinaturas atuais",
+    "superuser": "Superusuário",
+    "address": "Endereço",
+    "disconnected_at": "Desconectado às",
+    "disconnect_reason": "Motivo da desconexão",
+    "last_will": "Última vontade",
+    "session_expiry": "Expiração da sessão",
+    "session_created": "Sessão criada",
+    "subs_count": "Assinaturas",
+    "keepalive": "Keepalive",
+    "not_found": "Cliente {clientId} não encontrado ou removido"
   },
   "subscriptions": {
     "title": "Inscrições",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "Selecionar data e hora",
+    "now": "Agora",
+    "clear": "Limpar",
+    "hour": "Hora",
+    "minute": "Minuto",
+    "today": "Ir para hoje",
+    "prev_month": "Mês anterior",
+    "next_month": "Próximo mês"
   }
 }

--- a/rmqtt-dashboard/locales/ru.json
+++ b/rmqtt-dashboard/locales/ru.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "Все узлы",
+    "node_filter": "Фильтр узлов"
   },
   "gauge": {
     "connections": "Соединения",
@@ -198,7 +200,22 @@
     "subs": "Подписки",
     "expiry": "Срок",
     "ka": "Keepalive",
-    "connected_at": "Подключен"
+    "connected_at": "Подключен",
+    "detail_title": "Сведения о клиенте",
+    "back": "Назад",
+    "connection_info": "Подключение",
+    "session_info": "Сессия",
+    "current_subs": "Текущие подписки",
+    "superuser": "Суперпользователь",
+    "address": "Адрес",
+    "disconnected_at": "Отключён в",
+    "disconnect_reason": "Причина отключения",
+    "last_will": "Последняя воля",
+    "session_expiry": "Истечение сессии",
+    "session_created": "Сессия создана",
+    "subs_count": "Подписки",
+    "keepalive": "Keepalive",
+    "not_found": "Клиент {clientId} не найден или удалён"
   },
   "subscriptions": {
     "title": "Подписки",
@@ -285,5 +302,15 @@
     "close": "Close",
     "online": "Online",
     "offline": "Offline"
+  },
+  "datetime": {
+    "title": "Выбор даты и времени",
+    "now": "Сейчас",
+    "clear": "Очистить",
+    "hour": "Час",
+    "minute": "Минута",
+    "today": "К сегодняшнему дню",
+    "prev_month": "Предыдущий месяц",
+    "next_month": "Следующий месяц"
   }
 }

--- a/rmqtt-dashboard/locales/zh-CN.json
+++ b/rmqtt-dashboard/locales/zh-CN.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "入方向飞行",
     "forwards_count": "转发中",
     "message_storages_count": "消息存储",
-    "delayed_publishs_count": "延迟发布"
+    "delayed_publishs_count": "延迟发布",
+    "all_nodes": "所有节点",
+    "node_filter": "节点筛选"
   },
   "gauge": {
     "connections": "设备连接",
@@ -198,7 +200,22 @@
     "disconnect": "踢出",
     "disconnect_confirm": "确认踢出客户端 {clientId} ？",
     "disconnect_fail": "踢出失败: {msg}",
-    "no_results": "暂无数据"
+    "no_results": "暂无数据",
+    "detail_title": "客户端详情",
+    "back": "返回",
+    "connection_info": "连接信息",
+    "session_info": "会话信息",
+    "current_subs": "当前订阅",
+    "superuser": "超级用户",
+    "address": "地址",
+    "disconnected_at": "断开时间",
+    "disconnect_reason": "断开原因",
+    "last_will": "遗嘱消息",
+    "session_expiry": "会话过期",
+    "session_created": "会话创建时间",
+    "subs_count": "订阅数",
+    "keepalive": "保活",
+    "not_found": "客户端 {clientId} 不存在或已被移除"
   },
   "subscriptions": {
     "title": "订阅",
@@ -285,5 +302,15 @@
     "close": "关闭",
     "online": "在线",
     "offline": "离线"
+  },
+  "datetime": {
+    "title": "选择日期时间",
+    "now": "现在",
+    "clear": "清空",
+    "hour": "时",
+    "minute": "分",
+    "today": "回到今天",
+    "prev_month": "上一月",
+    "next_month": "下一月"
   }
 }

--- a/rmqtt-dashboard/locales/zh-TW.json
+++ b/rmqtt-dashboard/locales/zh-TW.json
@@ -138,7 +138,9 @@
     "in_inflights_count": "Incoming Inflight",
     "forwards_count": "Forwards",
     "message_storages_count": "Message Storage",
-    "delayed_publishs_count": "Delayed Publish"
+    "delayed_publishs_count": "Delayed Publish",
+    "all_nodes": "所有節點",
+    "node_filter": "節點篩選"
   },
   "gauge": {
     "connections": "設備連接",
@@ -198,7 +200,22 @@
     "subs": "訂閱",
     "expiry": "過期",
     "ka": "Keepalive",
-    "connected_at": "連線時間"
+    "connected_at": "連線時間",
+    "detail_title": "客戶端詳情",
+    "back": "返回",
+    "connection_info": "連線資訊",
+    "session_info": "會話資訊",
+    "current_subs": "目前訂閱",
+    "superuser": "超級使用者",
+    "address": "位址",
+    "disconnected_at": "斷線時間",
+    "disconnect_reason": "斷線原因",
+    "last_will": "遺囑訊息",
+    "session_expiry": "會話過期",
+    "session_created": "會話建立時間",
+    "subs_count": "訂閱數",
+    "keepalive": "保活",
+    "not_found": "用戶端 {clientId} 不存在或已被移除"
   },
   "subscriptions": {
     "title": "訂閱",
@@ -285,5 +302,15 @@
     "close": "关闭",
     "online": "在线",
     "offline": "离线"
+  },
+  "datetime": {
+    "title": "選擇日期時間",
+    "now": "現在",
+    "clear": "清除",
+    "hour": "時",
+    "minute": "分",
+    "today": "回到今天",
+    "prev_month": "上一個月",
+    "next_month": "下一個月"
   }
 }

--- a/rmqtt-dashboard/pages/client-detail.js
+++ b/rmqtt-dashboard/pages/client-detail.js
@@ -1,0 +1,270 @@
+/* ============================================================
+   RMQTT Dashboard — 客户端详情页
+   布局：连接信息 | 会话信息（左右两栏），下方当前订阅列表
+   数据：GET /clients/{clientid}（跨节点）+ GET /subscriptions?clientid=
+   ============================================================ */
+window.ClientDetailPage = Vue.defineComponent({
+  name: 'ClientDetailPage',
+  template: `
+    <div>
+      <div class="detail-toolbar">
+        <button class="btn btn-sm" style="border:1px solid var(--border);background:transparent;color:var(--text-muted);"
+                @click="back">&#8592; {{ $t('clients.back') }}</button>
+        <span class="detail-title"><code style="font-size:14px;">{{ clientid }}</code></span>
+        <span v-if="info" class="detail-status" :class="info.connected ? 'status-online' : 'status-offline'">
+          {{ info.connected ? $t('clients.connected') : $t('clients.disconnected') }}
+        </span>
+        <span style="flex:1;"></span>
+        <button v-if="info" class="btn btn-sm btn-primary" style="background:var(--red);"
+                @click="kick" :title="$t('clients.disconnect')">{{ $t('clients.disconnect') }}</button>
+        <button class="btn btn-sm" style="border:1px solid var(--border);background:transparent;color:var(--text-muted);"
+                @click="refresh">&#x27F3; {{ $t('common.refresh') }}</button>
+      </div>
+
+      <div v-if="loading" class="loading-text">{{ $t('common.loading') }}</div>
+
+      <div v-else-if="notFound" class="detail-empty">
+        <div style="font-size:28px;margin-bottom:12px;">&#128269;</div>
+        <div>{{ $t('clients.not_found', { clientId: clientid }) }}</div>
+      </div>
+
+      <template v-else-if="info">
+        <div class="detail-grid">
+          <div class="info-card">
+            <h3>{{ $t('clients.connection_info') }}</h3>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.status') }}</span>
+              <span class="info-value plain" :class="info.connected ? 'status-online' : 'status-offline'">
+                {{ info.connected ? $t('clients.connected') : $t('clients.disconnected') }}
+              </span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.node') }}</span>
+              <span class="info-value">{{ info.node_id ?? '-' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.client_id') }}</span>
+              <span class="info-value">{{ info.clientid }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.username') }}</span>
+              <span class="info-value">{{ info.username || '-' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.superuser') }}</span>
+              <span class="info-value plain">{{ info.superuser ? 'true' : 'false' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.proto_short') }}</span>
+              <span class="info-value plain">{{ info.proto_ver ? 'MQTT ' + info.proto_ver : '-' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.address') }}</span>
+              <span class="info-value">{{ info.ip_address || '-' }}<template v-if="info.port">:{{ info.port }}</template></span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.connected_at') }}</span>
+              <span class="info-value">{{ info.connected_at || '-' }}</span>
+            </div>
+            <div class="info-row" v-if="info.disconnected_at">
+              <span class="info-label">{{ $t('clients.disconnected_at') }}</span>
+              <span class="info-value">{{ info.disconnected_at }}</span>
+            </div>
+            <div class="info-row" v-if="info.disconnected_reason">
+              <span class="info-label">{{ $t('clients.disconnect_reason') }}</span>
+              <span class="info-value">{{ info.disconnected_reason }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.keepalive') }}</span>
+              <span class="info-value plain">{{ info.keepalive ? info.keepalive + 's' : '-' }}</span>
+            </div>
+            <div class="info-row" v-if="hasWill">
+              <span class="info-label">{{ $t('clients.last_will') }}</span>
+              <span class="info-value">{{ fmtWill(info.last_will) }}</span>
+            </div>
+          </div>
+
+          <div class="info-card">
+            <h3>{{ $t('clients.session_info') }}</h3>
+            <div class="info-row">
+              <span class="info-label">Clean Start</span>
+              <span class="info-value plain">{{ info.clean_start ? 'true' : 'false' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">Session Present</span>
+              <span class="info-value plain">{{ info.session_present ? 'true' : 'false' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.session_expiry') }}</span>
+              <span class="info-value plain">{{ fmtExpiry(info.expiry_interval) }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.session_created') }}</span>
+              <span class="info-value">{{ info.created_at || '-' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">{{ $t('clients.subs_count') }}</span>
+              <span class="info-value plain">{{ info.subscriptions_cnt ?? 0 }} / {{ info.max_subscriptions ?? '-' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">Inflight</span>
+              <span class="info-value plain">{{ info.inflight ?? 0 }} / {{ info.max_inflight ?? '-' }}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">Message Queue</span>
+              <span class="info-value plain">{{ info.mqueue_len ?? 0 }} / {{ info.max_mqueue ?? '-' }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="table-wrap" style="overflow-x:auto;">
+          <div class="detail-subs-header">
+            <span>{{ $t('clients.current_subs') }} <b>({{ subs.length }})</b></span>
+          </div>
+          <table style="min-width:640px;">
+            <thead>
+              <tr>
+                <th style="min-width:200px;">{{ $t('subscriptions.topic') }}</th>
+                <th style="width:60px;">{{ $t('subscriptions.qos') }}</th>
+                <th style="min-width:100px;">{{ $t('subscriptions.share_group') }}</th>
+                <th style="width:80px;">{{ $t('subscriptions.node') }}</th>
+                <th style="width:80px;">{{ $t('subscriptions.action') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="s in subs" :key="s.clientid + '|' + s.topic">
+                <td><code style="font-size:12px;">{{ s.topic }}</code></td>
+                <td style="text-align:center;">{{ s.opts?.qos ?? '-' }}</td>
+                <td style="font-size:12px;">{{ s.opts?.group || '-' }}</td>
+                <td style="font-size:12px;text-align:center;">{{ s.node_id ?? '-' }}</td>
+                <td>
+                  <button class="btn-icon" style="width:auto;padding:3px 10px;font-size:11px;color:var(--red);"
+                          @click="unsub(s)" :title="$t('subscriptions.unsubscribe')">
+                    {{ $t('subscriptions.unsub_btn') }}
+                  </button>
+                </td>
+              </tr>
+              <tr v-if="subs.length === 0">
+                <td colspan="5" style="text-align:center;color:var(--text-muted);padding:32px;">{{ $t('subscriptions.no_results') }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </template>
+    </div>
+  `,
+  setup() {
+    function $t(key, params) { return window.i18n.$t(key, params); }
+
+    // 从 hash 解析 clientid：'#/clients/detail?clientid=xxx'
+    const qs = (location.hash.split('?')[1] || '');
+    const clientid = new URLSearchParams(qs).get('clientid') || '';
+
+    const info = Vue.ref(null);
+    const subs = Vue.ref([]);
+    const loading = Vue.ref(true);
+    const notFound = Vue.ref(false);
+
+    function fmtExpiry(sec) {
+      if (sec == null || sec === 0) return '\u221E';
+      if (sec % 3600 === 0) return (sec / 3600) + 'h';
+      if (sec % 60 === 0) return (sec / 60) + 'm';
+      return sec + 's';
+    }
+
+    // 遗嘱消息：{ topic, message(base64), qos, retain }
+    const hasWill = Vue.computed(function() {
+      return !!(info.value && info.value.last_will && info.value.last_will.topic);
+    });
+
+    function fmtWill(will) {
+      if (!will) return '-';
+      var s = will.topic;
+      if (will.qos != null) s += ' [QoS ' + will.qos + ']';
+      if (will.retain) s += ' [retain]';
+      if (will.message) {
+        var payload = '';
+        try {
+          var bin = atob(will.message);
+          payload = new TextDecoder().decode(Uint8Array.from(bin, function(c) { return c.charCodeAt(0); }));
+        } catch (e) {
+          payload = will.message;
+        }
+        payload = payload.replace(/\s+/g, ' ').trim();
+        if (payload.length > 40) payload = payload.slice(0, 40) + '...';
+        if (payload) s += ' \u00B7 ' + payload;
+      }
+      return s;
+    }
+
+    async function load() {
+      if (!clientid) { notFound.value = true; loading.value = false; return; }
+      loading.value = true;
+      notFound.value = false;
+      try {
+        var [detail, subList] = await Promise.all([
+          http.get('/clients/' + encodeURIComponent(clientid)).catch(function(e) { return null; }),
+          http.get('/subscriptions', { clientid: clientid, _limit: 1000 }).catch(function() { return []; }),
+        ]);
+        if (detail) {
+          info.value = detail;
+        } else {
+          info.value = null;
+          notFound.value = true;
+        }
+        subs.value = Array.isArray(subList) ? subList : [];
+      } catch (e) {
+        console.error(e);
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    // 刷新不显示全屏 loading
+    function refresh() {
+      Promise.all([
+        http.get('/clients/' + encodeURIComponent(clientid)).catch(function() { return null; }),
+        http.get('/subscriptions', { clientid: clientid, _limit: 1000 }).catch(function() { return []; }),
+      ]).then(function(res) {
+        var detail = res[0], subList = res[1];
+        if (detail) {
+          info.value = detail;
+          notFound.value = false;
+        } else {
+          info.value = null;
+          notFound.value = true;
+        }
+        subs.value = Array.isArray(subList) ? subList : [];
+      }).catch(function(e) { console.error(e); });
+    }
+
+    async function kick() {
+      if (!confirm($t('clients.disconnect_confirm', { clientId: clientid }))) return;
+      try {
+        await http.del('/clients/' + encodeURIComponent(clientid));
+        refresh();
+      } catch (e) {
+        alert($t('clients.disconnect_fail', { msg: e.message }));
+      }
+    }
+
+    async function unsub(s) {
+      if (!confirm($t('subscriptions.unsub_confirm', { clientId: s.clientid, topic: s.topic }))) return;
+      try {
+        await http.post('/mqtt/unsubscribe', { clientid: s.clientid, topic: s.topic });
+        refresh();
+      } catch (e) {
+        alert($t('subscriptions.unsubscribe_fail', { msg: e.message }));
+      }
+    }
+
+    function back() {
+      location.hash = '#/clients';
+    }
+
+    Vue.onMounted(load);
+
+    return { clientid, info, subs, loading, notFound, hasWill,
+             fmtExpiry, fmtWill, load, refresh, kick, unsub, back, $t };
+  },
+});

--- a/rmqtt-dashboard/pages/clients.js
+++ b/rmqtt-dashboard/pages/clients.js
@@ -84,19 +84,19 @@ window.ClientsPage = Vue.defineComponent({
           </div>
           <div class="filter-row" style="align-items:center;">
             <span class="filter-label" style="margin-bottom:0;">{{ $t('clients.created_at') }}</span>
-            <input class="form-input" type="datetime-local" v-model="createdGte"
-                   style="flex:1;max-width:200px;" />
+            <datetime-picker v-model="createdGte" style="flex:1;max-width:200px;"
+                             :placeholder="$t('datetime.title')" />
             <span style="margin:0 6px;color:var(--text-muted);">~</span>
-            <input class="form-input" type="datetime-local" v-model="createdLte"
-                   style="flex:1;max-width:200px;" />
+            <datetime-picker v-model="createdLte" style="flex:1;max-width:200px;"
+                             :placeholder="$t('datetime.title')" />
           </div>
           <div class="filter-row" style="align-items:center;">
             <span class="filter-label" style="margin-bottom:0;">{{ $t('clients.connected_at') }}</span>
-            <input class="form-input" type="datetime-local" v-model="connectedGte"
-                   style="flex:1;max-width:200px;" />
+            <datetime-picker v-model="connectedGte" style="flex:1;max-width:200px;"
+                             :placeholder="$t('datetime.title')" />
             <span style="margin:0 6px;color:var(--text-muted);">~</span>
-            <input class="form-input" type="datetime-local" v-model="connectedLte"
-                   style="flex:1;max-width:200px;" />
+            <datetime-picker v-model="connectedLte" style="flex:1;max-width:200px;"
+                             :placeholder="$t('datetime.title')" />
           </div>
         </div>
       </div>
@@ -119,7 +119,7 @@ window.ClientsPage = Vue.defineComponent({
             </tr>
           </thead>
           <tbody>
-            <tr v-for="c in clients" :key="c.clientid">
+            <tr v-for="c in clients" :key="c.clientid" style="cursor:pointer;" @click="goDetail(c.clientid)">
               <td><code style="font-size:12px;">{{ c.clientid }}</code></td>
               <td style="font-size:12px;">{{ c.username || '-' }}</td>
               <td style="font-size:12px;">{{ c.node_id ?? '-' }}</td>
@@ -134,7 +134,7 @@ window.ClientsPage = Vue.defineComponent({
               <td style="font-size:12px;white-space:nowrap;">{{ c.connected_at || c.created_at || '-' }}</td>
               <td>
                 <button class="btn-icon" style="width:auto;padding:3px 10px;font-size:11px;"
-                        v-if="c.connected" @click="kick(c.clientid)"
+                        @click.stop="kick(c.clientid)"
                         :title="$t('clients.disconnect')">
                   {{ $t('clients.disconnect') }}
                 </button>
@@ -259,12 +259,29 @@ window.ClientsPage = Vue.defineComponent({
       }
     }
 
-    Vue.onMounted(loadClients);
+    // 点击行进入客户端详情页
+    function goDetail(clientid) {
+      location.hash = '#/clients/detail?clientid=' + encodeURIComponent(clientid);
+    }
+
+    Vue.onMounted(function() {
+      // 消费快速搜索跳转携带的 clientid（#/clients?clientid=xxx）
+      var qs = location.hash.split('?')[1];
+      if (qs) {
+        var q = new URLSearchParams(qs).get('clientid');
+        if (q) {
+          clientid.value = q;
+          loadClients();
+          return;
+        }
+      }
+      loadClients();
+    });
 
     return { clientid, username, ipAddress, filterOnline, protoVer, pageSize,
              showAdvanced, useFuzzyClientid, fuzzyClientid,
              useFuzzyUsername, fuzzyUsername, cleanStart, sessionPresent,
              createdGte, createdLte, connectedGte, connectedLte, clients, advancedActiveCount,
-             loadClients, reset, kick, fmtExpiry, $t };
+             loadClients, reset, kick, goDetail, fmtExpiry, $t };
   },
 });

--- a/rmqtt-dashboard/pages/overview.js
+++ b/rmqtt-dashboard/pages/overview.js
@@ -92,6 +92,12 @@
             <button v-for="r in timeRanges" :key="r.key"
                     class="time-btn" :class="{ active: timeRange === r.key }"
                     @click="setTimeRange(r.key)">{{ r.label }}</button>
+            <span style="flex:1;"></span>
+            <select class="form-select" v-model="chartNode" style="width:160px;"
+                    @change="onChartNodeChange" :title="$t('overview.node_filter')">
+              <option value="">{{ $t('overview.all_nodes') }}</option>
+              <option v-for="n in nodes" :key="n.node_id" :value="n.node_id">{{ n.node_name || n.node_id }}</option>
+            </select>
           </div>
           <div class="chart-grid">
             <div class="chart-card">
@@ -270,6 +276,29 @@
         { key: '15d', label: '15d' },
       ];
       const timeRange = ref('1h');
+      // 折线图节点筛选：'' = 所有节点（sum），否则具体节点（单节点 history）
+      const chartNode = ref('');
+
+      function onChartNodeChange() {
+        notMergeNext = true;
+        chartData.value = [];
+        fetchHistory();
+      }
+
+      // 依据选中节点生成 history 接口路径与查询串
+      function historyPaths(qs) {
+        if (chartNode.value) {
+          var id = encodeURIComponent(chartNode.value);
+          return {
+            stats: '/stats/history/' + id + '?' + qs,
+            metrics: '/metrics/history/' + id + '?' + qs,
+          };
+        }
+        return {
+          stats: '/stats/history/sum?' + qs,
+          metrics: '/metrics/history/sum?' + qs,
+        };
+      }
 
       // 指标分组：来自 /api/v1/metrics/sum 的累计值（只增不减）
       const metricGroups = Vue.computed(function() {
@@ -460,8 +489,8 @@
         qs += '&limit=' + params.limit + '&merge_window=' + params.merge_window;
 
         var [statsRes, metricsRes] = await Promise.all([
-          http.get('/stats/history/sum?' + qs).catch(function() { return null; }),
-          http.get('/metrics/history/sum?' + qs).catch(function() { return null; }),
+          http.get(historyPaths(qs).stats).catch(function() { return null; }),
+          http.get(historyPaths(qs).metrics).catch(function() { return null; }),
         ]);
 
         if (!statsRes || !metricsRes || statsRes.error || metricsRes.error) {
@@ -489,7 +518,9 @@
         // 按 ts 合并 metrics + stats
         var merged = [];
         if (metricsRes.data) {
-          metricsRes.data.forEach(function(d) {
+          // 丢弃最新桶：可能尚未聚合完所有节点数据，避免折线末尾出现低谷/跳变
+          var histData = metricsRes.data.slice(1);
+          histData.forEach(function(d) {
             var s = statsMap[d.ts] || {};
             merged.push({
               time: d.ts,
@@ -510,31 +541,90 @@
         startLiveHistoryPolling();
       }
 
-      // 每 merge_window 秒通过 history API 获取最新一个合并点
+      // 实时轮询每次拉取最近 N 个合并点：
+      //   与已有序列重叠的 ts 以最大值为准调整该点（节点数据晚到补齐时修正），
+      //   未重叠的新点按 ts 升序追加在末尾。
+      const HISTORY_LATEST_POINTS = 3;
+
       async function fetchLatestHistory() {
         if (isLiveMode) return;
-        var qs = 'minutes=' + currentLatestMinutes + '&limit=1&merge_window=' + currentMergeWindow;
+        var qs = 'minutes=' + currentLatestMinutes +
+                 '&limit=' + HISTORY_LATEST_POINTS + '&merge_window=' + currentMergeWindow;
         var [statsRes, metricsRes] = await Promise.all([
-          http.get('/stats/history/sum?' + qs).catch(function() { return null; }),
-          http.get('/metrics/history/sum?' + qs).catch(function() { return null; }),
+          http.get(historyPaths(qs).stats).catch(function() { return null; }),
+          http.get(historyPaths(qs).metrics).catch(function() { return null; }),
         ]);
         if (!metricsRes || !metricsRes.data || metricsRes.data.length === 0) return;
-        var point = metricsRes.data[metricsRes.data.length - 1];
-        var s = {};
-        if (statsRes && statsRes.data && statsRes.data.length > 0) {
-          var sp = statsRes.data[statsRes.data.length - 1];
-          s.connections = sp['connections.count'] ?? sp.connections_count ?? 0;
-          s.topics = sp['topics.count'] ?? sp.topics_count ?? 0;
-          s.subscriptions = sp['subscriptions.count'] ?? sp.subscriptions_count ?? 0;
+
+        // stats 按 ts 建索引，与 metrics 的合并桶对齐
+        var statsByTs = {};
+        if (statsRes && statsRes.data) {
+          statsRes.data.forEach(function(sp) {
+            statsByTs[sp.ts] = {
+              connections: sp['connections.count'] ?? sp.connections_count ?? 0,
+              topics: sp['topics.count'] ?? sp.topics_count ?? 0,
+              subscriptions: sp['subscriptions.count'] ?? sp.subscriptions_count ?? 0,
+            };
+          });
         }
-        chartData.value.push({
-          time: point.ts,
-          msgIn: point['messages.publish'] ?? point.messages_publish ?? 0,
-          msgOut: point['messages.delivered'] ?? point.messages_delivered ?? 0,
-          msgDropped: point['messages.dropped'] ?? point.messages_dropped ?? 0,
-          connections: s.connections ?? 0,
-          topics: s.topics ?? 0,
-          subscriptions: s.subscriptions ?? 0,
+
+        // 已有序列的 ts → index 索引
+        var idxByTs = {};
+        for (var i = 0; i < chartData.value.length; i++) {
+          idxByTs[chartData.value[i].time] = i;
+        }
+
+        // 后端返回降序（最新在前），转升序处理
+        var points = metricsRes.data.slice().sort(function(a, b) { return a.ts - b.ts; });
+
+        // 丢弃最新桶：可能尚未聚合完所有节点数据，不画半成品；下一轮它完整后再画
+        points.pop();
+        if (points.length === 0) return;
+
+        var toAppend = [];
+
+        points.forEach(function(point) {
+          var s = statsByTs[point.ts] || {};
+          var np = {
+            time: point.ts,
+            msgIn: point['messages.publish'] ?? point.messages_publish ?? 0,
+            msgOut: point['messages.delivered'] ?? point.messages_delivered ?? 0,
+            msgDropped: point['messages.dropped'] ?? point.messages_dropped ?? 0,
+            connections: s.connections ?? 0,
+            topics: s.topics ?? 0,
+            subscriptions: s.subscriptions ?? 0,
+          };
+          var idx = idxByTs[point.ts];
+          if (idx != null) {
+            // 重叠：以最大值为准调整该点的位置（只大不小）
+            var old = chartData.value[idx];
+            chartData.value[idx] = {
+              time: point.ts,
+              msgIn: Math.max(old.msgIn, np.msgIn),
+              msgOut: Math.max(old.msgOut, np.msgOut),
+              msgDropped: Math.max(old.msgDropped, np.msgDropped),
+              connections: Math.max(old.connections, np.connections),
+              topics: Math.max(old.topics, np.topics),
+              subscriptions: Math.max(old.subscriptions, np.subscriptions),
+            };
+          } else {
+            toAppend.push(np);
+          }
+        });
+
+        // 未重叠的新点按 ts 升序插入正确位置（保持序列单调），
+        // 避免轮询返回的桶比末尾旧（如大时间范围早期点被 maxChartPoints 截断过）时乱序
+        toAppend.sort(function(a, b) { return a.time - b.time; });
+        toAppend.forEach(function(np) {
+          var insertAt = -1;
+          for (var j = 0; j < chartData.value.length; j++) {
+            if (chartData.value[j].time > np.time) { insertAt = j; break; }
+          }
+          if (insertAt === -1) {
+            chartData.value.push(np);
+          } else {
+            chartData.value.splice(insertAt, 0, np);
+          }
         });
         if (chartData.value.length > maxChartPoints) {
           chartData.value.splice(0, chartData.value.length - maxChartPoints);
@@ -838,12 +928,29 @@
           };
         }
 
+        // 生成连接数/主题数/订阅数类 tooltip：MM/DD HH:mm:ss + 当前值
+        function makeValueTooltip() {
+          return {
+            trigger: 'axis',
+            confine: true,
+            formatter: function(params) {
+              var p = params[0];
+              if (!p || p.value == null || p.value[0] == null) return '';
+              var t = new Date(p.value[0]);
+              var ts = pad(t.getMonth() + 1) + '/' + pad(t.getDate()) + ' ' + pad(t.getHours()) + ':' + pad(t.getMinutes()) + ':' + pad(t.getSeconds());
+              var val = p.value[1];
+              if (typeof val === 'number' && val % 1 !== 0) val = +val.toFixed(2);
+              return ts + '<br/>' + (p.seriesName || '') + '：' + val;
+            }
+          };
+        }
+
         updateLineChart(chartMsgIn, $t('overview.msg_in_trend'), msgIn, '#3b82f6', null, makeMsgTooltip('msgIn'));
         updateLineChart(chartMsgOut, $t('overview.msg_out_trend'), msgOut, '#22c55e', null, makeMsgTooltip('msgOut'));
         updateLineChart(chartMsgDropped, $t('overview.msg_dropped_trend'), msgDropped, '#ef4444', null, makeMsgTooltip('msgDropped'));
-        updateLineChart(chartConnections, $t('overview.connections_trend'), data.map(function(d) { return [d.time, d.connections]; }), '#f59e0b', 'rgba(245,158,11,0.1)');
-        updateLineChart(chartTopics, $t('overview.topics_trend'), data.map(function(d) { return [d.time, d.topics]; }), '#8b5cf6');
-        updateLineChart(chartSubscriptions, $t('overview.subscriptions_trend'), data.map(function(d) { return [d.time, d.subscriptions]; }), '#06b6d4');
+        updateLineChart(chartConnections, $t('overview.connections_trend'), data.map(function(d) { return [d.time, d.connections]; }), '#f59e0b', 'rgba(245,158,11,0.1)', makeValueTooltip());
+        updateLineChart(chartTopics, $t('overview.topics_trend'), data.map(function(d) { return [d.time, d.topics]; }), '#8b5cf6', null, makeValueTooltip());
+        updateLineChart(chartSubscriptions, $t('overview.subscriptions_trend'), data.map(function(d) { return [d.time, d.subscriptions]; }), '#06b6d4', null, makeValueTooltip());
       }
 
       onMounted(function() {
@@ -883,6 +990,7 @@
         totalConnections, statusData, statusGroups, getStat,
         metricsData, metricGroups, getMetric,
         timeRanges, timeRange, setTimeRange,
+        chartNode, onChartNodeChange,
         selectedNodeId, nodeDetail, nodeDetailLoading, nodeDetailError,
         nodeStatsItems, showNodeDetail, hideNodeDetail, refreshNodeDetail,
         goToNodeList,

--- a/rmqtt-dashboard/style.css
+++ b/rmqtt-dashboard/style.css
@@ -1267,3 +1267,105 @@ tr:hover td { background: var(--bg-hover); }
 .error-text {
   color: var(--red);
 }
+
+/* ─── 自研日期时间选择器（可国际化，替代原生 datetime-local） ─── */
+.dtp { position: relative; }
+.dtp-input {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  cursor: pointer; user-select: none;
+}
+.dtp-input.active { border-color: var(--accent); }
+.dtp-placeholder { color: var(--text-muted); }
+.dtp-caret { color: var(--text-muted); font-size: 10px; flex-shrink: 0; }
+.dtp-popover {
+  position: absolute; top: calc(100% + 6px); left: 0; z-index: 1000;
+  width: 272px; background: var(--bg-card);
+  border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 10px; box-shadow: 0 8px 24px rgba(0,0,0,.35);
+}
+.dtp-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.dtp-title { font-size: 13px; font-weight: 600; unicode-bidi: plaintext; }
+.dtp-nav {
+  width: 26px; height: 26px; border: 1px solid var(--border);
+  background: transparent; color: var(--text-muted);
+  border-radius: 6px; cursor: pointer; font-size: 14px; line-height: 1;
+}
+.dtp-nav:hover { background: var(--bg-hover); color: var(--text); }
+.dtp-week { display: grid; grid-template-columns: repeat(7, 1fr); margin-bottom: 4px; }
+.dtp-week span { text-align: center; font-size: 11px; color: var(--text-muted); padding: 4px 0; }
+.dtp-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
+.dtp-cell {
+  height: 30px; border: 1px solid transparent; background: transparent;
+  color: var(--text); border-radius: 6px; cursor: pointer;
+  font-size: 12px; display: flex; align-items: center; justify-content: center;
+  padding: 0;
+}
+.dtp-cell:hover { background: var(--bg-hover); }
+.dtp-cell.out { color: var(--text-muted); opacity: .45; }
+.dtp-cell.today { border-color: var(--accent); }
+.dtp-cell.sel { background: var(--accent); color: #fff; }
+.dtp-cell.sel:hover { background: var(--accent-hover); color: #fff; }
+.dtp-time {
+  display: flex; align-items: center; gap: 6px; margin-top: 10px;
+  padding-top: 10px; border-top: 1px solid var(--border);
+}
+.dtp-tlbl { font-size: 12px; color: var(--text-muted); }
+.dtp-colon { color: var(--text-muted); }
+.dtp-select {
+  background: var(--bg); border: 1px solid var(--border); color: var(--text);
+  border-radius: 6px; padding: 3px 4px; font-size: 12px;
+  max-height: 140px; overflow-y: auto;
+}
+.dtp-today {
+  margin-left: auto; width: 26px; height: 26px; border: 1px solid var(--border);
+  background: transparent; color: var(--text-muted); border-radius: 6px;
+  cursor: pointer; font-size: 10px; display: flex; align-items: center; justify-content: center;
+}
+.dtp-today:hover { background: var(--bg-hover); color: var(--text); }
+.dtp-foot { display: flex; justify-content: flex-end; gap: 8px; margin-top: 10px; }
+.btn-sm { padding: 4px 12px; font-size: 12px; }
+
+/* ─── 客户端详情页 ─── */
+.detail-toolbar {
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 16px; flex-wrap: wrap;
+}
+.detail-title { font-size: 15px; font-weight: 600; }
+.detail-status { font-size: 13px; }
+.detail-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 16px;
+  margin-bottom: 16px;
+}
+@media (max-width: 900px) {
+  .detail-grid { grid-template-columns: 1fr; }
+}
+.info-card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 16px;
+}
+.info-card h3 {
+  font-size: 13px; font-weight: 600; color: var(--text-muted);
+  margin-bottom: 10px; letter-spacing: .3px;
+}
+.info-row {
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 16px; padding: 7px 0; border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.info-row:last-child { border-bottom: none; }
+.info-label { color: var(--text-muted); flex-shrink: 0; }
+.info-value {
+  color: var(--text); text-align: right; word-break: break-all;
+  font-family: monospace; font-size: 12px;
+}
+.info-value.plain { font-family: inherit; }
+.detail-empty {
+  text-align: center; color: var(--text-muted);
+  padding: 60px 20px; font-size: 14px;
+}
+.detail-subs-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 16px; border-bottom: 1px solid var(--border);
+  font-size: 13px; color: var(--text-muted);
+}
+.detail-subs-header b { color: var(--text); font-weight: 600; }

--- a/rmqtt-plugins/rmqtt-http-api/src/api.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/api.rs
@@ -2828,10 +2828,14 @@ async fn query_history_remote(
                 .send()
                 .await
                 {
-                    if let Ok(MessageReply::StatsHistoryReply(d)) | Ok(MessageReply::MetricsHistoryReply(d)) =
+                    // 跨节点传输的是 JSON 字符串化的 HistoryData
+                    // （postcard 无法反序列化 serde_json::Value）
+                    if let Ok(MessageReply::StatsHistoryReply(s)) | Ok(MessageReply::MetricsHistoryReply(s)) =
                         MessageReply::decode(&reply_data)
                     {
-                        return d;
+                        if let Ok(d) = serde_json::from_str::<HistoryData>(&s) {
+                            return d;
+                        }
                     }
                 }
             }
@@ -2896,8 +2900,13 @@ async fn query_history_all_nodes(
                 (id, Ok(GrpcMessageReply::Data(data))) => {
                     if let Ok(reply_msg) = MessageReply::decode(&data) {
                         match reply_msg {
-                            MessageReply::StatsHistoryReply(d) | MessageReply::MetricsHistoryReply(d) => {
-                                nodes.insert(id, d);
+                            // 跨节点传输的是 JSON 字符串化的 HistoryData
+                            MessageReply::StatsHistoryReply(s) | MessageReply::MetricsHistoryReply(s) => {
+                                if let Ok(d) = serde_json::from_str::<HistoryData>(&s) {
+                                    nodes.insert(id, d);
+                                } else {
+                                    log::warn!("invalid history data from node({id})");
+                                }
                             }
                             _ => {
                                 log::info!("unexpected history reply from node({id})");
@@ -2918,12 +2927,22 @@ async fn query_history_all_nodes(
     nodes
 }
 
-/// Aggregates per-node history data into a single time series by summing
-/// numeric fields at each timestamp. Returns `(data_points, node_count)`.
+/// Aggregates per-node history data into a single time series.
+///
+/// Numeric fields are summed across nodes at each timestamp, except for
+/// cluster-wide fields that all nodes report identically (the shared topic /
+/// route tables): those take the maximum instead of a sum.
+/// Returns `(data_points, node_count)`.
 fn aggregate_history_data(nodes_data: &HashMap<NodeId, HistoryData>) -> (Vec<serde_json::Value>, usize) {
     let node_count = nodes_data.len();
     if node_count == 0 {
         return (vec![], 0);
+    }
+
+    // Cluster-shared quantities: every node reports the same value for the
+    // shared topic/route tables, so summing would over-count (N nodes → N×).
+    fn take_max(key: &str) -> bool {
+        matches!(key, "topics.count" | "topics.max" | "routes.count" | "routes.max")
     }
 
     // Group values by timestamp.
@@ -2936,7 +2955,7 @@ fn aggregate_history_data(nodes_data: &HashMap<NodeId, HistoryData>) -> (Vec<ser
         }
     }
 
-    // For each unique timestamp, sum all numeric fields.
+    // For each unique timestamp, merge all numeric fields.
     let mut result: Vec<(u64, serde_json::Value)> = Vec::with_capacity(grouped.len());
     for (ts, points) in grouped {
         let mut merged = serde_json::Map::new();
@@ -2953,7 +2972,11 @@ fn aggregate_history_data(nodes_data: &HashMap<NodeId, HistoryData>) -> (Vec<ser
                             let val = n.as_f64().unwrap_or(0.0);
                             let entry = merged.entry(k.clone()).or_insert_with(|| json!(0.0_f64));
                             if let Some(existing) = entry.as_f64() {
-                                *entry = json!(existing + val);
+                                *entry = if take_max(k) {
+                                    json!(existing.max(val))
+                                } else {
+                                    json!(existing + val)
+                                };
                             }
                         }
                         _ => {

--- a/rmqtt-plugins/rmqtt-http-api/src/handler.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/handler.rs
@@ -289,7 +289,9 @@ impl Handler for HookHandler {
                                         data: vec![],
                                     },
                                 };
-                                match MessageReply::StatsHistoryReply(data).encode() {
+                                // postcard 无法反序列化 serde_json::Value，跨节点用 JSON 字符串传输
+                                let data_json = serde_json::to_string(&data).unwrap_or_default();
+                                match MessageReply::StatsHistoryReply(data_json).encode() {
                                     Ok(ress) => {
                                         HookResult::GrpcMessageReply(Ok(GrpcMessageReply::Data(ress)))
                                     }
@@ -321,7 +323,9 @@ impl Handler for HookHandler {
                                         data: vec![],
                                     },
                                 };
-                                match MessageReply::MetricsHistoryReply(data).encode() {
+                                // postcard 无法反序列化 serde_json::Value，跨节点用 JSON 字符串传输
+                                let data_json = serde_json::to_string(&data).unwrap_or_default();
+                                match MessageReply::MetricsHistoryReply(data_json).encode() {
                                     Ok(ress) => {
                                         HookResult::GrpcMessageReply(Ok(GrpcMessageReply::Data(ress)))
                                     }

--- a/rmqtt-plugins/rmqtt-http-api/src/types.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/types.rs
@@ -95,10 +95,14 @@ pub enum MessageReply {
     LoadPlugin,
     UnloadPlugin(bool),
     // ── History query replies ──────────────────────────────────────────
-    /// Stats history data from a node
-    StatsHistoryReply(HistoryData),
-    /// Metrics history data from a node
-    MetricsHistoryReply(HistoryData),
+    /// Stats history data from a node.
+    ///
+    /// The [`HistoryData`] is transported as its **JSON string** because
+    /// postcard cannot deserialize `serde_json::Value` (it requires
+    /// `deserialize_any`, which postcard explicitly does not implement).
+    StatsHistoryReply(String),
+    /// Metrics history data from a node (same JSON-string transport).
+    MetricsHistoryReply(String),
 }
 
 impl MessageReply {


### PR DESCRIPTION
**Summary**
Major enhancements to the dashboard and cluster example configurations:
- New client detail page with full client/session information
- Node selector for chart filtering in overview
- Comprehensive cluster example port and config updates
- History data aggregation fixes

**Dashboard Changes**

New Client Detail Page:
- Dedicated page at `#/clients/detail?clientid=xxx`
- Displays connection info, session info, and current subscriptions
- Shows superuser status, address, disconnect reason, last will, session expiry
- Click client row in clients list to navigate to detail page
- Back button to return to client list
- Sidebar "Clients" menu stays highlighted when on detail page

Client List Improvements:
- Clickable rows navigate to client detail
- `@click.stop` on kick button prevents row click
- Supports quick search via `#/clients?clientid=xxx` URL param

Overview Chart Node Selector:
- Dropdown to filter history charts by specific node or "All Nodes"
- History API paths switch between `/stats/history/{node}` and `/stats/history/sum`
- Chart node selection persists across time range changes

**Backend Fixes**

History Data Aggregation:
- Fixed cluster-shared fields (topics.count, topics.max, routes.count, routes.max)
  - Previously summed across nodes, causing over-count (N nodes → N×)
  - Now takes `max` instead of `sum` for shared topic/route tables

Cross-Node History Transport:
- `HistoryData` now transmitted as JSON string between nodes
- Postcard cannot deserialize `serde_json::Value` (requires `deserialize_any`)
- Updated `StatsHistoryReply` and `MetricsHistoryReply` to carry `String` instead of `HistoryData`

**Cluster Example Configurations**

Massive port shifting across all cluster examples to avoid conflicts:

Broadcast (3 nodes) + Raft-3 (3 nodes) + Raft-5 (5 nodes):
- All gRPC ports: 5363→5364, 5364→5365, 5365→5366 (and upward)
- All Raft ports: 6003→6004, 6004→6005, 6005→6006 (and upward)
- All MQTT ports: 1883→1884, 1884→1885, 1885→1886 (and upward)
- All HTTP API ports: 6060→6061, 6061→6062, 6062→6063 (and upward)

HTTP API Plugin Configuration (all nodes):
- Added comprehensive config with history storage (Redb backend by default)
- Dashboard static directory: `../../../rmqtt-dashboard`
- All nodes now enable `rmqtt-http-api` plugin by default

**I18n Updates**
- Added `clients.detail_title`, `clients.back`, `clients.connection_info`, `clients.session_info`, `clients.current_subs`, `clients.superuser`, `clients.address`, `clients.disconnected_at`, `clients.disconnect_reason`, `clients.last_will`, `clients.session_expiry`, `clients.session_created`, `clients.subs_count`, `clients.keepalive`, `clients.not_found`
- Added `overview.all_nodes`, `overview.node_filter`
- Added `datetime` section (now, clear, hour, minute, today, prev_month, next_month)

**UI Components Added**
- `datetime-picker.js`: Custom datetime picker component with i18n support
- `ClientDetailPage`: Full client detail view component

**Benefits**
- Full client drill-down capability
- Per-node chart filtering for historical data
- Fixed history aggregation for shared cluster data
- Non-conflicting ports in cluster examples
- All nodes now include HTTP API for easier testing