### PR TITLE
feat(dashboard/retains): add delete retained message functionality

### DIFF
--- a/rmqtt-dashboard/components/confirm.js
+++ b/rmqtt-dashboard/components/confirm.js
@@ -1,0 +1,96 @@
+/* ============================================================
+   RMQTT Dashboard — 全局确认浮层（Promise 封装）
+   用法：
+     const ok = await window.$confirm(message, options);
+     ok === true  → 用户点击「确认」
+     ok === false → 用户点击「取消」/ 关闭按钮 / 点击遮罩
+   选项 options（均可省略）：
+     title      自定义标题（默认 i18n common.confirm_title）
+     confirmText 确认按钮文案（默认 i18n common.confirm）
+     cancelText  取消按钮文案（默认 i18n common.cancel）
+   独立挂载到 body 的临时 Vue 实例，弹窗关闭后自动销毁；
+   同一时间只允许一个确认弹窗（重复调用直接返回 false）。
+   ============================================================ */
+;(function() {
+  'use strict';
+
+  let instance = null; // 当前弹窗实例，防止叠加
+
+  window.$confirm = function(message, options) {
+    if (instance) return Promise.resolve(false);
+
+    const opts = options || {};
+    return new Promise(function(resolve) {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const app = Vue.createApp({
+        setup() {
+          const localeTick = Vue.ref(0);
+          const closing = Vue.ref(false);
+
+          function onLocaleChanged() {
+            localeTick.value++; // 触发文案重算，响应语言切换
+          }
+          Vue.onMounted(function() {
+            window.addEventListener('locale-changed', onLocaleChanged);
+          });
+          Vue.onUnmounted(function() {
+            window.removeEventListener('locale-changed', onLocaleChanged);
+          });
+
+          const title = Vue.computed(function() {
+            localeTick.value;
+            return opts.title || window.i18n.$t('common.confirm_title');
+          });
+          const confirmText = Vue.computed(function() {
+            localeTick.value;
+            return opts.confirmText || window.i18n.$t('common.confirm');
+          });
+          const cancelText = Vue.computed(function() {
+            localeTick.value;
+            return opts.cancelText || window.i18n.$t('common.cancel');
+          });
+
+          function close(result) {
+            if (closing.value) return;
+            closing.value = true;
+            resolve(result);
+            setTimeout(dispose, 200);
+          }
+
+          function dispose() {
+            if (!instance) return;
+            try { instance.app.unmount(); } catch (e) { /* noop */ }
+            if (instance.container.parentNode) {
+              instance.container.parentNode.removeChild(instance.container);
+            }
+            instance = null;
+          }
+
+          return { message, title, confirmText, cancelText, close };
+        },
+        template: `
+          <div class="modal-overlay" @click.self="close(false)">
+            <div class="modal-panel" style="width:auto;max-width:420px;">
+              <div class="modal-header">
+                <h3>{{ title }}</h3>
+                <button class="btn-icon modal-close" @click="close(false)">&times;</button>
+              </div>
+              <div class="modal-body">
+                <p style="margin:0;word-break:break-all;white-space:pre-wrap;line-height:1.6;">{{ message }}</p>
+              </div>
+              <div class="modal-footer">
+                <button class="btn" @click="close(false)">{{ cancelText }}</button>
+                <button class="btn btn-primary" style="margin-left:8px;" @click="close(true)">{{ confirmText }}</button>
+              </div>
+            </div>
+          </div>
+        `,
+      });
+
+      instance = { app, container };
+      app.mount(container);
+    });
+  };
+})();

--- a/rmqtt-dashboard/i18n.js
+++ b/rmqtt-dashboard/i18n.js
@@ -28,7 +28,7 @@
       this.locale = FALLBACK;
       this._messages = {};
       this._cache = {};
-      this._localeVer = 11;  // 语言文件版本号，修改后递增以绕过浏览器缓存
+      this._localeVer = 13;  // 语言文件版本号，修改后递增以绕过浏览器缓存
     }
 
     /** 初始化：检测语言 → 预加载全部语言包 */

--- a/rmqtt-dashboard/index.html
+++ b/rmqtt-dashboard/index.html
@@ -16,7 +16,7 @@
   <script src="https://unpkg.com/echarts@5/dist/echarts.min.js"></script>
   <script src="./http.js?v=3"></script>
   <script src="./store.js?v=3"></script>
-  <script src="./i18n.js?v=13"></script>
+  <script src="./i18n.js?v=14"></script>
   <script src="./components/app-layout.js?v=3"></script>
   <script src="./components/sidebar-nav.js?v=7"></script>
   <script src="./components/metric-card.js?v=5"></script>
@@ -26,12 +26,13 @@
   <script src="./components/msg-rate-panel.js?v=13"></script>
   <script src="./components/ring-chart.js?v=3"></script>
   <script src="./components/node-detail.js?v=8"></script>
+  <script src="./components/confirm.js?v=1"></script>
   <script src="./pages/login.js?v=3"></script>
   <script src="./pages/overview.js?v=32"></script>
-  <script src="./pages/clients.js?v=11"></script>
-  <script src="./pages/client-detail.js?v=2"></script>
-  <script src="./pages/subscriptions.js?v=6"></script>
-  <script src="./pages/retains.js?v=4"></script>
+  <script src="./pages/clients.js?v=12"></script>
+  <script src="./pages/client-detail.js?v=3"></script>
+  <script src="./pages/subscriptions.js?v=11"></script>
+  <script src="./pages/retains.js?v=5"></script>
   <script src="./pages/publish.js?v=4"></script>
   <script src="./pages/plugins.js?v=4"></script>
   <script src="./app.js?v=20"></script>

--- a/rmqtt-dashboard/locales/ar.json
+++ b/rmqtt-dashboard/locales/ar.json
@@ -299,7 +299,10 @@
     "error": "فشل الطلب",
     "retry": "إعادة المحاولة",
     "close": "إغلاق",
-    "dashboard": "لوحة التحكم"
+    "dashboard": "لوحة التحكم",
+    "confirm": "تأكيد",
+    "cancel": "إلغاء",
+    "confirm_title": "تأكيد"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "لا توجد رسائل محفوظة",
     "create_time": "تاريخ الإنشاء",
     "client_id": "معرف العميل",
-    "publish_time": "وقت النشر"
+    "publish_time": "وقت النشر",
+    "delete": "حذف",
+    "delete_confirm": "هل تريد حذف الرسالة المحفوظة للموضوع {topic}؟",
+    "delete_fail": "فشل حذف الرسالة: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/bn.json
+++ b/rmqtt-dashboard/locales/bn.json
@@ -299,7 +299,10 @@
     "error": "অনুরোধ ব্যর্থ",
     "retry": "পুনরায় চেষ্টা করুন",
     "close": "বন্ধ করুন",
-    "dashboard": "ড্যাশবোর্ড"
+    "dashboard": "ড্যাশবোর্ড",
+    "confirm": "নিশ্চিত করুন",
+    "cancel": "বাতিল",
+    "confirm_title": "নিশ্চিতকরণ"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "কোনো ধরে রাখা বার্তা নেই",
     "create_time": "তৈরির সময়",
     "client_id": "ক্লায়েন্ট ID",
-    "publish_time": "প্রকাশের সময়"
+    "publish_time": "প্রকাশের সময়",
+    "delete": "মুছুন",
+    "delete_confirm": "{topic} বিষয়ের জন্য সংরক্ষিত বার্তাটি মুছবেন?",
+    "delete_fail": "বার্তা মুছতে ব্যর্থ হয়েছে: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/de.json
+++ b/rmqtt-dashboard/locales/de.json
@@ -299,7 +299,10 @@
     "error": "Anfrage fehlgeschlagen",
     "retry": "Wiederholen",
     "close": "Schließen",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "Bestätigen",
+    "cancel": "Abbrechen",
+    "confirm_title": "Bestätigung"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "Keine zurückgehaltenen Nachrichten",
     "create_time": "Erstellt am",
     "client_id": "Client-ID",
-    "publish_time": "Veröffentlicht um"
+    "publish_time": "Veröffentlicht um",
+    "delete": "Löschen",
+    "delete_confirm": "Retained-Message für Thema {topic} löschen?",
+    "delete_fail": "Löschen fehlgeschlagen: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/en.json
+++ b/rmqtt-dashboard/locales/en.json
@@ -299,7 +299,10 @@
     "error": "Request failed",
     "retry": "Retry",
     "close": "Close",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "confirm_title": "Confirmation"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "No retained messages",
     "create_time": "Created At",
     "client_id": "Client ID",
-    "publish_time": "Published At"
+    "publish_time": "Published At",
+    "delete": "Delete",
+    "delete_confirm": "Delete retained message for topic {topic}?",
+    "delete_fail": "Delete failed: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/es.json
+++ b/rmqtt-dashboard/locales/es.json
@@ -299,7 +299,10 @@
     "error": "Error en la solicitud",
     "retry": "Reintentar",
     "close": "Cerrar",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "Confirmar",
+    "cancel": "Cancelar",
+    "confirm_title": "Confirmación"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "Sin mensajes retenidos",
     "create_time": "Creado en",
     "client_id": "ID de cliente",
-    "publish_time": "Publicado el"
+    "publish_time": "Publicado el",
+    "delete": "Eliminar",
+    "delete_confirm": "¿Eliminar el mensaje retenido para el tema {topic}?",
+    "delete_fail": "Error al eliminar: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/fr.json
+++ b/rmqtt-dashboard/locales/fr.json
@@ -299,7 +299,10 @@
     "error": "Échec de la requête",
     "retry": "Réessayer",
     "close": "Fermer",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "Confirmer",
+    "cancel": "Annuler",
+    "confirm_title": "Confirmation"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "Aucun message retenu",
     "create_time": "Créé à",
     "client_id": "ID client",
-    "publish_time": "Publié à"
+    "publish_time": "Publié à",
+    "delete": "Supprimer",
+    "delete_confirm": "Supprimer le message retenu pour le sujet {topic} ?",
+    "delete_fail": "Échec de la suppression : {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/hi.json
+++ b/rmqtt-dashboard/locales/hi.json
@@ -299,7 +299,10 @@
     "error": "अनुरोध विफल",
     "retry": "पुनः प्रयास करें",
     "close": "बंद करें",
-    "dashboard": "डैशबोर्ड"
+    "dashboard": "डैशबोर्ड",
+    "confirm": "पुष्टि करें",
+    "cancel": "रद्द करें",
+    "confirm_title": "पुष्टि"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "कोई रिटेन संदेश नहीं",
     "create_time": "निर्मित",
     "client_id": "क्लाइंट ID",
-    "publish_time": "प्रकाशित समय"
+    "publish_time": "प्रकाशित समय",
+    "delete": "हटाएं",
+    "delete_confirm": "क्या आप {topic} विषय का रखा गया संदेश हटाना चाहते हैं?",
+    "delete_fail": "संदेश हटाने में विफल: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/it.json
+++ b/rmqtt-dashboard/locales/it.json
@@ -299,7 +299,10 @@
     "error": "Richiesta fallita",
     "retry": "Riprova",
     "close": "Chiudi",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "Conferma",
+    "cancel": "Annulla",
+    "confirm_title": "Conferma"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "Nessun messaggio trattenuto",
     "create_time": "Creato il",
     "client_id": "ID cliente",
-    "publish_time": "Pubblicato il"
+    "publish_time": "Pubblicato il",
+    "delete": "Elimina",
+    "delete_confirm": "Eliminare il messaggio conservato per l'argomento {topic}?",
+    "delete_fail": "Eliminazione non riuscita: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/pt.json
+++ b/rmqtt-dashboard/locales/pt.json
@@ -299,7 +299,10 @@
     "error": "Falha na requisição",
     "retry": "Tentar novamente",
     "close": "Fechar",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "Confirmar",
+    "cancel": "Cancelar",
+    "confirm_title": "Confirmação"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "Sem mensagens retidas",
     "create_time": "Criado em",
     "client_id": "ID do cliente",
-    "publish_time": "Publicado em"
+    "publish_time": "Publicado em",
+    "delete": "Excluir",
+    "delete_confirm": "Excluir a mensagem retida para o tópico {topic}?",
+    "delete_fail": "Falha ao excluir: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/ru.json
+++ b/rmqtt-dashboard/locales/ru.json
@@ -299,7 +299,10 @@
     "error": "Ошибка запроса",
     "retry": "Повторить",
     "close": "Закрыть",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "Подтвердить",
+    "cancel": "Отмена",
+    "confirm_title": "Подтверждение"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "Нет retained-сообщений",
     "create_time": "Создано",
     "client_id": "ID клиента",
-    "publish_time": "Опубликовано"
+    "publish_time": "Опубликовано",
+    "delete": "Удалить",
+    "delete_confirm": "Удалить сохранённое сообщение для темы {topic}?",
+    "delete_fail": "Не удалось удалить: {msg}"
   }
 }

--- a/rmqtt-dashboard/locales/zh-CN.json
+++ b/rmqtt-dashboard/locales/zh-CN.json
@@ -299,7 +299,10 @@
     "error": "请求失败",
     "retry": "重试",
     "close": "关闭",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "确定",
+    "cancel": "取消",
+    "confirm_title": "确认操作"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "暂无保留消息",
     "create_time": "创建时间",
     "client_id": "客户端 ID",
-    "publish_time": "发布时间"
+    "publish_time": "发布时间",
+    "delete": "删除",
+    "delete_confirm": "确定删除主题 {topic} 的保留消息吗？",
+    "delete_fail": "删除失败：{msg}"
   }
 }

--- a/rmqtt-dashboard/locales/zh-TW.json
+++ b/rmqtt-dashboard/locales/zh-TW.json
@@ -299,7 +299,10 @@
     "error": "請求失敗",
     "retry": "重試",
     "close": "關閉",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "confirm": "確定",
+    "cancel": "取消",
+    "confirm_title": "確認操作"
   },
   "node_detail": {
     "cpu": "CPU",
@@ -345,6 +348,9 @@
     "no_results": "暫無保留訊息",
     "create_time": "建立時間",
     "client_id": "客戶端 ID",
-    "publish_time": "發佈時間"
+    "publish_time": "發佈時間",
+    "delete": "刪除",
+    "delete_confirm": "確定刪除主題 {topic} 的保留訊息嗎？",
+    "delete_fail": "刪除失敗：{msg}"
   }
 }

--- a/rmqtt-dashboard/pages/client-detail.js
+++ b/rmqtt-dashboard/pages/client-detail.js
@@ -239,7 +239,7 @@ window.ClientDetailPage = Vue.defineComponent({
     }
 
     async function kick() {
-      if (!confirm($t('clients.disconnect_confirm', { clientId: clientid }))) return;
+      if (!await window.$confirm($t('clients.disconnect_confirm', { clientId: clientid }))) return;
       try {
         await http.del('/clients/' + encodeURIComponent(clientid));
         refresh();
@@ -249,7 +249,7 @@ window.ClientDetailPage = Vue.defineComponent({
     }
 
     async function unsub(s) {
-      if (!confirm($t('subscriptions.unsub_confirm', { clientId: s.clientid, topic: s.topic }))) return;
+      if (!await window.$confirm($t('subscriptions.unsub_confirm', { clientId: s.clientid, topic: s.topic }))) return;
       try {
         await http.post('/mqtt/unsubscribe', { clientid: s.clientid, topic: s.topic });
         refresh();

--- a/rmqtt-dashboard/pages/clients.js
+++ b/rmqtt-dashboard/pages/clients.js
@@ -250,7 +250,7 @@ window.ClientsPage = Vue.defineComponent({
     }
 
     async function kick(clientid) {
-      if (!confirm($t('clients.disconnect_confirm', { clientId: clientid }))) return;
+      if (!await window.$confirm($t('clients.disconnect_confirm', { clientId: clientid }))) return;
       try {
         await http.del('/clients/' + encodeURIComponent(clientid));
         loadClients();

--- a/rmqtt-dashboard/pages/retains.js
+++ b/rmqtt-dashboard/pages/retains.js
@@ -40,7 +40,7 @@ window.RetainsPage = Vue.defineComponent({
 
       <!-- 列表 -->
       <div class="table-wrap" style="overflow-x:auto;">
-        <table style="min-width:800px;">
+        <table style="min-width:900px;">
           <thead>
             <tr>
               <th style="min-width:160px;">{{ $t('retains.topic') }}</th>
@@ -48,7 +48,7 @@ window.RetainsPage = Vue.defineComponent({
               <th style="width:50px;">QoS</th>
               <th style="width:90px;">{{ $t('retains.ttl') }}</th>
               <th style="width:140px;">{{ $t('retains.publish_time') }}</th>
-              <th style="width:70px;">{{ $t('retains.action') }}</th>
+              <th style="width:150px;text-align:center;">{{ $t('retains.action') }}</th>
             </tr>
           </thead>
           <tbody>
@@ -61,8 +61,12 @@ window.RetainsPage = Vue.defineComponent({
               </td>
               <td style="text-align:center;font-size:12px;">{{ formatTime(item.publish?.create_time) }}</td>
               <td>
-                <button class="btn-icon" style="width:auto;padding:3px 10px;font-size:11px;color:var(--accent);"
-                        @click.stop="showDetail(item)">&#128065; {{ $t('retains.view') }}</button>
+                <div style="display:inline-flex;gap:6px;">
+                  <button class="btn-icon" style="width:auto;padding:3px 10px;font-size:11px;color:var(--accent);"
+                          @click.stop="showDetail(item)">&#128065; {{ $t('retains.view') }}</button>
+                  <button class="btn-icon" style="width:auto;padding:3px 10px;font-size:11px;color:#e74c3c;"
+                          @click.stop="removeRetain(item)">&#128465; {{ $t('retains.delete') }}</button>
+                </div>
               </td>
             </tr>
             <tr v-if="!loading && items.length === 0">
@@ -218,6 +222,21 @@ window.RetainsPage = Vue.defineComponent({
       detail.value = item;
     }
 
+    // 删除保留消息：确认浮层 → DELETE /retains?topic=xxx → 刷新列表
+    async function removeRetain(item) {
+      if (!await window.$confirm($t('retains.delete_confirm', { topic: item.topic }))) return;
+      try {
+        await http.del('/retains?topic=' + encodeURIComponent(item.topic));
+        // 当前页仅剩 1 条且非首页 → 回退一页，避免空页
+        if (items.value.length === 1 && offset.value > 0) offset.value -= pageSize.value;
+        load();
+      } catch (e) {
+        alert($t('retains.delete_fail', { msg: e.message }));
+        // 404 说明消息已被删除（如其他端操作），刷新同步
+        if (e.message.indexOf('404') === 0) load();
+      }
+    }
+
     // 检测 retain 功能是否启用（请求 /features）
     async function checkFeature() {
       try {
@@ -243,7 +262,7 @@ window.RetainsPage = Vue.defineComponent({
     return {
       topicFilter, pageSize, offset, items, hasMore, loading, error, detail, featureDisabled,
       payloadPreview, payloadFull, formatTime, formatFrom, formatProperties,
-      load, search, prevPage, nextPage, reset, showDetail, $t,
+      load, search, prevPage, nextPage, reset, showDetail, removeRetain, $t,
     };
   },
 });

--- a/rmqtt-dashboard/pages/subscriptions.js
+++ b/rmqtt-dashboard/pages/subscriptions.js
@@ -106,15 +106,19 @@ window.SubscriptionsPage = Vue.defineComponent({
     }
 
     async function unsub(s) {
-      if (!confirm($t('subscriptions.unsub_confirm', { clientId: s.clientid, topic: s.topic }))) return;
+      if (!await window.$confirm($t('subscriptions.unsub_confirm', { clientId: s.clientid, topic: s.topic }))) return;
+      // 先立即从本地列表移除该行，获得即时反馈（不等网络请求）
+      subs.value = subs.value.filter(function(x) {
+        return !(x.clientid === s.clientid && x.topic === s.topic);
+      });
       try {
         await http.post('/mqtt/unsubscribe', {
           clientid: s.clientid,
           topic: s.topic,
         });
-        loadSubs();
       } catch (e) {
         alert($t('subscriptions.unsubscribe_fail', { msg: e.message }));
+        loadSubs(); // 失败时重载列表：若后端未删，该行会重新出现
       }
     }
 

--- a/rmqtt-plugins/rmqtt-http-api/src/api.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/api.rs
@@ -33,7 +33,7 @@ use rmqtt::{
     stats::Stats,
     types::NodeId,
     types::{
-        ClientId, CodecPublish, From, HashMap, Id, NodeHealthStatus, Publish, QoS, SubsSearchParams,
+        ClientId, CodecPublish, From, HashMap, Id, NodeHealthStatus, Publish, QoS, Retain, SubsSearchParams,
         TopicFilter, TopicName, UserName,
     },
     utils::timestamp_millis,
@@ -123,7 +123,7 @@ fn route(
                 .push(Router::with_path("{clientid}").get(get_client_subscriptions)),
         )
         .push(Router::with_path("routes").get(get_routes).push(Router::with_path("{topic}").get(get_route)))
-        .push(Router::with_path("retains").get(get_retains))
+        .push(Router::with_path("retains").get(get_retains).delete(delete_retain))
         .push(
             Router::with_path("mqtt")
                 .push(Router::with_path("publish").post(publish))
@@ -362,6 +362,12 @@ async fn list_apis(res: &mut Response) {
             "method": "GET",
             "path": "/api/v1/retains",
             "descr": "Query retained messages with optional topic_filter/offset/limit"
+        },
+        {
+            "name": "delete_retain",
+            "method": "DELETE",
+            "path": "/api/v1/retains?topic={topic}",
+            "descr": "Delete a retained message by exact topic (cluster-wide)"
         },
 
         {
@@ -1548,6 +1554,104 @@ async fn get_retains(
     };
 
     res.render(Json(json!({"items": items, "has_more": has_more})));
+    Ok(())
+}
+
+/// Delete a retained message by exact topic.
+///
+/// Query parameters:
+/// - `topic`: concrete topic name (wildcards `#` / `+` are NOT allowed).
+///
+/// Deletion follows the MQTT convention: publishing an empty-payload retained
+/// message on the topic clears it from storage via `RetainStorage::set`.
+/// The deletion is then propagated to all cluster peers through
+/// `retain_set_broadcast`, so every node removes its local copy.
+///
+/// Responses:
+/// - `200`: deleted successfully.
+/// - `400`: missing or wildcard topic.
+/// - `404`: no retained message exists for the topic.
+/// - `503`: retain storage unavailable.
+#[handler]
+async fn delete_retain(
+    req: &mut Request,
+    depot: &mut Depot,
+    res: &mut Response,
+) -> std::result::Result<(), salvo::Error> {
+    let (scx, cfg) = get_scx_cfg(depot)?;
+    let http_laddr = cfg.read().await.http_laddr;
+
+    let topic = match req.query::<String>("topic") {
+        Some(t) if !t.trim().is_empty() => TopicName::from(t.trim()),
+        _ => {
+            res.render(StatusError::bad_request().detail("topic is required"));
+            return Ok(());
+        }
+    };
+
+    // Deletion requires a concrete topic; wildcards are not supported.
+    let topic_str = topic.to_string();
+    if topic_str.contains('#') || topic_str.contains('+') {
+        res.render(
+            StatusError::bad_request()
+                .detail("topic must be a concrete topic, wildcards '#' and '+' are not allowed"),
+        );
+        return Ok(());
+    }
+
+    let retain_mgr = scx.extends.retain().await;
+    if !retain_mgr.enable() {
+        res.render(StatusError::service_unavailable().detail("retain storage is not enabled"));
+        return Ok(());
+    }
+
+    // Return 404 when no retained message exists for the exact topic.
+    match retain_mgr.get(&topic).await {
+        Ok(list) => {
+            if !list.iter().any(|(t, _)| t == &topic) {
+                res.render(
+                    StatusError::not_found().detail(format!("retain message not found for topic: {topic}")),
+                );
+                return Ok(());
+            }
+        }
+        Err(e) => {
+            res.render(StatusError::service_unavailable().detail(e.to_string()));
+            return Ok(());
+        }
+    }
+
+    // Empty-payload retained publish clears the retain store (MQTT semantics).
+    let from = From::from_admin(Id::new(
+        scx.node.id(),
+        http_laddr.port(),
+        Some(http_laddr),
+        None,
+        ClientId::default(),
+        Some(UserName::from("admin")),
+    ));
+    let p = CodecPublish {
+        dup: false,
+        retain: true,
+        qos: QoS::AtMostOnce,
+        topic: topic.clone(),
+        packet_id: None,
+        payload: bytes::Bytes::new(),
+        properties: Some(PublishProperties::default()),
+    };
+    let retain = Retain { msg_id: None, from, publish: <CodecPublish as Into<Publish>>::into(p) };
+
+    if let Err(e) = retain_mgr.set(&topic, retain.clone(), None).await {
+        res.render(StatusError::service_unavailable().detail(e.to_string()));
+        return Ok(());
+    }
+
+    // Propagate the deletion to cluster peers so their local stores stay in sync.
+    if let Err(e) = scx.extends.shared().await.retain_set_broadcast(&topic, &retain, None).await {
+        log::warn!("retain delete broadcast to cluster peers failed, {e}");
+    }
+
+    res.render(Text::Plain("ok"));
     Ok(())
 }
 


### PR DESCRIPTION
**Summary**
Add ability to delete individual retained messages from the Dashboard and HTTP API, with user confirmation and optimistic UI updates.

**Dashboard Retains Page**
- Add "Delete" button next to each retained message (red trash icon)
- Show confirmation dialog before deletion
- Optimistic UI: remove item from list immediately on delete attempt
- Pagination awareness: if only 1 item on page and not first page, go back one page
- Handle 404 response (message already deleted elsewhere) by reloading list

**HTTP API Backend**
- Add `DELETE /api/v1/retains?topic={topic}` endpoint
- Rejects wildcard topics (`#` and `+` are not allowed)
- Returns 404 if no retained message exists for the topic
- Uses MQTT empty-payload retained publish semantics to clear storage
- Propagates deletion to all cluster peers via `retain_set_broadcast`

**Confirm Dialog Component**
- Add `confirm.js` component with Promise-based API (`window.$confirm()`)
- Replace all native `confirm()` calls with custom confirm dialog
- Provides consistent UI with i18n support
- Applied to: clients kick, subscriptions unsubscribe, retains delete

**i18n Updates**
- Add `common.confirm`, `common.cancel`, `common.confirm_title`
- Add `retains.delete`, `retains.delete_confirm`, `retains.delete_fail`
- Update all 11 language files

**Component Version Bumps**
- i18n: v13 → v14
- clients: v11 → v12
- client-detail: v2 → v3
- subscriptions: v6 → v11
- retains: v4 → v5

**Benefits**
- Users can now clean up retained messages directly from Dashboard
- Consistent confirmation dialog across all destructive actions
- Optimistic UI updates improve perceived performance
- Cluster-wide retention deletion keeps all nodes in sync