### PR TITLE
fix(v5): reject CONNECT with Will Retain when retain is unavailable

### DIFF
--- a/rmqtt-test/configs/retain-disabled/rmqtt.toml
+++ b/rmqtt-test/configs/retain-disabled/rmqtt.toml
@@ -1,0 +1,69 @@
+##--------------------------------------------------------------------
+## rmqttd config for the GitHub issue #457 reproduction test
+## (Will Retain vs Retain Available, MQTT-3.2.2-13)
+##
+## This config deliberately does NOT load the rmqtt-retainer plugin, so the
+## broker advertises `Retain Available = 0` in its CONNACK. According to the
+## spec, a CONNECT whose Will Message has `Will Retain = 1` must then be
+## rejected with CONNACK reason 0x9A ("Retain not supported").
+##
+## Usage (run from the rmqtt repository root so that `plugins.dir`
+## resolves correctly):
+##   target/release/mqtt_harness \
+##     --binary target/release/rmqttd \
+##     --config rmqtt-test/configs/retain-disabled/rmqtt.toml \
+##     --workspace . \
+##     --suites functional_v5 \
+##     --workers 1
+##
+## Expected result today (before the fix): the
+## `v5_will_retain_rejected_when_retain_unavailable` test FAILS because the
+## broker accepts the `Will Retain = 1` connection with reason 0x00.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+## Task
+##--------------------------------------------------------------------
+task.exec_workers = 2000
+task.exec_queue_max = 300_000
+
+##--------------------------------------------------------------------
+## Node
+##--------------------------------------------------------------------
+node.id = 1
+node.busy.check_enable = false
+node.busy.update_interval = "2s"
+node.busy.loadavg = 80.0
+node.busy.cpuloadavg = 90.0
+node.busy.handshaking = 0
+
+##--------------------------------------------------------------------
+## Log
+##--------------------------------------------------------------------
+log.to = "console"
+log.level = "info"
+log.dir = "."
+log.file = "rmqtt.log"
+
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+plugins.dir = "rmqtt-plugins/"
+# NOTE: rmqtt-retainer is intentionally NOT loaded, so the broker advertises
+# `Retain Available = 0` (the CONNECT-side `retain_available` config item was
+# removed in 0.11.0; availability is driven solely by the retainer plugin).
+plugins.default_startups = [
+    "rmqtt-message-storage",
+]
+plugins.disabled_default_startups = []
+
+##--------------------------------------------------------------------
+## Listener
+##--------------------------------------------------------------------
+listener.tcp.external.addr = "127.0.0.1:1883"
+listener.tcp.external.workers = 8
+listener.tcp.external.max_connections = 1024000
+listener.tcp.external.max_handshaking_limit = 500
+listener.tcp.external.handshake_timeout = "30s"
+listener.tcp.external.max_packet_size = "1MB"
+listener.tcp.external.backlog = 1024

--- a/rmqtt-test/src/framework/context.rs
+++ b/rmqtt-test/src/framework/context.rs
@@ -1,11 +1,14 @@
 //! Test Context - shared state available to all test cases
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use bytestring::ByteString;
 use parking_lot::Mutex;
+use uuid::Uuid;
 
 use crate::broker::BrokerProcess;
+use crate::framework::testcase::TestResult;
 
 /// Metrics collected during test execution
 #[derive(Debug, Default, Clone)]
@@ -164,6 +167,65 @@ impl TestContext {
             b.health_check()
         } else {
             false
+        }
+    }
+
+    /// Probe whether the broker advertises `Retain Available = 1` in CONNACK,
+    /// i.e. whether retained messages are enabled (the `rmqtt-retainer`
+    /// plugin is loaded). Synchronous: creates its own tokio runtime,
+    /// matching the style of `create_v5_client`.
+    ///
+    /// Uses a raw v5 CONNECT (the CONNACK `retain_available` property only
+    /// exists in the v5 protocol); the capability is a broker-wide property
+    /// independent of the client's protocol version.
+    pub fn retain_available(&self) -> Result<bool, anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new().expect("failed to create runtime");
+        rt.block_on(async {
+            let (mut reader, mut writer) =
+                crate::transport::tcp_v5::connect(&self.config.broker_addr, self.config.connect_timeout)
+                    .await?;
+            let connect = rmqtt_codec::v5::Connect {
+                clean_start: true,
+                keep_alive: 60,
+                client_id: ByteString::from(format!("retain-probe-{}", Uuid::new_v4().as_simple())),
+                ..Default::default()
+            };
+            writer.send_packet(&rmqtt_codec::v5::Packet::Connect(Box::new(connect))).await?;
+            let pkt = tokio::time::timeout(Duration::from_secs(5), reader.read_packet()).await.map_err(
+                |_| anyhow::anyhow!("timed out waiting for CONNACK while probing retain availability"),
+            )??;
+            match pkt {
+                rmqtt_codec::v5::Packet::ConnectAck(ack) => Ok(ack.retain_available),
+                other => Err(anyhow::anyhow!(
+                    "expected CONNACK while probing retain availability, got {:?}",
+                    crate::transport::tcp_v5::packet_name_v5(&other)
+                )),
+            }
+        })
+    }
+
+    /// Guard for retain-dependent tests.
+    ///
+    /// If the broker does not support retained messages (the `rmqtt-retainer`
+    /// plugin is not enabled, CONNACK advertises `Retain Available = 0`), the
+    /// test is not executed and is reported as **passed** with an explanatory
+    /// note. Returns `None` when retained messages ARE available and the test
+    /// should run normally.
+    pub fn guard_retain_required(&self, name: &str, suite: &str, start: Instant) -> Option<TestResult> {
+        match self.retain_available() {
+            Ok(true) => None,
+            Ok(false) => Some(TestResult::passed_with_note(
+                name,
+                suite,
+                start.elapsed(),
+                "skipped: 'rmqtt-retainer' plugin not enabled (Retain Available = 0)",
+            )),
+            Err(e) => Some(TestResult::failed(
+                name,
+                suite,
+                start.elapsed(),
+                format!("failed to probe retain availability: {e}"),
+            )),
         }
     }
 }

--- a/rmqtt-test/src/framework/testcase.rs
+++ b/rmqtt-test/src/framework/testcase.rs
@@ -26,6 +26,9 @@ pub struct TestResult {
     pub verdict: TestVerdict,
     pub duration: Duration,
     pub retries: u32,
+    /// Optional annotation surfaced in reports, e.g. the reason a test passed
+    /// without executing (retain-dependent tests when the plugin is disabled).
+    pub note: Option<String>,
 }
 
 impl TestResult {
@@ -36,6 +39,20 @@ impl TestResult {
             verdict: TestVerdict::Passed,
             duration,
             retries: 0,
+            note: None,
+        }
+    }
+
+    /// Passed with an explanatory note (e.g. "skipped: 'rmqtt-retainer'
+    /// plugin not enabled"), so the reason is visible in the reports.
+    pub fn passed_with_note(name: &str, suite: &str, duration: Duration, note: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            suite: suite.to_string(),
+            verdict: TestVerdict::Passed,
+            duration,
+            retries: 0,
+            note: Some(note.to_string()),
         }
     }
 
@@ -46,6 +63,7 @@ impl TestResult {
             verdict: TestVerdict::Failed(reason),
             duration,
             retries: 0,
+            note: None,
         }
     }
 
@@ -56,6 +74,7 @@ impl TestResult {
             verdict: TestVerdict::Timeout,
             duration,
             retries: 0,
+            note: None,
         }
     }
 
@@ -66,6 +85,7 @@ impl TestResult {
             verdict: TestVerdict::Skipped(reason.to_string()),
             duration,
             retries: 0,
+            note: None,
         }
     }
 
@@ -76,6 +96,7 @@ impl TestResult {
             verdict: TestVerdict::Error(msg),
             duration,
             retries: 0,
+            note: None,
         }
     }
 }

--- a/rmqtt-test/src/main.rs
+++ b/rmqtt-test/src/main.rs
@@ -313,6 +313,7 @@ fn build_functional_v5_suite() -> TestSuite {
     use tests::functional::qos2_pubrel_resume_collision::*;
     use tests::functional::request_response_v5::*;
     use tests::functional::retain_handling_v5::*;
+    use tests::functional::retain_unavailable_v5::*;
     use tests::functional::server_keepalive_v5::*;
     use tests::functional::session_v5::*;
     use tests::functional::shared_subscription::*;
@@ -342,6 +343,8 @@ fn build_functional_v5_suite() -> TestSuite {
     suite.add(RetainHandlingNoAtSubscribeV5Test);
     suite.add(RetainHandlingNewV5Test);
     suite.add(RetainAsPublishedV5Test);
+    // Will Retain vs Retain Available conformance (GitHub issue #457)
+    suite.add(WillRetainRejectedWhenRetainUnavailableV5Test);
     // Disconnect reason codes
     suite.add(DisconnectReasonV5Test);
     // Flow control

--- a/rmqtt-test/src/report/console.rs
+++ b/rmqtt-test/src/report/console.rs
@@ -24,7 +24,7 @@ impl ConsoleReporter {
                     format!(" ({})", r)
                 }
                 TestVerdict::Timeout => " (timeout)".to_string(),
-                TestVerdict::Passed => String::new(),
+                TestVerdict::Passed => result.note.as_ref().map(|n| format!(" ({})", n)).unwrap_or_default(),
             };
 
             let duration = if result.duration.as_millis() < 1000 {

--- a/rmqtt-test/src/report/detail_log.rs
+++ b/rmqtt-test/src/report/detail_log.rs
@@ -95,7 +95,13 @@ fn write_test_detail(file: &mut std::fs::File, result: &TestResult) -> Result<()
             writeln!(file, "  This often indicates a protocol-level issue (e.g., broker rejected")?;
             writeln!(file, "  a packet, or the client sent a malformed packet).")?;
         }
-        TestVerdict::Passed => {}
+        TestVerdict::Passed => {
+            if let Some(note) = &result.note {
+                writeln!(file)?;
+                writeln!(file, "  NOTE: {}", note)?;
+                writeln!(file)?;
+            }
+        }
     }
 
     Ok(())

--- a/rmqtt-test/src/report/html.rs
+++ b/rmqtt-test/src/report/html.rs
@@ -61,7 +61,7 @@ impl HtmlReporter {
             let reason = match &r.verdict {
                 TestVerdict::Failed(r) | TestVerdict::Error(r) | TestVerdict::Skipped(r) => r.clone(),
                 TestVerdict::Timeout => "timed out".to_string(),
-                TestVerdict::Passed => String::new(),
+                TestVerdict::Passed => r.note.clone().unwrap_or_default(),
             };
             let duration = if r.duration.as_millis() < 1000 {
                 format!("{}ms", r.duration.as_millis())

--- a/rmqtt-test/src/report/json.rs
+++ b/rmqtt-test/src/report/json.rs
@@ -46,7 +46,7 @@ impl JsonReporter {
                 name: r.name.clone(),
                 suite: r.suite.clone(),
                 status: verdict_to_status(&r.verdict),
-                reason: verdict_to_reason(&r.verdict),
+                reason: verdict_to_reason(&r.verdict).or_else(|| r.note.clone()),
                 duration_ms: r.duration.as_millis() as u64,
                 retries: r.retries,
             })

--- a/rmqtt-test/src/tests/functional/mod.rs
+++ b/rmqtt-test/src/tests/functional/mod.rs
@@ -26,6 +26,7 @@ pub mod qos2_pubrel_resume_collision;
 pub mod qos2_pubrel_resume_collision_cluster;
 pub mod request_response_v5;
 pub mod retain_handling_v5;
+pub mod retain_unavailable_v5;
 pub mod server_keepalive_v5;
 pub mod session_v311;
 pub mod session_v5;

--- a/rmqtt-test/src/tests/functional/pubsub_v311.rs
+++ b/rmqtt-test/src/tests/functional/pubsub_v311.rs
@@ -199,6 +199,10 @@ impl TestCase for RetainV311Test {
 
     fn execute(&self, ctx: &mut TestContext) -> TestResult {
         let start = Instant::now();
+        // Skip (as passed) when retained messages are unavailable.
+        if let Some(result) = ctx.guard_retain_required(self.name(), "functional_v311", start) {
+            return result;
+        }
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let result = rt.block_on(async {

--- a/rmqtt-test/src/tests/functional/retain_handling_v5.rs
+++ b/rmqtt-test/src/tests/functional/retain_handling_v5.rs
@@ -17,6 +17,10 @@ impl TestCase for RetainHandlingNoAtSubscribeV5Test {
 
     fn execute(&self, ctx: &mut TestContext) -> TestResult {
         let start = Instant::now();
+        // Skip (as passed) when retained messages are unavailable.
+        if let Some(result) = ctx.guard_retain_required(self.name(), "functional_v5", start) {
+            return result;
+        }
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let result: anyhow::Result<()> = rt.block_on(async {
@@ -76,6 +80,10 @@ impl TestCase for RetainHandlingNewV5Test {
 
     fn execute(&self, ctx: &mut TestContext) -> TestResult {
         let start = Instant::now();
+        // Skip (as passed) when retained messages are unavailable.
+        if let Some(result) = ctx.guard_retain_required(self.name(), "functional_v5", start) {
+            return result;
+        }
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let result: anyhow::Result<()> = rt.block_on(async {

--- a/rmqtt-test/src/tests/functional/retain_unavailable_v5.rs
+++ b/rmqtt-test/src/tests/functional/retain_unavailable_v5.rs
@@ -1,0 +1,180 @@
+//! MQTT v5 conformance: Will Retain vs Retain Available (MQTT-3.2.2-13)
+//!
+//! GitHub issue #457 (https://github.com/rmqtt/rmqtt/issues/457):
+//! rmqtt advertises `Retain Available = 0` in its CONNACK (retain feature
+//! disabled) yet accepts a CONNECT whose Will Message has `Will Retain = 1`,
+//! returning reason `0x00`. The specification requires the Server to reject
+//! such a connection with CONNACK reason `0x9A` ("Retain not supported") and
+//! close the Network Connection.
+//!
+//! Reproduction (run the harness with a config that does NOT load the
+//! rmqtt-retainer plugin, see `rmqtt-test/configs/retain-disabled/rmqtt.toml`):
+//!
+//! ```text
+//! mqtt_harness \
+//!   --binary target/release/rmqttd \
+//!   --config rmqtt-test/configs/retain-disabled/rmqtt.toml \
+//!   --workspace . \
+//!   --suites functional_v5 \
+//!   --workers 1
+//! ```
+//!
+//! Expected result today (before the fix): the test FAILS — the broker accepts
+//! the `Will Retain = 1` connection with reason 0x00 instead of 0x9A, which is
+//! exactly the issue being reproduced.
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use bytestring::ByteString;
+use rmqtt_codec::types::QoS;
+use rmqtt_codec::v5::{Connect, ConnectAckReason, LastWill, Packet};
+use uuid::Uuid;
+
+use crate::framework::context::TestContext;
+use crate::framework::testcase::{TestCase, TestResult};
+use crate::transport::tcp_v5::{packet_name_v5, TcpTransportV5Reader};
+
+/// Test outcome used to distinguish a real result from "not applicable".
+enum Outcome {
+    Ok,
+    /// The server advertises Retain Available = 1, so the scenario does not
+    /// apply (mirrors the "not applicable" branch of the issue's repro script).
+    NotApplicable,
+}
+
+/// Result of one raw CONNECT probe.
+struct Probe {
+    reason: ConnectAckReason,
+    retain_available: bool,
+    reader: TcpTransportV5Reader,
+}
+
+/// Open a raw TCP connection, send a CONNECT (optionally with a Will Message)
+/// and read the CONNACK. Returns the reason code, the advertised
+/// `retain_available` property and the reader half (for close verification).
+async fn probe_connect(ctx: &TestContext, will_retain: Option<bool>) -> Result<Probe, anyhow::Error> {
+    let (mut reader, mut writer) =
+        crate::transport::tcp_v5::connect(&ctx.config.broker_addr, ctx.config.connect_timeout).await?;
+
+    let last_will = will_retain.map(|retain| LastWill {
+        qos: QoS::AtMostOnce,
+        retain,
+        topic: ByteString::from("will/retain-probe"),
+        message: Bytes::from_static(b"bye"),
+        will_delay_interval_sec: None,
+        correlation_data: None,
+        message_expiry_interval: None,
+        content_type: None,
+        user_properties: Vec::new(),
+        is_utf8_payload: None,
+        response_topic: None,
+    });
+
+    let connect = Connect {
+        clean_start: true,
+        keep_alive: 60,
+        last_will,
+        client_id: ByteString::from(format!("wr-probe-{}", Uuid::new_v4().as_simple())),
+        ..Default::default()
+    };
+
+    writer.send_packet(&Packet::Connect(Box::new(connect))).await?;
+
+    let pkt = tokio::time::timeout(Duration::from_secs(5), reader.read_packet())
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for CONNACK"))??;
+
+    match pkt {
+        Packet::ConnectAck(ack) => {
+            Ok(Probe { reason: ack.reason_code, retain_available: ack.retain_available, reader })
+        }
+        other => Err(anyhow::anyhow!("expected CONNACK, got {:?}", packet_name_v5(&other))),
+    }
+}
+
+/// After a rejected CONNECT the Server MUST close the Network Connection
+/// (MQTT-3.2.2-13). A clean EOF (or no further data within a short window) is
+/// acceptable; receiving an extra MQTT packet is a violation.
+async fn assert_connection_closed(reader: &mut TcpTransportV5Reader) -> Result<(), anyhow::Error> {
+    match tokio::time::timeout(Duration::from_secs(2), reader.read_packet()).await {
+        Ok(Ok(pkt)) => Err(anyhow::anyhow!(
+            "expected the Network Connection to be closed after rejection, \
+             but received an extra packet: {:?}",
+            packet_name_v5(&pkt)
+        )),
+        Ok(Err(_)) => Ok(()), // EOF: connection closed by broker
+        Err(_) => Ok(()),     // lenient: no further data within the window
+    }
+}
+
+/// GitHub issue #457 reproduction: a CONNECT carrying `Will Retain = 1` must
+/// be rejected with `0x9A` (RetainNotSupported) when the server advertises
+/// `Retain Available = 0` (MQTT-3.2.2-13).
+pub struct WillRetainRejectedWhenRetainUnavailableV5Test;
+
+impl TestCase for WillRetainRejectedWhenRetainUnavailableV5Test {
+    fn name(&self) -> &str {
+        "v5_will_retain_rejected_when_retain_unavailable"
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(20)
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let result: Result<Outcome, anyhow::Error> = rt.block_on(async {
+            // 1) Probe: plain CONNECT (no will) -> inspect CONNACK `retain_available`.
+            let p = probe_connect(ctx, None).await?;
+            if p.retain_available {
+                // Server supports retained messages: scenario not applicable.
+                return Ok(Outcome::NotApplicable);
+            }
+
+            // 2) CONNECT with Will Retain = 1 MUST be rejected with 0x9A.
+            let p = probe_connect(ctx, Some(true)).await?;
+            if p.reason != ConnectAckReason::RetainNotSupported {
+                // Actual rmqtt behaviour (issue #457): accepted with 0x00.
+                return Err(anyhow::anyhow!(
+                    "MQTT-3.2.2-13 violation: server advertises Retain Available = 0 \
+                     but accepted CONNECT with Will Retain = 1, CONNACK reason = {:?} (0x{:02X}); \
+                     expected RetainNotSupported (0x9A)",
+                    p.reason,
+                    u8::from(p.reason)
+                ));
+            }
+
+            // 3) After the rejection the server must close the connection.
+            let mut reader = p.reader;
+            assert_connection_closed(&mut reader).await?;
+
+            // 4) Control: CONNECT with Will Retain = 0 must still be accepted.
+            let p = probe_connect(ctx, Some(false)).await?;
+            if p.reason != ConnectAckReason::Success {
+                return Err(anyhow::anyhow!(
+                    "control failed: CONNECT with Will Retain = 0 (retain unavailable) \
+                     should be accepted, got {:?} (0x{:02X})",
+                    p.reason,
+                    u8::from(p.reason)
+                ));
+            }
+
+            Ok(Outcome::Ok)
+        });
+
+        match result {
+            Ok(Outcome::Ok) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Ok(Outcome::NotApplicable) => TestResult::skipped(
+                self.name(),
+                "functional_v5",
+                start.elapsed(),
+                "server advertises Retain Available = 1 (retain feature enabled); \
+                 scenario not applicable",
+            ),
+            Err(e) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+        }
+    }
+}

--- a/rmqtt-test/src/tests/stress/memory.rs
+++ b/rmqtt-test/src/tests/stress/memory.rs
@@ -16,6 +16,10 @@ impl TestCase for RetainFloodTest {
 
     fn execute(&self, ctx: &mut TestContext) -> TestResult {
         let start = Instant::now();
+        // Skip (as passed) when retained messages are unavailable.
+        if let Some(result) = ctx.guard_retain_required(self.name(), "stress", start) {
+            return result;
+        }
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let result = rt.block_on(async {

--- a/rmqtt/src/types.rs
+++ b/rmqtt/src/types.rs
@@ -1168,6 +1168,15 @@ impl LastWill<'_> {
         }
     }
 
+    /// Whether the Will Message is to be Retained when it is published.
+    #[inline]
+    pub fn retain(&self) -> bool {
+        match self {
+            LastWill::V3(lw) => lw.retain,
+            LastWill::V5(lw) => lw.retain,
+        }
+    }
+
     #[inline]
     pub fn to_json(&self) -> serde_json::Value {
         match self {

--- a/rmqtt/src/v5.rs
+++ b/rmqtt/src/v5.rs
@@ -224,6 +224,29 @@ async fn _handshake(
         ));
     }
 
+    //[MQTT-3.2.2-13] A Server that advertises `Retain Available = 0` in its
+    //CONNACK (retained messages not supported) MUST NOT accept a CONNECT whose
+    //Will Message has `Will Retain = 1`; the connection is rejected with
+    //CONNACK reason 0x9A (Retain not supported).
+    if connect_info.last_will().is_some_and(|lw| lw.retain()) {
+        let retain_available = {
+            #[cfg(feature = "retain")]
+            {
+                scx.extends.retain().await.enable()
+            }
+            #[cfg(not(feature = "retain"))]
+            {
+                false
+            }
+        };
+        if !retain_available {
+            return Err((
+                ConnectAckReason::V5(ConnectAckReasonV5::RetainNotSupported),
+                anyhow!("will retain is not supported by the server"),
+            ));
+        }
+    }
+
     let entry = scx.extends.shared().await.entry(id.clone());
     let max_sessions = scx.mqtt_max_sessions;
     if max_sessions > 0 && scx.sessions.count() >= max_sessions && !entry.exist() {


### PR DESCRIPTION
Per MQTT-3.2.2-13, a server that advertises Retain Available = 0 in its CONNACK must reject a CONNECT whose Will Message has Will Retain = 1 with reason 0x9A (Retain not supported) and close the connection.

Previously rmqtt accepted such connections with reason 0x00, violating the spec (GitHub issue #457).

- Add LastWill::retain() accessor
- Enforce the check during the v5 handshake
- Add regression test v5_will_retain_rejected_when_retain_unavailable
- Add TestResult::note and TestContext::guard_retain_required so retain-dependent tests skip (passed with a note) when the rmqtt-retainer plugin is not loaded
- Surface notes in console/detail_log/html/json reports
- Add retain-disabled harness config