### PR TITLE
fix(session): isolate inflight packet-id space to prevent PUBREL resume overwrite

### DIFF
--- a/rmqtt-test/README-CN.md
+++ b/rmqtt-test/README-CN.md
@@ -11,8 +11,9 @@ RMQTT 的工业级验证与压测核心引擎（Test Harness + Chaos + Benchmark
 
 - **自研 MQTT 客户端** — 零第三方 MQTT 依赖，完整实现 MQTT 3.1 / 3.1.1 / 5.0 协议栈
 - **Broker 生命周期管理** — 自动启动/停止/重启 rmqttd 进程，TCP 健康检查
-- **五类测试套件** — functional_v3 / functional_v311 / functional_v5 / stress / chaos
+- **六类测试套件** — functional_v3 / functional_v311 / functional_v5 / functional_v5_cluster / stress / chaos
 - **QoS 全覆盖** — QoS 0 / QoS 1 / QoS 2（含完整四步握手）正确性验证
+- **并发缺陷复现** — QoS 2 会话恢复时 PUBREL 重发与存储消息的 packet-id 冲突（单元级 + 集群端到端）
 - **混沌注入** — Broker 重启、连接风暴、慢消费者、丢包模拟
 - **多格式报告** — Console + JSON + HTML
 - **DAG 调度** — 测试用例依赖关系拓扑排序，超时与重试机制
@@ -91,15 +92,38 @@ cargo build -p rmqtt-test --release
 | `wildcard_plus` | 单层通配符 `+` 匹配 |
 | `wildcard_hash` | 多层通配符 `#` 匹配 |
 
-### functional_v5（5 个用例）— MQTT 5.0
+### functional_v5（34 个用例）— MQTT 5.0
 
 | 用例 | 说明 |
 |------|------|
-| `connect_v5` | MQTT 5.0 连接与断开 |
-| `connect_v5_reason_codes` | V5 连接 Reason Code 验证 |
-| `pubsub_v5_qos0` | MQTT 5.0 QoS 0 发布/订阅 |
-| `pubsub_v5_qos1` | MQTT 5.0 QoS 1 发布/订阅 |
-| `pubsub_v5_qos2` | MQTT 5.0 QoS 2 发布/订阅 |
+| `connect_v5` / `connect_v5_reason_codes` | MQTT 5.0 连接与 Reason Code 验证 |
+| `pubsub_v5_qos0/1/2` | MQTT 5.0 QoS 0/1/2 发布/订阅 |
+| `session_expiry_v5` / `session_takeover_v5` / `session_clean_start_v5` | 会话过期 / 接管 / Clean Start |
+| `qos2_replayed_publish_dedup` | [MQTT-4.3.3-10] 重放 QoS 2 PUBLISH 去重（issue #456） |
+| `qos2_pubrel_resend_on_resume` | [MQTT-4.4.0-1] 会话恢复时重发欠的 PUBREL（issue #456） |
+| `qos2_pubrel_resume_collision` | **PUBREL 重发与并发 deliver 的 packet-id 冲突（单机版回归测试）** |
+| `flow_control_v5` / `no_local_v5` / `will_delay_v5` | 流控 / 本地不转发 / Will 延迟 |
+| `retain_handling_*_v5` / `shared_sub_v5` / `topic_alias_v5` 等 | V5 特性覆盖（详见 `src/tests/functional/`） |
+
+### functional_v5_cluster（1 个用例）— 双节点集群端到端复现
+
+| 用例 | 说明 |
+|------|------|
+| `qos2_pubrel_resume_collision_cluster` | 集群路径端到端复现 packet-id 冲突：远端投递不标记存储 → 会话跨节点恢复时存储消息与 PUBREL 重发抢 id |
+
+该套件**需要手动启动双节点**（默认全量运行不会包含它，避免污染单机测试）：
+
+```bash
+# 终端 1 / 终端 2：启动两个节点
+./target/release/rmqttd -f rmqtt-test/configs/pubrel-collision-cluster/node1/rmqtt.toml
+./target/release/rmqttd -f rmqtt-test/configs/pubrel-collision-cluster/node2/rmqtt.toml
+
+# 终端 3：运行集群复现套件
+./target/release/mqtt_harness --no-broker --addr 127.0.0.1:1884 --suites functional_v5_cluster --workers 1
+```
+
+> 该测试修复前 3/3 轮复现 BUG（重复 PUBREL）；修复后 3/3 轮 PASS。修复方案详见
+> [`designs/pubrel-resume-inflight-id-collision.md`](../designs/pubrel-resume-inflight-id-collision.md)。
 
 ### stress（3 个用例）
 
@@ -134,7 +158,12 @@ rmqtt-test/
     transport/                   # 网络传输层
     framework/                   # 测试框架（TestCase, DAG 调度器, 上下文）
     tests/                       # 测试用例（功能测试、压测、混沌测试）
+      functional/                #   functional_v3/v311/v5 用例
+      functional/qos2_pubrel_resume_collision_cluster.rs  # 集群复现用例
     report/                      # 报告系统（控制台、JSON、HTML、详细日志）
+  configs/                       # 测试用 broker 配置
+    pubrel-collision/            #   单机：启用 message-storage 的 broker 配置
+    pubrel-collision-cluster/    #   集群：node1/node2 双节点配置（1884/1885 MQTT、5364/5365 gRPC）
 ```
 
 ## 📄 许可证

--- a/rmqtt-test/README.md
+++ b/rmqtt-test/README.md
@@ -13,8 +13,9 @@ The build artifact `mqtt_harness` is a standalone executable that provides funct
 
 - **Custom MQTT Client** — Zero third-party MQTT dependency, complete MQTT 3.1 / 3.1.1 / 5.0 protocol stack
 - **Broker Lifecycle Management** — Auto start/stop/restart `rmqttd` process with TCP health checks
-- **Five Test Suites** — `functional_v3` / `functional_v311` / `functional_v5` / `stress` / `chaos`
+- **Six Test Suites** — `functional_v3` / `functional_v311` / `functional_v5` / `functional_v5_cluster` / `stress` / `chaos`
 - **Full QoS Coverage** — QoS 0 / QoS 1 / QoS 2 (including full 4-step handshake) correctness verification
+- **Concurrency Bug Reproduction** — QoS 2 PUBREL-resume packet-id collision (unit-level + cluster end-to-end)
 - **Chaos Injection** — Broker restart, connection storms, slow consumers, packet loss simulation
 - **Multi-Format Reports** — Console + JSON + HTML
 - **DAG Scheduling** — Topological sort of test case dependencies with timeout and retry
@@ -93,15 +94,38 @@ The program will auto-locate `target/release/rmqttd` and start the broker.
 | `wildcard_plus` | Single-level wildcard `+` matching |
 | `wildcard_hash` | Multi-level wildcard `#` matching |
 
-### `functional_v5` (5 cases) — MQTT 5.0
+### `functional_v5` (34 cases) — MQTT 5.0
 
 | Case | Description |
 |------|-------------|
-| `connect_v5` | MQTT 5.0 connect/disconnect |
-| `connect_v5_reason_codes` | V5 Reason Code verification |
-| `pubsub_v5_qos0` | Qos 0 publish/subscribe |
-| `pubsub_v5_qos1` | QoS 1 publish/subscribe |
-| `pubsub_v5_qos2` | QoS 2 publish/subscribe |
+| `connect_v5` / `connect_v5_reason_codes` | MQTT 5.0 connect / Reason Code verification |
+| `pubsub_v5_qos0/1/2` | MQTT 5.0 QoS 0/1/2 publish/subscribe |
+| `session_expiry_v5` / `session_takeover_v5` / `session_clean_start_v5` | Session expiry / takeover / Clean Start |
+| `qos2_replayed_publish_dedup` | [MQTT-4.3.3-10] replayed QoS 2 PUBLISH dedup (issue #456) |
+| `qos2_pubrel_resend_on_resume` | [MQTT-4.4.0-1] owed PUBREL resent on session resume (issue #456) |
+| `qos2_pubrel_resume_collision` | **PUBREL-resume packet-id collision (single-node regression test)** |
+| `flow_control_v5` / `no_local_v5` / `will_delay_v5` / `shared_sub_v5` / `topic_alias_v5` etc. | V5 feature coverage (see `src/tests/functional/`) |
+
+### `functional_v5_cluster` (1 case) — two-node cluster end-to-end reproduction
+
+| Case | Description |
+|------|-------------|
+| `qos2_pubrel_resume_collision_cluster` | Cluster-path end-to-end reproduction of the packet-id collision: remote delivery is not `mark_forwarded` on the receiving node, so a stored message loaded during cross-node session resume races with owed PUBREL re-sends |
+
+This suite **requires two manually started nodes** and is never included in the default full run (so it cannot break the single-node suites):
+
+```bash
+# terminal 1 / terminal 2: start both nodes
+./target/release/rmqttd -f rmqtt-test/configs/pubrel-collision-cluster/node1/rmqtt.toml
+./target/release/rmqttd -f rmqtt-test/configs/pubrel-collision-cluster/node2/rmqtt.toml
+
+# terminal 3: run the cluster reproduction suite
+./target/release/mqtt_harness --no-broker --addr 127.0.0.1:1884 --suites functional_v5_cluster --workers 1
+```
+
+> Before the fix this test reproduced the BUG in 3/3 rounds (duplicate PUBREL);
+> after the fix it PASSES in 3/3 rounds. Fix design: see
+> [`designs/pubrel-resume-inflight-id-collision.md`](../designs/pubrel-resume-inflight-id-collision.md).
 
 ### `stress` (3 cases)
 
@@ -136,7 +160,12 @@ rmqtt-test/
     transport/                   # Network transport layer
     framework/                   # Test framework (TestCase, DAG scheduler, context)
     tests/                       # Test cases (functional, stress, chaos)
+      functional/                #   functional_v3/v311/v5 cases
+      functional/qos2_pubrel_resume_collision_cluster.rs  # cluster reproduction case
     report/                      # Report system (console, JSON, HTML, detail log)
+  configs/                       # Test broker configs
+    pubrel-collision/            #   single node: message-storage enabled broker config
+    pubrel-collision-cluster/    #   cluster: node1/node2 configs (1884/1885 MQTT, 5364/5365 gRPC)
 ```
 
 ## 📄 License

--- a/rmqtt-test/configs/pubrel-collision-cluster/node1/plugins/rmqtt-cluster-broadcast.toml
+++ b/rmqtt-test/configs/pubrel-collision-cluster/node1/plugins/rmqtt-cluster-broadcast.toml
@@ -1,0 +1,9 @@
+##--------------------------------------------------------------------
+## rmqtt-cluster-broadcast (node 1)
+##--------------------------------------------------------------------
+message_type = 98
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365"]
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/rmqtt-test/configs/pubrel-collision-cluster/node1/plugins/rmqtt-message-storage.toml
+++ b/rmqtt-test/configs/pubrel-collision-cluster/node1/plugins/rmqtt-message-storage.toml
@@ -1,0 +1,37 @@
+##--------------------------------------------------------------------
+## rmqtt-message-storage
+##--------------------------------------------------------------------
+
+##ram, redis, redis-cluster
+storage.type = "ram"
+
+##ram
+storage.ram.cache_capacity = "3G"
+storage.ram.cache_max_count = 1_000_000
+storage.ram.encode = false
+
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "message-{node}"
+
+##redis-cluster
+storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
+storage.redis-cluster.prefix = "message-{node}"
+
+##Quantity of expired messages cleared during each cleanup cycle.
+cleanup_count = 5000
+
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
+
+##─── Circuit breaker ────────────────────────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##The per-operation timeout uses `backend_timeout` above.

--- a/rmqtt-test/configs/pubrel-collision-cluster/node1/rmqtt.toml
+++ b/rmqtt-test/configs/pubrel-collision-cluster/node1/rmqtt.toml
@@ -1,0 +1,60 @@
+##--------------------------------------------------------------------
+## rmqttd node 1 — pubrel-collision cluster reproduction (node 1/2)
+## See designs/pubrel-resume-inflight-id-collision.md
+##--------------------------------------------------------------------
+node.id = 1
+
+##--------------------------------------------------------------------
+## RPC
+##--------------------------------------------------------------------
+rpc.server_addr = "0.0.0.0:5364"
+rpc.server_workers = 4
+rpc.batch_size = 128
+rpc.client_concurrency_limit = 128
+rpc.client_timeout = "5s"
+
+##--------------------------------------------------------------------
+## Log
+##--------------------------------------------------------------------
+log.to = "console"
+log.level = "info"
+log.dir = "."
+log.file = "rmqtt_1.log"
+
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+plugins.dir = "./rmqtt-test/configs/pubrel-collision-cluster/node1/plugins"
+plugins.default_startups = [
+    "rmqtt-cluster-broadcast",
+    "rmqtt-message-storage",
+    "rmqtt-retainer",
+    "rmqtt-shared-subscription",
+]
+plugins.disabled_default_startups = ["rmqtt-acl", "rmqtt-counter", "rmqtt-http-api"]
+
+##--------------------------------------------------------------------
+## MQTT listener
+##--------------------------------------------------------------------
+listener.tcp.external.addr = "0.0.0.0:1884"
+listener.tcp.external.workers = 8
+listener.tcp.external.max_connections = 102400
+listener.tcp.external.max_handshaking_limit = 500
+listener.tcp.external.handshake_timeout = "30s"
+listener.tcp.external.max_packet_size = "1m"
+listener.tcp.external.backlog = 1024
+listener.tcp.external.allow_anonymous = true
+listener.tcp.external.min_keepalive = 0
+listener.tcp.external.keepalive_backoff = 0.75
+listener.tcp.external.max_inflight = 16
+listener.tcp.external.max_mqueue_len = 1000
+listener.tcp.external.mqueue_rate_limit = "1000,1s"
+listener.tcp.external.max_clientid_len = 65535
+listener.tcp.external.max_qos_allowed = 2
+listener.tcp.external.max_topic_levels = 0
+listener.tcp.external.retain_available = false
+listener.tcp.external.session_expiry_interval = "5m"
+listener.tcp.external.message_retry_interval = "5s"
+listener.tcp.external.message_expiry_interval = "5m"
+listener.tcp.external.max_subscriptions = 0
+listener.tcp.external.shared_subscription = true

--- a/rmqtt-test/configs/pubrel-collision-cluster/node2/plugins/rmqtt-cluster-broadcast.toml
+++ b/rmqtt-test/configs/pubrel-collision-cluster/node2/plugins/rmqtt-cluster-broadcast.toml
@@ -1,0 +1,9 @@
+##--------------------------------------------------------------------
+## rmqtt-cluster-broadcast (node 2)
+##--------------------------------------------------------------------
+message_type = 98
+node_grpc_addrs = ["1@127.0.0.1:5364", "2@127.0.0.1:5365"]
+node_grpc_circuit_breaker_enabled = true
+node_grpc_circuit_failure_threshold = 10
+node_grpc_circuit_reset_timeout = "15s"
+node_grpc_circuit_half_open_success_threshold = 3

--- a/rmqtt-test/configs/pubrel-collision-cluster/node2/plugins/rmqtt-message-storage.toml
+++ b/rmqtt-test/configs/pubrel-collision-cluster/node2/plugins/rmqtt-message-storage.toml
@@ -1,0 +1,37 @@
+##--------------------------------------------------------------------
+## rmqtt-message-storage
+##--------------------------------------------------------------------
+
+##ram, redis, redis-cluster
+storage.type = "ram"
+
+##ram
+storage.ram.cache_capacity = "3G"
+storage.ram.cache_max_count = 1_000_000
+storage.ram.encode = false
+
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "message-{node}"
+
+##redis-cluster
+storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
+storage.redis-cluster.prefix = "message-{node}"
+
+##Quantity of expired messages cleared during each cleanup cycle.
+cleanup_count = 5000
+
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
+
+##─── Circuit breaker ────────────────────────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##The per-operation timeout uses `backend_timeout` above.

--- a/rmqtt-test/configs/pubrel-collision-cluster/node2/rmqtt.toml
+++ b/rmqtt-test/configs/pubrel-collision-cluster/node2/rmqtt.toml
@@ -1,0 +1,67 @@
+##--------------------------------------------------------------------
+## rmqttd node 2 — pubrel-collision cluster reproduction (node 1/2)
+## See designs/pubrel-resume-inflight-id-collision.md
+##--------------------------------------------------------------------
+node.id = 2
+
+##--------------------------------------------------------------------
+## RPC
+##--------------------------------------------------------------------
+rpc.server_addr = "0.0.0.0:5365"
+rpc.server_workers = 4
+rpc.batch_size = 128
+rpc.client_concurrency_limit = 128
+rpc.client_timeout = "5s"
+
+##--------------------------------------------------------------------
+## Log
+##--------------------------------------------------------------------
+log.to = "console"
+log.level = "info"
+log.dir = "."
+log.file = "rmqtt_2.log"
+
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+plugins.dir = "./rmqtt-test/configs/pubrel-collision-cluster/node2/plugins"
+plugins.default_startups = [
+    "rmqtt-cluster-broadcast",
+    "rmqtt-message-storage",
+    "rmqtt-retainer",
+    "rmqtt-shared-subscription",
+]
+plugins.disabled_default_startups = ["rmqtt-acl", "rmqtt-counter", "rmqtt-http-api"]
+
+##--------------------------------------------------------------------
+## MQTT listener
+##--------------------------------------------------------------------
+listener.tcp.external.addr = "0.0.0.0:1885"
+listener.tcp.external.workers = 8
+listener.tcp.external.max_connections = 102400
+listener.tcp.external.max_handshaking_limit = 500
+listener.tcp.external.handshake_timeout = "30s"
+listener.tcp.external.max_packet_size = "1m"
+listener.tcp.external.backlog = 1024
+listener.tcp.external.allow_anonymous = true
+listener.tcp.external.min_keepalive = 0
+listener.tcp.external.keepalive_backoff = 0.75
+listener.tcp.external.max_inflight = 16
+listener.tcp.external.max_mqueue_len = 1000
+listener.tcp.external.mqueue_rate_limit = "1000,1s"
+listener.tcp.external.max_clientid_len = 65535
+listener.tcp.external.max_qos_allowed = 2
+listener.tcp.external.max_topic_levels = 0
+listener.tcp.external.retain_available = false
+listener.tcp.external.session_expiry_interval = "5m"
+listener.tcp.external.message_retry_interval = "5s"
+listener.tcp.external.message_expiry_interval = "5m"
+listener.tcp.external.max_subscriptions = 0
+listener.tcp.external.shared_subscription = true
+
+## Disable default listeners that collide with node 1 on the same host.
+listener.tcp.internal.enable = false
+listener.tls.external.enable = false
+listener.ws.external.enable = false
+listener.wss.external.enable = false
+listener.quic.external.enable = false

--- a/rmqtt-test/configs/pubrel-collision/rmqtt.toml
+++ b/rmqtt-test/configs/pubrel-collision/rmqtt.toml
@@ -1,0 +1,58 @@
+##--------------------------------------------------------------------
+## rmqttd config for the pubrel-collision reproduction test
+## (designs/pubrel-resume-inflight-id-collision.md)
+##
+## Usage (run from the rmqtt repository root so that `plugins.dir`
+## resolves correctly):
+##   target/release/mqtt_harness \
+##     --binary target/release/rmqttd \
+##     --config rmqtt-test/configs/pubrel-collision/rmqtt.toml \
+##     --workspace . \
+##     --suites functional_v5 \
+##     --workers 1
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+## Task
+##--------------------------------------------------------------------
+task.exec_workers = 2000
+task.exec_queue_max = 300_000
+
+##--------------------------------------------------------------------
+## Node
+##--------------------------------------------------------------------
+node.id = 1
+node.busy.check_enable = false
+node.busy.update_interval = "2s"
+node.busy.loadavg = 80.0
+node.busy.cpuloadavg = 90.0
+node.busy.handshaking = 0
+
+##--------------------------------------------------------------------
+## Log
+##--------------------------------------------------------------------
+log.to = "console"
+log.level = "info"
+log.dir = "."
+log.file = "rmqtt.log"
+
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+plugins.dir = "rmqtt-plugins/"
+# Only the message-storage plugin is required for the reproduction.
+plugins.default_startups = [
+    "rmqtt-message-storage",
+]
+plugins.disabled_default_startups = []
+
+##--------------------------------------------------------------------
+## Listener
+##--------------------------------------------------------------------
+listener.tcp.external.addr = "127.0.0.1:1883"
+listener.tcp.external.workers = 8
+listener.tcp.external.max_connections = 1024000
+listener.tcp.external.max_handshaking_limit = 500
+listener.tcp.external.handshake_timeout = "30s"
+listener.tcp.external.max_packet_size = "1MB"
+listener.tcp.external.backlog = 1024

--- a/rmqtt-test/src/broker/lifecycle.rs
+++ b/rmqtt-test/src/broker/lifecycle.rs
@@ -80,7 +80,8 @@ impl BrokerProcess {
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::piped());
 
         if let Some(ref config) = self.config_path {
-            cmd.arg("-c").arg(config);
+            // rmqttd accepts `-f`/`--config` (config filename); `-c` is rejected.
+            cmd.arg("-f").arg(config);
         }
 
         let child = cmd.spawn()?;

--- a/rmqtt-test/src/framework/context.rs
+++ b/rmqtt-test/src/framework/context.rs
@@ -118,6 +118,15 @@ impl TestContext {
         self.metrics.lock().errors += 1;
     }
 
+    /// Whether this context manages a broker process.
+    ///
+    /// Returns `false` in `--no-broker` mode (external broker), in which case
+    /// tests that depend on broker lifecycle management (restart/kill) should
+    /// be skipped rather than failed.
+    pub fn has_broker(&self) -> bool {
+        self.broker.is_some()
+    }
+
     /// Restart the broker (for chaos testing) - synchronous
     pub fn restart_broker(&self) -> Result<(), anyhow::Error> {
         if let Some(ref broker) = self.broker {

--- a/rmqtt-test/src/framework/testcase.rs
+++ b/rmqtt-test/src/framework/testcase.rs
@@ -59,6 +59,16 @@ impl TestResult {
         }
     }
 
+    pub fn skipped(name: &str, suite: &str, duration: Duration, reason: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            suite: suite.to_string(),
+            verdict: TestVerdict::Skipped(reason.to_string()),
+            duration,
+            retries: 0,
+        }
+    }
+
     pub fn error(name: &str, suite: &str, duration: Duration, msg: String) -> Self {
         Self {
             name: name.to_string(),

--- a/rmqtt-test/src/main.rs
+++ b/rmqtt-test/src/main.rs
@@ -199,6 +199,14 @@ fn build_suites(opt: &Opt) -> Vec<TestSuite> {
         suites.push(build_functional_v5_suite());
     }
 
+    // functional_v5_cluster requires a manually started two-node cluster
+    // (see rmqtt-test/configs/pubrel-collision-cluster/). It is only run when
+    // explicitly requested — never as part of the default full run, so it
+    // cannot break the single-node suites.
+    if opt.suites.iter().any(|s| s == "functional_v5_cluster") {
+        suites.push(build_functional_v5_cluster_suite());
+    }
+
     if should_run("stress") {
         suites.push(build_stress_suite(opt.stress_clients));
     }
@@ -302,6 +310,7 @@ fn build_functional_v5_suite() -> TestSuite {
     use tests::functional::publication_expiry_v5::*;
     use tests::functional::pubsub_v5::*;
     use tests::functional::qos2_conformance::*;
+    use tests::functional::qos2_pubrel_resume_collision::*;
     use tests::functional::request_response_v5::*;
     use tests::functional::retain_handling_v5::*;
     use tests::functional::server_keepalive_v5::*;
@@ -355,6 +364,19 @@ fn build_functional_v5_suite() -> TestSuite {
     // QoS 2 exactly-once conformance (GitHub issue #456)
     suite.add(Qos2ReplayedPublishDedupTest);
     suite.add(Qos2PubrelResendOnResumeTest);
+    // PUBREL resume packet-id collision (designs/pubrel-resume-inflight-id-collision.md)
+    suite.add(Qos2PubrelResumeCollisionTest);
+    suite
+}
+
+/// Cluster-only reproduction suite (needs two manually started rmqttd nodes,
+/// see `rmqtt-test/configs/pubrel-collision-cluster/`):
+///   mqtt_harness --no-broker --addr 127.0.0.1:1884 --suites functional_v5_cluster
+fn build_functional_v5_cluster_suite() -> TestSuite {
+    use tests::functional::qos2_pubrel_resume_collision_cluster::*;
+
+    let mut suite = TestSuite::new("functional_v5_cluster");
+    suite.add(Qos2PubrelResumeCollisionClusterTest);
     suite
 }
 

--- a/rmqtt-test/src/tests/chaos/restart.rs
+++ b/rmqtt-test/src/tests/chaos/restart.rs
@@ -16,6 +16,16 @@ impl TestCase for BrokerRestartTest {
 
     fn execute(&self, ctx: &mut TestContext) -> TestResult {
         let start = Instant::now();
+        // Broker-restart chaos tests require this harness to manage the broker
+        // process; in `--no-broker` mode there is nothing to restart → skip.
+        if !ctx.has_broker() {
+            return TestResult::skipped(
+                self.name(),
+                "chaos",
+                start.elapsed(),
+                "no broker managed by this context (--no-broker mode)",
+            );
+        }
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let result = rt.block_on(async {
@@ -78,6 +88,16 @@ impl TestCase for BrokerRestartPubSubTest {
 
     fn execute(&self, ctx: &mut TestContext) -> TestResult {
         let start = Instant::now();
+        // Broker-restart chaos tests require this harness to manage the broker
+        // process; in `--no-broker` mode there is nothing to restart → skip.
+        if !ctx.has_broker() {
+            return TestResult::skipped(
+                self.name(),
+                "chaos",
+                start.elapsed(),
+                "no broker managed by this context (--no-broker mode)",
+            );
+        }
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let result = rt.block_on(async {

--- a/rmqtt-test/src/tests/functional/mod.rs
+++ b/rmqtt-test/src/tests/functional/mod.rs
@@ -22,6 +22,8 @@ pub mod pubsub_v311;
 pub mod pubsub_v5;
 pub mod qos2_conformance;
 pub mod qos2_conformance_v311;
+pub mod qos2_pubrel_resume_collision;
+pub mod qos2_pubrel_resume_collision_cluster;
 pub mod request_response_v5;
 pub mod retain_handling_v5;
 pub mod server_keepalive_v5;

--- a/rmqtt-test/src/tests/functional/qos2_pubrel_resume_collision.rs
+++ b/rmqtt-test/src/tests/functional/qos2_pubrel_resume_collision.rs
@@ -1,0 +1,202 @@
+//! QoS 2 PUBREL resume packet-id collision reproduction test
+//!
+//! Reproduces the concurrency bug analysed in
+//! `designs/pubrel-resume-inflight-id-collision.md`:
+//!
+//! On session resume (`Clean Start = 0`), `transfer_session_state` both
+//!   1. spawns `send_storaged_messages` (async) to load **stored** QoS messages, and
+//!   2. re-forwards the owed PUBREL for every incomplete QoS 2 exchange
+//!      (`send_rerelease`, which re-registers the message into `out_inflight`
+//!      under its **old** packet-id).
+//!
+//! The new session's packet-id allocator (`OutInflight::next_id`) restarts at 1,
+//! so a stored message delivered concurrently can be assigned the **same**
+//! packet-id as a transferred message. `OutInflight::push_back` is a
+//! `HashMap::insert` — the second registration **silently overwrites** the first,
+//! destroying the overwritten message's QoS 2 state.
+//!
+//! Observable symptom: the client receives **two PUBREL with the same packet id**
+//! (one from `send_rerelease`, one from the PUBREC-response path acting on the
+//! overwritten entry). A fixed broker (packet-id space isolation) never produces
+//! duplicate PUBRELs.
+//!
+//! # Reproduction window (timing-sensitive)
+//!
+//! A stored message is only re-loaded by `send_storaged_messages` if it was not
+//! yet `mark_forwarded`-ed. `mark_forwarded` is executed **asynchronously** by
+//! the message-storage workers (`route_msg` → worker queue), so if the client
+//! disconnects and **immediately** reconnects, some messages may still be seen
+//! as un-forwarded and be re-delivered — racing with the owed PUBREL re-sends.
+//! Larger message counts lengthen the worker backlog and widen the window.
+//!
+//! The test is a *probabilistic* reproduction: it reports FAILED (with evidence)
+//! when a duplicate PUBREL is observed, and PASSES when no round hits the window.
+//! Tune `UNCOMPLETE_COUNT` / `ROUNDS` to increase the hit rate.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::framework::context::TestContext;
+use crate::framework::testcase::{TestCase, TestResult};
+use crate::mqtt::common::QoS;
+use crate::mqtt::v5::MqttV5Client;
+
+/// Number of incomplete QoS 2 exchanges left in the session before resume.
+/// Larger values lengthen the async mark_forwarded backlog.
+const UNCOMPLETE_COUNT: usize = 8;
+
+/// Disconnect → reconnect latencies tried (ms). 0 = reconnect as fast as possible.
+const RECONNECT_LATENCIES_MS: &[u64] = &[0, 20, 50];
+
+/// Reproduction: duplicate PUBREL on session resume with concurrent stored-message delivery.
+pub struct Qos2PubrelResumeCollisionTest;
+
+impl TestCase for Qos2PubrelResumeCollisionTest {
+    fn name(&self) -> &str {
+        "qos2_pubrel_resume_collision"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let result = rt.block_on(async {
+            let uid = uuid::Uuid::new_v4().simple().to_string();
+            let pub_cid = format!("coll-pub-{uid}");
+
+            let mut reproductions = Vec::new();
+
+            for (round, latency_ms) in RECONNECT_LATENCIES_MS.iter().enumerate() {
+                let topic = format!("pubrel-collision/{uid}/r{round}");
+                let sub_cid = format!("coll-sub-{uid}-r{round}");
+
+                // ---- Phase 1: persistent session, leave N incomplete QoS 2 exchanges
+                let mut subscriber = MqttV5Client::connect_with_options(
+                    &ctx.config.broker_addr,
+                    &sub_cid,
+                    ctx.config.connect_timeout,
+                    true, // clean_start
+                    60,
+                    None,
+                    None,
+                    None,
+                    Some(300), // session_expiry_interval
+                    None,
+                    None,
+                )
+                .await?;
+                subscriber.subscribe(&topic, QoS::ExactlyOnce).await?;
+                // Never answer PUBREL → every QoS 2 exchange stays incomplete.
+                subscriber.set_auto_pubcomp(false);
+
+                let publisher =
+                    MqttV5Client::connect(&ctx.config.broker_addr, &pub_cid, ctx.config.connect_timeout)
+                        .await?;
+
+                let mut expected_rel_ids = Vec::new();
+                for i in 0..UNCOMPLETE_COUNT {
+                    let payload = format!("inflight-{round}-{i}");
+                    publisher
+                        .publish_with_properties(
+                            &topic,
+                            payload.as_bytes(),
+                            QoS::ExactlyOnce,
+                            false,
+                            None,
+                            Some(300), // message_expiry_interval → message-storage stores it
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .await?;
+
+                    // Subscriber receives PUBLISH (auto-replies PUBREC), then PUBREL.
+                    let msg = subscriber
+                        .recv_message_timeout(Duration::from_secs(5))
+                        .await
+                        .ok_or_else(|| anyhow::anyhow!("round {round}: no PUBLISH delivered"))?;
+                    if msg.payload.as_ref() != payload.as_bytes() {
+                        return Err(anyhow::anyhow!(
+                            "round {round}: unexpected payload {:?}",
+                            String::from_utf8_lossy(&msg.payload)
+                        ));
+                    }
+                    let rel_id = subscriber
+                        .recv_pubrel_timeout(Duration::from_secs(5))
+                        .await
+                        .ok_or_else(|| anyhow::anyhow!("round {round}: no PUBREL after PUBREC"))?;
+                    expected_rel_ids.push(rel_id);
+                }
+
+                // Leave the session with the incomplete exchanges, then reconnect
+                // quickly so the async mark_forwarded may not have landed yet.
+                let _ = subscriber.abort_connection().await;
+                let _ = publisher.disconnect().await;
+                tokio::time::sleep(Duration::from_millis(*latency_ms)).await;
+
+                // ---- Phase 2: resume (Clean Start = 0), collect all PUBRELs
+                let mut resumed = MqttV5Client::connect_with_options(
+                    &ctx.config.broker_addr,
+                    &sub_cid,
+                    ctx.config.connect_timeout,
+                    false, // clean_start = 0 → session resume
+                    60,
+                    None,
+                    None,
+                    None,
+                    Some(300),
+                    None,
+                    None,
+                )
+                .await?;
+
+                let mut rel_ids = Vec::new();
+                if let Some(first) = resumed.recv_pubrel_timeout(Duration::from_secs(5)).await {
+                    rel_ids.push(first);
+                    // Drain the rest until the channel is quiet.
+                    while let Some(id) = resumed.recv_pubrel_timeout(Duration::from_millis(600)).await {
+                        rel_ids.push(id);
+                    }
+                }
+                let _ = resumed.disconnect().await;
+
+                // ---- Assert: no packet-id may appear twice among the PUBRELs.
+                let mut counts: HashMap<u16, usize> = HashMap::new();
+                for id in &rel_ids {
+                    *counts.entry(*id).or_default() += 1;
+                }
+                let duplicates: Vec<(u16, usize)> =
+                    counts.iter().filter(|(_, c)| **c >= 2).map(|(id, c)| (*id, *c)).collect();
+
+                tracing::info!(
+                    "pubrel-collision round {round}: expected {expected_rel_ids:?}, got {rel_ids:?}, \
+                     duplicates: {duplicates:?}"
+                );
+
+                if !duplicates.is_empty() {
+                    reproductions.push((round, duplicates.clone()));
+                }
+            }
+
+            if !reproductions.is_empty() {
+                Err(anyhow::anyhow!(
+                    "BUG REPRODUCED: duplicate PUBREL packet-id(s) on session resume \
+                     (rounds: {reproductions:?}); stored-message registration was overwritten \
+                     by send_rerelease — see designs/pubrel-resume-inflight-id-collision.md"
+                ))
+            } else {
+                Ok(())
+            }
+        });
+
+        match result {
+            Ok(()) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Err(e) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(120)
+    }
+}

--- a/rmqtt-test/src/tests/functional/qos2_pubrel_resume_collision_cluster.rs
+++ b/rmqtt-test/src/tests/functional/qos2_pubrel_resume_collision_cluster.rs
@@ -1,0 +1,246 @@
+//! QoS 2 PUBREL resume packet-id collision — CLUSTER reproduction test
+//!
+//! Same bug as `qos2_pubrel_resume_collision`, but exercised through the
+//! cluster broadcast path, which is the realistic end-to-end trigger:
+//!
+//! A message published on node B and forwarded to a subscriber on node A is
+//! **stored on the publishing node (B)** and delivered on A without being
+//! `mark_forwarded`-ed on B (`shared.rs::forwards` only marks recipients that
+//! were matched on the publishing node itself, `from_node_id == node.id()`).
+//!
+//! So when the subscriber's persistent session (with incomplete QoS 2
+//! exchanges) resumes **on node B**, `send_storaged_messages` reloads the
+//! un-forwarded stored message and races with the owed PUBREL re-sends
+//! (`send_rerelease`) — both can be assigned the same packet-id and the
+//! stored message's registration is silently overwritten.
+//!
+//! Observable symptom: the client receives **two PUBREL with the same packet
+//! id** (one from `send_rerelease`, one from the PUBREC-response path acting
+//! on the overwritten entry).
+//!
+//! # Setup
+//!
+//! Requires two rmqttd nodes (see `rmqtt-test/configs/pubrel-collision-cluster/`):
+//! - node 1: 127.0.0.1:1884 (MQTT), 5364 (gRPC)
+//! - node 2: 127.0.0.1:1885 (MQTT), 5365 (gRPC)
+//!
+//! Run with the harness in `--no-broker` mode pointing at node 1:
+//!   mqtt_harness --no-broker --addr 127.0.0.1:1884 --suites functional_v5
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::framework::context::TestContext;
+use crate::framework::testcase::{TestCase, TestResult};
+use crate::mqtt::common::QoS;
+use crate::mqtt::v5::MqttV5Client;
+
+/// Node 2 MQTT address (hard-coded for the cluster reproduction setup).
+const NODE2_ADDR: &str = "127.0.0.1:1885";
+
+/// Number of incomplete QoS 2 exchanges left in the session before resume.
+/// Larger values lengthen the reforward loop (each entry awaits the expiry
+/// check hook), giving the async stored-message load more time to enqueue
+/// first — which is required for the packet-id collision.
+const UNCOMPLETE_COUNT: usize = 16;
+
+/// Number of stored messages published on node 2 while the subscriber is offline.
+/// Multiple messages load in parallel (one spawn per message batch), further
+/// widening the race window.
+const STORED_COUNT: usize = 2;
+
+/// Reproduction rounds.
+const ROUNDS: usize = 3;
+
+/// Cluster reproduction: duplicate PUBREL on cross-node session resume.
+pub struct Qos2PubrelResumeCollisionClusterTest;
+
+impl TestCase for Qos2PubrelResumeCollisionClusterTest {
+    fn name(&self) -> &str {
+        "qos2_pubrel_resume_collision_cluster"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let result = rt.block_on(async {
+            let uid = uuid::Uuid::new_v4().simple().to_string();
+            let mut reproductions = Vec::new();
+
+            for round in 0..ROUNDS {
+                let topic = format!("pubrel-collision-cluster/{uid}/r{round}");
+                let sub_cid = format!("cc-sub-{uid}-r{round}");
+                let pub_cid = format!("cc-pub-{uid}-r{round}");
+
+                // ---- Phase 1: subscriber session on NODE 1 with incomplete QoS 2 exchanges
+                let mut subscriber = MqttV5Client::connect_with_options(
+                    &ctx.config.broker_addr, // node 1
+                    &sub_cid,
+                    ctx.config.connect_timeout,
+                    true, // clean_start
+                    60,
+                    None,
+                    None,
+                    None,
+                    Some(300), // session_expiry_interval
+                    None,
+                    None,
+                )
+                .await?;
+                subscriber.subscribe(&topic, QoS::ExactlyOnce).await?;
+                subscriber.set_auto_pubcomp(false);
+
+                // Cross-node forward sanity check: publish on node 2, receive on node 1.
+                // Use QoS 0 so the probe does NOT consume a packet id (the transferred
+                // exchanges must start at id 1 for the collision to be observable).
+                let probe = MqttV5Client::connect(NODE2_ADDR, &pub_cid, ctx.config.connect_timeout).await?;
+                probe
+                    .publish_with_properties(
+                        &topic,
+                        b"probe",
+                        QoS::AtMostOnce,
+                        false,
+                        None,
+                        Some(300),
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                    .await?;
+                subscriber
+                    .recv_message_timeout(Duration::from_secs(5))
+                    .await
+                    .ok_or_else(|| anyhow::anyhow!("round {round}: cluster forward probe not received"))?;
+                let _ = probe.disconnect().await;
+
+                // Now leave N incomplete QoS 2 exchanges (publisher on node 1).
+                let publisher =
+                    MqttV5Client::connect(&ctx.config.broker_addr, &pub_cid, ctx.config.connect_timeout)
+                        .await?;
+                let mut expected_rel_ids = Vec::new();
+                for i in 0..UNCOMPLETE_COUNT {
+                    let payload = format!("inflight-{round}-{i}");
+                    publisher
+                        .publish_with_properties(
+                            &topic,
+                            payload.as_bytes(),
+                            QoS::ExactlyOnce,
+                            false,
+                            None,
+                            Some(300),
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .await?;
+                    let msg = subscriber
+                        .recv_message_timeout(Duration::from_secs(5))
+                        .await
+                        .ok_or_else(|| anyhow::anyhow!("round {round}: no PUBLISH delivered"))?;
+                    if msg.payload.as_ref() != payload.as_bytes() {
+                        return Err(anyhow::anyhow!(
+                            "round {round}: unexpected payload {:?}",
+                            String::from_utf8_lossy(&msg.payload)
+                        ));
+                    }
+                    let rel_id = subscriber
+                        .recv_pubrel_timeout(Duration::from_secs(5))
+                        .await
+                        .ok_or_else(|| anyhow::anyhow!("round {round}: no PUBREL after PUBREC"))?;
+                    expected_rel_ids.push(rel_id);
+                }
+                let _ = subscriber.abort_connection().await;
+                let _ = publisher.disconnect().await;
+                tokio::time::sleep(Duration::from_millis(500)).await;
+
+                // ---- Phase 2: publish stored messages on NODE 2 while the subscriber
+                // is offline. Stored on node 2, delivered on node 1 (offline), NOT
+                // mark_forwarded on node 2 (no local recipients).
+                let storer = MqttV5Client::connect(NODE2_ADDR, &pub_cid, ctx.config.connect_timeout).await?;
+                for i in 0..STORED_COUNT {
+                    storer
+                        .publish_with_properties(
+                            &topic,
+                            format!("stored-{round}-{i}").as_bytes(),
+                            QoS::ExactlyOnce,
+                            false,
+                            None,
+                            Some(300),
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .await?;
+                }
+                let _ = storer.disconnect().await;
+                tokio::time::sleep(Duration::from_millis(300)).await;
+
+                // ---- Phase 3: resume the session on NODE 2 (cross-node session
+                // migration) so that send_storaged_messages (node 2) reloads M1
+                // while send_rerelease re-sends the owed PUBRELs.
+                let mut resumed = MqttV5Client::connect_with_options(
+                    NODE2_ADDR,
+                    &sub_cid,
+                    ctx.config.connect_timeout,
+                    false, // clean_start = 0
+                    60,
+                    None,
+                    None,
+                    None,
+                    Some(300),
+                    None,
+                    None,
+                )
+                .await?;
+
+                let mut rel_ids = Vec::new();
+                if let Some(first) = resumed.recv_pubrel_timeout(Duration::from_secs(5)).await {
+                    rel_ids.push(first);
+                    // Drain the rest until the channel is quiet.
+                    while let Some(id) = resumed.recv_pubrel_timeout(Duration::from_millis(600)).await {
+                        rel_ids.push(id);
+                    }
+                }
+                let _ = resumed.disconnect().await;
+
+                let mut counts: HashMap<u16, usize> = HashMap::new();
+                for id in &rel_ids {
+                    *counts.entry(*id).or_default() += 1;
+                }
+                let duplicates: Vec<(u16, usize)> =
+                    counts.iter().filter(|(_, c)| **c >= 2).map(|(id, c)| (*id, *c)).collect();
+
+                tracing::info!(
+                    "pubrel-collision-cluster round {round}: expected {expected_rel_ids:?}, got {rel_ids:?}, \
+                     duplicates: {duplicates:?}"
+                );
+
+                if !duplicates.is_empty() {
+                    reproductions.push((round, duplicates.clone()));
+                }
+            }
+
+            if !reproductions.is_empty() {
+                Err(anyhow::anyhow!(
+                    "BUG REPRODUCED (cluster): duplicate PUBREL packet-id(s) on cross-node resume \
+                     (rounds: {reproductions:?}) — see designs/pubrel-resume-inflight-id-collision.md"
+                ))
+            } else {
+                Ok(())
+            }
+        });
+
+        match result {
+            Ok(()) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Err(e) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(120)
+    }
+}

--- a/rmqtt/src/inflight.rs
+++ b/rmqtt/src/inflight.rs
@@ -334,6 +334,17 @@ impl OutInflight {
         Err(anyhow!("no packet_id available, should unreachable!()"))
     }
 
+    /// Advance the packet-id allocator so that ids already reserved by
+    /// transferred inflight messages (kept under their old ids) are never
+    /// re-issued to concurrently delivered messages. `next_id` only checks
+    /// the current queue, so without this isolation a stored message
+    /// delivered during session resume can be assigned the same id as a
+    /// transferred message and `push_back` would silently overwrite it.
+    #[inline]
+    pub fn advance_next_id(&self, max_reserved: u16) {
+        self.next.fetch_max(max_reserved.saturating_add(1), Ordering::SeqCst);
+    }
+
     #[inline]
     pub fn to_inflight_messages(&mut self) -> Vec<OutInflightMessage> {
         let mut inflight_messages = Vec::new();
@@ -418,5 +429,112 @@ impl InInflight {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use bytestring::ByteString;
+
+    use crate::types::{CodecPublish, Id};
+
+    fn make_publish(topic: &str, packet_id: u16) -> Publish {
+        Publish {
+            inner: Box::new(CodecPublish {
+                dup: false,
+                retain: false,
+                qos: QoS::ExactlyOnce,
+                topic: ByteString::from(topic),
+                packet_id: NonZeroU16::new(packet_id),
+                properties: None,
+                payload: Bytes::from_static(b"payload"),
+            }),
+            target_clientid: None,
+            delay_interval: None,
+            create_time: None,
+        }
+    }
+
+    fn make_from(client: &str) -> From {
+        From::from_custom(Id::new(1, 1, None, None, ByteString::from(client), None))
+    }
+
+    fn make_msg(topic: &str, pid: u16, status: MomentStatus) -> OutInflightMessage {
+        OutInflightMessage::new(status, make_from(topic), make_publish(topic, pid))
+    }
+
+    /// Root cause 1: the packet-id allocator restarts at 1 and is not
+    /// isolated from the id space of transferred inflight messages
+    /// (which keep their old ids 1..N and are registered later by
+    /// `send_rerelease`). `next_id` only checks the current queue, so a
+    /// concurrently delivered stored message can be assigned the same id.
+    #[test]
+    fn next_id_restarts_at_one_and_collides_with_transfer_ids() {
+        let inflight = OutInflight::new(100, 0, 0);
+        // The transferred messages (old ids 1..=3) are still queued behind
+        // `SendRerelease`; the new session's queue is empty, so the allocator
+        // hands out id 1 again — the exact overlap that causes the collision.
+        assert_eq!(inflight.next_id().unwrap(), 1, "allocator is not isolated from the transferred id space");
+    }
+
+    /// Root cause 2: `push_back` silently overwrites an existing entry with
+    /// the same packet-id (`HashMap::insert`), returning the overwritten id.
+    /// A second registration therefore destroys the first message's QoS 2 state.
+    #[test]
+    fn push_back_same_packet_id_silently_overwrites() {
+        let mut inflight = OutInflight::new(100, 0, 0);
+        inflight.push_back(make_msg("stored/a", 1, MomentStatus::UnReceived));
+
+        // Second registration with the same id (send_rerelease path).
+        let old = inflight.push_back(make_msg("inflight/b", 1, MomentStatus::UnComplete));
+        assert_eq!(old.map(|id| id.get()), Some(1), "push_back reported the overwrite");
+
+        let cur = inflight.get(1).expect("packet 1 is still tracked");
+        assert_eq!(cur.publish.inner.topic, ByteString::from_static("inflight/b"));
+        assert_eq!(cur.status, MomentStatus::UnComplete);
+    }
+
+    /// Fix verification: after `advance_next_id`, new allocations skip the
+    /// transferred id range (1..=N), so a concurrently delivered stored
+    /// message can never collide with a transferred message's old id.
+    #[test]
+    fn advance_next_id_isolates_transfer_id_space() {
+        let inflight = OutInflight::new(100, 0, 0);
+        inflight.advance_next_id(5); // transferred messages keep ids 1..=5
+        assert_eq!(inflight.next_id().unwrap(), 6, "allocator must skip the transferred id range");
+    }
+
+    /// End-to-end mechanism reproduction: during session resume, a stored
+    /// message is first delivered (id 1), then `send_rerelease` registers a
+    /// transferred message under the same old id 1 and overwrites it. The
+    /// stored message's QoS 2 state is permanently lost — the PUBCOMP that
+    /// arrives later completes the *other* message and the stored one has no
+    /// record at all (no resend, no ack hook).
+    #[test]
+    fn resume_collision_loses_stored_message() {
+        let mut inflight = OutInflight::new(100, 0, 0);
+
+        // (1) stored message M1 delivered by send_storaged_messages: next_id=1
+        let pid = NonZeroU16::new(inflight.next_id().unwrap()).unwrap();
+        assert_eq!(pid.get(), 1);
+        inflight.push_back(make_msg("stored/M1", pid.get(), MomentStatus::UnReceived));
+
+        // (2) transferred message M2 (old id 1) registered by send_rerelease → overwrites M1
+        let old = inflight.push_back(make_msg("inflight/M2", pid.get(), MomentStatus::UnComplete));
+        assert_eq!(
+            old.map(|id| id.get()),
+            Some(1),
+            "send_rerelease overwrote the stored message (bug reproduced)"
+        );
+
+        // (3) M1's PUBREC/PUBCOMP removes M2 — M1 is left with no tracking at all
+        let removed = inflight.remove(&pid.get()).expect("something is tracked under id 1");
+        assert_eq!(removed.publish.inner.topic, ByteString::from_static("inflight/M2"));
+        assert!(
+            inflight.get(pid.get()).is_none(),
+            "M1's QoS 2 state is gone: no resend, no ack hook, message effectively lost"
+        );
     }
 }

--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -1397,6 +1397,24 @@ impl SessionState {
                 offline_info.offline_messages.len(),
                 clear_subscriptions
             );
+
+        // Transferred inflight messages keep their old packet-ids (1..N), while
+        // the new session's allocator restarts at 1. Without isolating the two
+        // id spaces, the async stored-message load (send_storaged_messages) or
+        // offline deliveries can be assigned the same ids, and send_rerelease's
+        // push_back would silently overwrite them, destroying their QoS 2 state.
+        // Advance the allocator past the transferred id range BEFORE any of the
+        // concurrent deliver paths can allocate (this must run before the
+        // send_storaged_messages spawns below).
+        let max_transfer_id = offline_info
+            .inflight_messages
+            .iter()
+            .filter_map(|m| m.publish.packet_id.map(|id| id.get()))
+            .max();
+        if let Some(max_id) = max_transfer_id {
+            self.out_inflight().write().await.advance_next_id(max_id);
+        }
+
         if !clear_subscriptions && !offline_info.subscriptions.is_empty() {
             for (tf, opts) in offline_info.subscriptions.iter() {
                 let id = self.id.clone();
@@ -1572,11 +1590,25 @@ impl SessionState {
         Io: AsyncRead + AsyncWrite + Unpin,
     {
         let packet_id = Self::packet_id(iflt_msg.publish.packet_id)?;
-        self.out_inflight().write().await.push_back(OutInflightMessage::new(
+
+        // Defensive check: with the allocator isolated (advance_next_id) this
+        // branch is unreachable on the resume path; if it ever fires it means a
+        // concurrent deliver allocated the same id and push_back below would
+        // silently overwrite an existing QoS 2 entry — make it visible instead.
+        let mut inflight = self.out_inflight().write().await;
+        if inflight.get(packet_id.get()).is_some() {
+            log::warn!(
+                "{:?} send_rerelease: packet_id {packet_id} already registered, overwriting; \
+                 possible id collision with concurrent deliver",
+                self.id
+            );
+        }
+        inflight.push_back(OutInflightMessage::new(
             MomentStatus::UnComplete,
             iflt_msg.from,
             iflt_msg.publish,
         ));
+        drop(inflight); // release the write lock before awaiting network I/O
 
         match sink {
             Sink::V3(s) => {


### PR DESCRIPTION
During QoS 2 session resume (Clean Start 0), send_rerelease re-registers transferred inflight messages under their OLD packet-ids (1..N), while the new session's OutInflight allocator restarts at 1. A stored message delivered concurrently by send_storaged_messages could be assigned the same id and then silently overwritten by push_back (HashMap::insert), permanently destroying the stored message's QoS 2 state (no resend, no ack hook, possible loss).

### Fix

- rmqtt/src/inflight.rs: add OutInflight::advance_next_id(max) — pushes the packet-id allocator past the transferred id range (fetch_max, forward-only)
- rmqtt/src/session.rs transfer_session_state: compute the max transferred packet-id and call advance_next_id BEFORE send_storaged_messages spawns, isolating the transferred id space from any concurrently allocated id
- rmqtt/src/session.rs send_rerelease: defensive existence check before push_back (logs a warning instead of silently overwriting), and release the inflight write lock before awaiting network I/O

### Tests

- Unit (rmqtt/src/inflight.rs #[cfg(test)]): 4 tests — 3 reproduce the mechanism (allocator restart, silent overwrite, message loss) + 1 verifies advance_next_id isolation
- Single-node regression qos2_pubrel_resume_collision (functional_v5)
- Cluster end-to-end qos2_pubrel_resume_collision_cluster (new functional_v5_cluster suite, two manually started nodes): reproduced the bug 3/3 rounds before the fix (duplicate PUBREL), passes 3/3 after (stored messages allocated outside the transferred id range)

### Harness improvements

- rmqtt-test/src/broker/lifecycle.rs: pass -f instead of -c to rmqttd (the broker accepts -f/--config)
- rmqtt-test/src/framework: add TestResult::skipped and TestContext::has_broker; chaos broker-restart tests now SKIP in --no-broker mode instead of failing
- functional_v5_cluster only runs when explicitly requested (--suites functional_v5_cluster), never in the default full run

### Docs

- rmqtt-test/README.md / README-CN.md: document the new suite and configs
- designs/pubrel-resume-inflight-id-collision.md: analysis, fix design and verification records