### PR TITLE
feat(dashboard): add dropped message panel with abnormal/non-subscriber tabs

### DIFF
--- a/rmqtt-dashboard/i18n.js
+++ b/rmqtt-dashboard/i18n.js
@@ -28,7 +28,7 @@
       this.locale = FALLBACK;
       this._messages = {};
       this._cache = {};
-      this._localeVer = 6;  // 语言文件版本号，修改后递增以绕过浏览器缓存
+      this._localeVer = 7;  // 语言文件版本号，修改后递增以绕过浏览器缓存
     }
 
     /** 初始化：检测语言 → 预加载全部语言包 */

--- a/rmqtt-dashboard/index.html
+++ b/rmqtt-dashboard/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
   <title>RMQTT Dashboard</title>
-  <link rel="stylesheet" href="./style.css?v=25">
+  <link rel="stylesheet" href="./style.css?v=26">
 </head>
 <body>
   <div id="app"></div>
@@ -16,7 +16,7 @@
   <script src="https://unpkg.com/echarts@5/dist/echarts.min.js"></script>
   <script src="./http.js?v=3"></script>
   <script src="./store.js?v=3"></script>
-  <script src="./i18n.js?v=12"></script>
+  <script src="./i18n.js?v=13"></script>
   <script src="./components/app-layout.js?v=3"></script>
   <script src="./components/sidebar-nav.js?v=6"></script>
   <script src="./components/metric-card.js?v=5"></script>
@@ -27,7 +27,7 @@
   <script src="./components/ring-chart.js?v=3"></script>
   <script src="./components/node-detail.js?v=7"></script>
   <script src="./pages/login.js?v=3"></script>
-  <script src="./pages/overview.js?v=25"></script>
+  <script src="./pages/overview.js?v=28"></script>
   <script src="./pages/clients.js?v=11"></script>
   <script src="./pages/client-detail.js?v=2"></script>
   <script src="./pages/subscriptions.js?v=6"></script>

--- a/rmqtt-dashboard/locales/ar.json
+++ b/rmqtt-dashboard/locales/ar.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "رسائل واردة",
     "msg_out_trend": "رسائل صادرة",
     "msg_dropped_trend": "رسائل مرفوضة",
+    "msg_dropped_abnormal": "إسقاط غير طبيعي",
+    "msg_dropped_nonsub": "بدون مشترك",
     "connections_trend": "الاتصالات",
     "topics_trend": "المواضيع",
     "subscriptions_trend": "الاشتراكات",

--- a/rmqtt-dashboard/locales/bn.json
+++ b/rmqtt-dashboard/locales/bn.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "Msg ইন",
     "msg_out_trend": "Msg আউট",
     "msg_dropped_trend": "Msg বাদ",
+    "msg_dropped_abnormal": "অস্বাভাবিক ড্রপ",
+    "msg_dropped_nonsub": "সাবস্ক্রাইবারহীন",
     "connections_trend": "সংযোগ",
     "topics_trend": "টপিক",
     "subscriptions_trend": "সাবস্ক্রিপশন",

--- a/rmqtt-dashboard/locales/de.json
+++ b/rmqtt-dashboard/locales/de.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "Nachr. Rein",
     "msg_out_trend": "Nachr. Raus",
     "msg_dropped_trend": "Nachr. Verw.",
+    "msg_dropped_abnormal": "Abnormal verw.",
+    "msg_dropped_nonsub": "Ohne Abonnenten",
     "connections_trend": "Verbindungen",
     "topics_trend": "Topics",
     "subscriptions_trend": "Abonnements",

--- a/rmqtt-dashboard/locales/en.json
+++ b/rmqtt-dashboard/locales/en.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "Message In",
     "msg_out_trend": "Message Out",
     "msg_dropped_trend": "Message Dropped",
+    "msg_dropped_abnormal": "Abnormal Drop",
+    "msg_dropped_nonsub": "No Subscriber",
     "connections_trend": "Connections",
     "topics_trend": "Topics",
     "subscriptions_trend": "Subscriptions",

--- a/rmqtt-dashboard/locales/es.json
+++ b/rmqtt-dashboard/locales/es.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "Msg Entrante",
     "msg_out_trend": "Msg Saliente",
     "msg_dropped_trend": "Msg Descartado",
+    "msg_dropped_abnormal": "Descarte anormal",
+    "msg_dropped_nonsub": "Sin suscriptor",
     "connections_trend": "Conexiones",
     "topics_trend": "Topics",
     "subscriptions_trend": "Suscripciones",

--- a/rmqtt-dashboard/locales/fr.json
+++ b/rmqtt-dashboard/locales/fr.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "Msg Entrant",
     "msg_out_trend": "Msg Sortant",
     "msg_dropped_trend": "Msg Rejeté",
+    "msg_dropped_abnormal": "Rejet anormal",
+    "msg_dropped_nonsub": "Sans abonné",
     "connections_trend": "Connexions",
     "topics_trend": "Topics",
     "subscriptions_trend": "Abonnements",

--- a/rmqtt-dashboard/locales/hi.json
+++ b/rmqtt-dashboard/locales/hi.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "Msg इन",
     "msg_out_trend": "Msg आउट",
     "msg_dropped_trend": "Msg ड्रॉप",
+    "msg_dropped_abnormal": "असामान्य ड्रॉप",
+    "msg_dropped_nonsub": "बिना सब्सक्राइबर",
     "connections_trend": "कनेक्शन",
     "topics_trend": "टॉपिक",
     "subscriptions_trend": "सदस्यता",

--- a/rmqtt-dashboard/locales/it.json
+++ b/rmqtt-dashboard/locales/it.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "Msg In",
     "msg_out_trend": "Msg Out",
     "msg_dropped_trend": "Msg Scartate",
+    "msg_dropped_abnormal": "Scarto anormale",
+    "msg_dropped_nonsub": "Senza sottoscrittore",
     "connections_trend": "Connessioni",
     "topics_trend": "Topic",
     "subscriptions_trend": "Sottoscrizioni",

--- a/rmqtt-dashboard/locales/pt.json
+++ b/rmqtt-dashboard/locales/pt.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "Msg Entrada",
     "msg_out_trend": "Msg Saída",
     "msg_dropped_trend": "Msg Descartada",
+    "msg_dropped_abnormal": "Descarte anormal",
+    "msg_dropped_nonsub": "Sem assinante",
     "connections_trend": "Conexões",
     "topics_trend": "Tópicos",
     "subscriptions_trend": "Assinaturas",

--- a/rmqtt-dashboard/locales/ru.json
+++ b/rmqtt-dashboard/locales/ru.json
@@ -96,6 +96,8 @@
     "msg_in_trend": "Входящие",
     "msg_out_trend": "Исходящие",
     "msg_dropped_trend": "Отброшено",
+    "msg_dropped_abnormal": "Аварийный сброс",
+    "msg_dropped_nonsub": "Без подписчиков",
     "connections_trend": "Соединения",
     "topics_trend": "Топики",
     "subscriptions_trend": "Подписки",

--- a/rmqtt-dashboard/locales/zh-CN.json
+++ b/rmqtt-dashboard/locales/zh-CN.json
@@ -104,6 +104,8 @@
     "msg_in_trend": "消息流入",
     "msg_out_trend": "消息流出",
     "msg_dropped_trend": "消息丢弃",
+    "msg_dropped_abnormal": "异常丢弃",
+    "msg_dropped_nonsub": "无订阅者丢弃",
     "connections_trend": "连接数",
     "topics_trend": "主题数",
     "subscriptions_trend": "订阅数",

--- a/rmqtt-dashboard/locales/zh-TW.json
+++ b/rmqtt-dashboard/locales/zh-TW.json
@@ -96,6 +96,8 @@
     "msg_in_trend": "消息流入",
     "msg_out_trend": "消息流出",
     "msg_dropped_trend": "消息丟棄",
+    "msg_dropped_abnormal": "異常丟棄",
+    "msg_dropped_nonsub": "無訂閱者丟棄",
     "connections_trend": "連接數",
     "topics_trend": "主題數",
     "subscriptions_trend": "訂閱數",

--- a/rmqtt-dashboard/pages/overview.js
+++ b/rmqtt-dashboard/pages/overview.js
@@ -109,7 +109,17 @@
               <div class="chart-box" id="chartMsgOut"></div>
             </div>
             <div class="chart-card">
-              <h3>{{ $t('overview.msg_dropped_trend') }}</h3>
+              <div class="chart-card-head">
+                <h3>{{ $t('overview.msg_dropped_trend') }}</h3>
+                <div class="seg-tabs" role="tablist" :aria-label="$t('overview.msg_dropped_trend')">
+                  <button type="button" role="tab" :aria-selected="droppedTab === 'abnormal'"
+                          class="seg-btn" :class="{ active: droppedTab === 'abnormal' }"
+                          @click="switchDroppedTab('abnormal')">{{ $t('overview.msg_dropped_abnormal') }}</button>
+                  <button type="button" role="tab" :aria-selected="droppedTab === 'nonsub'"
+                          class="seg-btn" :class="{ active: droppedTab === 'nonsub' }"
+                          @click="switchDroppedTab('nonsub')">{{ $t('overview.msg_dropped_nonsub') }}</button>
+                </div>
+              </div>
               <div class="chart-box" id="chartMsgDropped"></div>
             </div>
             <div class="chart-card">
@@ -362,6 +372,8 @@
 
       // 历史数据（用于图表渲染，来自 history API + live poll）
       const chartData = ref([]);
+      // 消息丢弃面板切换：'abnormal' 异常丢弃（转发失败/过期/异常）| 'nonsub' 无订阅者丢弃
+      const droppedTab = ref('abnormal');
       let isLiveMode = false;     // 历史 API 不可用时回退纯实时模式
       const CHART_POINTS = 360;   // 图表固定点数上限
       let maxChartPoints = CHART_POINTS + 20;    // 动态上限
@@ -527,6 +539,7 @@
               msgIn: d['messages.publish'] ?? d.messages_publish ?? 0,
               msgOut: d['messages.delivered'] ?? d.messages_delivered ?? 0,
               msgDropped: d['messages.dropped'] ?? d.messages_dropped ?? 0,
+              msgNonSub: d['messages.nonsubscribed'] ?? d.messages_nonsubscribed ?? 0,
               connections: s.connections ?? 0,
               topics: s.topics ?? 0,
               subscriptions: s.subscriptions ?? 0,
@@ -544,7 +557,7 @@
       // 实时轮询每次拉取最近 N 个合并点：
       //   与已有序列重叠的 ts 以最大值为准调整该点（节点数据晚到补齐时修正），
       //   未重叠的新点按 ts 升序追加在末尾。
-      const HISTORY_LATEST_POINTS = 3;
+      const HISTORY_LATEST_POINTS = 5;
 
       async function fetchLatestHistory() {
         if (isLiveMode) return;
@@ -590,6 +603,7 @@
             msgIn: point['messages.publish'] ?? point.messages_publish ?? 0,
             msgOut: point['messages.delivered'] ?? point.messages_delivered ?? 0,
             msgDropped: point['messages.dropped'] ?? point.messages_dropped ?? 0,
+            msgNonSub: point['messages.nonsubscribed'] ?? point.messages_nonsubscribed ?? 0,
             connections: s.connections ?? 0,
             topics: s.topics ?? 0,
             subscriptions: s.subscriptions ?? 0,
@@ -603,6 +617,7 @@
               msgIn: Math.max(old.msgIn, np.msgIn),
               msgOut: Math.max(old.msgOut, np.msgOut),
               msgDropped: Math.max(old.msgDropped, np.msgDropped),
+              msgNonSub: Math.max(old.msgNonSub, np.msgNonSub),
               connections: Math.max(old.connections, np.connections),
               topics: Math.max(old.topics, np.topics),
               subscriptions: Math.max(old.subscriptions, np.subscriptions),
@@ -761,6 +776,7 @@
                 msgIn: ms(metricsSum, 'messages.publish'),
                 msgOut: ms(metricsSum, 'messages.delivered'),
                 msgDropped: ms(metricsSum, 'messages.dropped'),
+                msgNonSub: ms(metricsSum, 'messages.nonsubscribed'),
                 connections: stats.value.connections,
                 topics: stats.value.topics,
                 subscriptions: stats.value.subscriptions,
@@ -813,6 +829,14 @@
         if (key.endsWith('h')) return parseInt(key) * 3600000;
         if (key.endsWith('d')) return parseInt(key) * 86400000;
         return 3600000;
+      }
+
+      // 切换消息丢弃面板 tab：强制重建图表，避免合并动画产生竖线
+      function switchDroppedTab(tab) {
+        if (droppedTab.value === tab) return;
+        droppedTab.value = tab;
+        notMergeNext = true;
+        updateCharts();
       }
 
       function updateCharts() {
@@ -903,8 +927,12 @@
         var msgOut = data.length > 1 ? data.slice(1).map(function(d, i) {
           return toRate(data[i], d, 'msgOut');
         }) : [];
+        // 消息丢弃面板按 tab 选择数据字段与颜色（异常丢弃 / 无订阅者丢弃）
+        var droppedField = droppedTab.value === 'nonsub' ? 'msgNonSub' : 'msgDropped';
+        var droppedColor = droppedTab.value === 'nonsub' ? '#f59e0b' : '#ef4444';
+        var droppedName = $t(droppedTab.value === 'nonsub' ? 'overview.msg_dropped_nonsub' : 'overview.msg_dropped_abnormal');
         var msgDropped = data.length > 1 ? data.slice(1).map(function(d, i) {
-          return toRate(data[i], d, 'msgDropped');
+          return toRate(data[i], d, droppedField);
         }) : [];
 
         // 生成消息流 tooltip：MM/DD HH:mm:ss + N秒内消息总数
@@ -947,7 +975,7 @@
 
         updateLineChart(chartMsgIn, $t('overview.msg_in_trend'), msgIn, '#3b82f6', null, makeMsgTooltip('msgIn'));
         updateLineChart(chartMsgOut, $t('overview.msg_out_trend'), msgOut, '#22c55e', null, makeMsgTooltip('msgOut'));
-        updateLineChart(chartMsgDropped, $t('overview.msg_dropped_trend'), msgDropped, '#ef4444', null, makeMsgTooltip('msgDropped'));
+        updateLineChart(chartMsgDropped, droppedName, msgDropped, droppedColor, null, makeMsgTooltip(droppedField));
         updateLineChart(chartConnections, $t('overview.connections_trend'), data.map(function(d) { return [d.time, d.connections]; }), '#f59e0b', 'rgba(245,158,11,0.1)', makeValueTooltip());
         updateLineChart(chartTopics, $t('overview.topics_trend'), data.map(function(d) { return [d.time, d.topics]; }), '#8b5cf6', null, makeValueTooltip());
         updateLineChart(chartSubscriptions, $t('overview.subscriptions_trend'), data.map(function(d) { return [d.time, d.subscriptions]; }), '#06b6d4', null, makeValueTooltip());
@@ -990,6 +1018,7 @@
         totalConnections, statusData, statusGroups, getStat,
         metricsData, metricGroups, getMetric,
         timeRanges, timeRange, setTimeRange,
+        droppedTab, switchDroppedTab,
         chartNode, onChartNodeChange,
         selectedNodeId, nodeDetail, nodeDetailLoading, nodeDetailError,
         nodeStatsItems, showNodeDetail, hideNodeDetail, refreshNodeDetail,

--- a/rmqtt-dashboard/style.css
+++ b/rmqtt-dashboard/style.css
@@ -666,6 +666,38 @@ tr:hover td { background: var(--bg-hover); }
   color: #fff;
 }
 
+/* 消息丢弃面板分段切换 */
+.chart-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.chart-card-head h3 { margin-bottom: 0; }
+.seg-tabs {
+  display: flex;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2px;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.seg-btn {
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius) - 3px);
+  color: var(--text-muted);
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: .15s;
+  white-space: nowrap;
+}
+.seg-btn:hover { color: var(--text); background: var(--bg-hover); }
+.seg-btn.active { background: var(--accent); color: #fff; }
+
 /* 环形图区域 */
 .ring-section {
   background: var(--bg-card);


### PR DESCRIPTION
**Summary**
Enhance the Overview page's dropped messages chart with a segmented tab control to distinguish between abnormal drops and no-subscriber drops.

**Changes**

Overview Page:
- Add two-tab selector for dropped messages chart:
  - "Abnormal Drop" (messages.dropped) — red color
  - "No Subscriber" (messages.nonsubscribed) — amber color
- Chart data now includes `msgNonSub` field from metrics
- `HISTORY_LATEST_POINTS` increased from 3 to 5 for better data continuity
- `msg_dropped_abnormal` and `msg_dropped_nonsub` i18n keys added

UI Component:
- `.seg-tabs` segmented button group with active state styling
- `.chart-card-head` flex layout for title + tab controls

**Benefits**
- Clearer visibility into why messages are being dropped
- Separate tracking for abnormal drops (forwarding failures, expiry) vs no-subscriber drops
- Better diagnostic capability for message flow issues