### PR TITLE
fix(handshake): correct CONNACK reason code for empty ClientId with CleanStart/CleanSession=0

### DIFF
--- a/rmqtt-test/src/main.rs
+++ b/rmqtt-test/src/main.rs
@@ -233,6 +233,7 @@ fn build_functional_v311_suite() -> TestSuite {
     use tests::functional::boundary::*;
     use tests::functional::connect_v311::*;
     use tests::functional::dollar_topics::*;
+    use tests::functional::empty_clientid_cleansession0_v311::*;
     use tests::functional::keepalive::*;
     use tests::functional::last_will::*;
     use tests::functional::multi_topic::*;
@@ -267,6 +268,8 @@ fn build_functional_v311_suite() -> TestSuite {
     // Authentication edge cases
     suite.add(AuthEmptyClientIdFailTest);
     suite.add(AuthConnectDisconnectSequenceTest);
+    // Empty ClientId + CleanSession = 0 must be rejected with 0x02 (MQTT-3.1.3-6)
+    suite.add(EmptyClientIdCleanSession0RejectedV311Test);
     // Boundary tests
     suite.add(MaxClientIdTest);
     suite.add(LongTopicTest);
@@ -301,6 +304,7 @@ fn build_functional_v5_suite() -> TestSuite {
     use tests::functional::connect_v5::*;
     use tests::functional::disconnect_reason_v5::*;
     use tests::functional::dollar_topics::*;
+    use tests::functional::empty_clientid_cleanstart0_v5::*;
     use tests::functional::flow_control_v5::*;
     use tests::functional::keepalive::*;
     use tests::functional::last_will::*;
@@ -353,6 +357,8 @@ fn build_functional_v5_suite() -> TestSuite {
     suite.add(SharedSubV5Test);
     // V5 CONNACK property checks
     suite.add(AssignedClientIdV5Test);
+    // Empty ClientId + CleanStart = 0 must be rejected with 0x85 (MQTT-3.1.3-8)
+    suite.add(EmptyClientIdCleanStart0RejectedV5Test);
     suite.add(ServerKeepAliveV5Test);
     suite.add(ServerTopicAliasV5Test);
     suite.add(MaxPacketSizeV5Test);

--- a/rmqtt-test/src/tests/functional/empty_clientid_cleansession0_v311.rs
+++ b/rmqtt-test/src/tests/functional/empty_clientid_cleansession0_v311.rs
@@ -1,0 +1,140 @@
+//! MQTT 3.1.1 conformance: empty ClientId + CleanSession = 0 must be rejected (MQTT-3.1.3-6)
+//!
+//! The MQTT 3.1.1 specification requires:
+//!
+//! * [MQTT-3.1.3-6] If the ClientId is a zero-length byte string and CleanSession
+//!   is 0, the Server MUST send a CONNACK with return code `0x02`
+//!   (Identifier Rejected) and then close the Network Connection.
+//! * [MQTT-3.1.3-7] If the ClientId is a zero-length byte string and CleanSession
+//!   is 1, the Server MAY allow the Client to connect with a zero-byte ClientId
+//!   and assign it a unique ClientId (Session Present is then 0).
+//!
+//! Current rmqtt behaviour (after the MQTT-3.1.3-6 fix in `rmqtt/src/v3.rs`):
+//! the check exists at the codec layer — `rmqtt-codec/src/v3/decode.rs`
+//! rejects an empty ClientId with `DecodeError::InvalidClientId` when
+//! CleanSession is 0. `rmqtt/src/v3.rs` maps that decode error to a CONNACK
+//! with return code `0x02` (Identifier Rejected). Before the fix it was
+//! reported as `0x03` (ServiceUnavailable), which violated MQTT-3.1.3-6.
+//!
+//! This test protects the fix: it must PASS with the fix in place, and would
+//! have FAILED before the fix (return code 0x03 instead of 0x02).
+
+use std::time::{Duration, Instant};
+
+use bytestring::ByteString;
+use rmqtt_codec::types::{Protocol, MQTT_LEVEL_311};
+use rmqtt_codec::v3::{Connect, ConnectAckReason, Packet};
+
+use crate::framework::context::TestContext;
+use crate::framework::testcase::{TestCase, TestResult};
+use crate::transport::tcp_v3::{packet_name_v3, TcpTransportV3Reader};
+
+/// Result of one raw CONNECT probe.
+struct Probe {
+    reason: ConnectAckReason,
+    reader: TcpTransportV3Reader,
+}
+
+/// Open a raw TCP connection and send a v3.1.1 CONNECT with an **empty**
+/// ClientId and the given CleanSession flag, then read the CONNACK. Returns
+/// the return code and the reader half (for close verification).
+async fn probe_empty_clientid_connect(
+    ctx: &TestContext,
+    clean_session: bool,
+) -> Result<Probe, anyhow::Error> {
+    let (mut reader, mut writer) =
+        crate::transport::tcp_v3::connect(&ctx.config.broker_addr, ctx.config.connect_timeout).await?;
+
+    let connect = Connect {
+        protocol: Protocol(MQTT_LEVEL_311),
+        clean_session,
+        keep_alive: 60,
+        client_id: ByteString::from(""),
+        ..Default::default()
+    };
+
+    writer.send_packet(&Packet::Connect(Box::new(connect))).await?;
+
+    let pkt = tokio::time::timeout(Duration::from_secs(5), reader.read_packet())
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for CONNACK"))??;
+
+    match pkt {
+        Packet::ConnectAck(ack) => Ok(Probe { reason: ack.return_code, reader }),
+        other => Err(anyhow::anyhow!("expected CONNACK, got {:?}", packet_name_v3(&other))),
+    }
+}
+
+/// After a rejected CONNECT the Server MUST close the Network Connection
+/// (MQTT-3.1.3-6). A clean EOF (or no further data within a short window) is
+/// acceptable; receiving an extra MQTT packet is a violation.
+async fn assert_connection_closed(reader: &mut TcpTransportV3Reader) -> Result<(), anyhow::Error> {
+    match tokio::time::timeout(Duration::from_secs(2), reader.read_packet()).await {
+        Ok(Ok(pkt)) => Err(anyhow::anyhow!(
+            "expected the Network Connection to be closed after rejection, \
+             but received an extra packet: {:?}",
+            packet_name_v3(&pkt)
+        )),
+        Ok(Err(_)) => Ok(()), // EOF: connection closed by broker
+        Err(_) => Ok(()),     // lenient: no further data within the window
+    }
+}
+
+/// GitHub issue reproduction: an empty ClientId with CleanSession = 0 MUST be
+/// rejected with `0x02` (IdentifierRejected) and the connection closed
+/// (MQTT-3.1.3-6). Control: empty ClientId with CleanSession = 1 MUST be
+/// accepted (MQTT-3.1.3-7).
+pub struct EmptyClientIdCleanSession0RejectedV311Test;
+
+impl TestCase for EmptyClientIdCleanSession0RejectedV311Test {
+    fn name(&self) -> &str {
+        "v311_empty_clientid_cleansession0_rejected"
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(20)
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let result: Result<(), anyhow::Error> = rt.block_on(async {
+            // 1) Empty ClientId + CleanSession = 0 MUST be rejected with 0x02.
+            let p = probe_empty_clientid_connect(ctx, false).await?;
+            if p.reason != ConnectAckReason::IdentifierRejected {
+                // Actual rmqtt behaviour before the fix: rejected with 0x03.
+                return Err(anyhow::anyhow!(
+                    "MQTT-3.1.3-6 violation: empty ClientId with CleanSession = 0 \
+                     must be rejected with return code IdentifierRejected (0x02), \
+                     but CONNACK return code = {:?} (0x{:02X})",
+                    p.reason,
+                    u8::from(p.reason)
+                ));
+            }
+
+            // 2) After the rejection the server must close the connection.
+            let mut reader = p.reader;
+            assert_connection_closed(&mut reader).await?;
+
+            // 3) Control: empty ClientId + CleanSession = 1 MUST be accepted
+            //    (the broker assigns a ClientId, MQTT-3.1.3-7).
+            let p = probe_empty_clientid_connect(ctx, true).await?;
+            if p.reason != ConnectAckReason::ConnectionAccepted {
+                return Err(anyhow::anyhow!(
+                    "control failed: empty ClientId with CleanSession = 1 \
+                     should be accepted, got {:?} (0x{:02X})",
+                    p.reason,
+                    u8::from(p.reason)
+                ));
+            }
+
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => TestResult::passed(self.name(), "functional_v311", start.elapsed()),
+            Err(e) => TestResult::failed(self.name(), "functional_v311", start.elapsed(), e.to_string()),
+        }
+    }
+}

--- a/rmqtt-test/src/tests/functional/empty_clientid_cleanstart0_v5.rs
+++ b/rmqtt-test/src/tests/functional/empty_clientid_cleanstart0_v5.rs
@@ -1,0 +1,149 @@
+//! MQTT v5 conformance: empty ClientId + CleanStart = 0 must be rejected (MQTT-3.1.3-8)
+//!
+//! The MQTT 5.0 specification requires:
+//!
+//! * [MQTT-3.1.3-7] If the ClientId is a zero-length byte string and CleanStart
+//!   is 1, the Server MUST assign a unique ClientId and return it in the
+//!   CONNACK `Assigned Client Identifier` property.
+//! * [MQTT-3.1.3-8] If the ClientId is a zero-length byte string and CleanStart
+//!   is 0, the Server MUST send a CONNACK with reason code `0x85`
+//!   (Client Identifier not valid) and then close the Network Connection.
+//!
+//! Current rmqtt behaviour (defect under reproduction): the check itself
+//! exists at the codec layer — `rmqtt-codec/src/v5/packet/connect.rs` rejects
+//! an empty ClientId with `DecodeError::InvalidClientId` when CleanStart is 0
+//! (MQTT-3.1.3-8). However `rmqtt/src/v5.rs` maps that decode error to a
+//! CONNACK with reason `0x88` (ServerUnavailable) instead of the required
+//! `0x85` (Client Identifier not valid), so the Server does not return the
+//! reason code mandated by the specification.
+//!
+//! Expected result today (before the fix): this test FAILS — the broker
+//! rejects the connection with reason 0x88 instead of 0x85, which is exactly
+//! the MQTT-3.1.3-8 violation being reproduced.
+
+use std::time::{Duration, Instant};
+
+use bytestring::ByteString;
+use rmqtt_codec::v5::{Connect, ConnectAckReason, Packet};
+
+use crate::framework::context::TestContext;
+use crate::framework::testcase::{TestCase, TestResult};
+use crate::transport::tcp_v5::{packet_name_v5, TcpTransportV5Reader};
+
+/// Result of one raw CONNECT probe.
+struct Probe {
+    reason: ConnectAckReason,
+    assigned_client_id: Option<ByteString>,
+    reader: TcpTransportV5Reader,
+}
+
+/// Open a raw TCP connection and send a v5 CONNECT with an **empty** ClientId
+/// and the given CleanStart flag, then read the CONNACK. Returns the reason
+/// code, the `assigned_client_id` property and the reader half (for close
+/// verification).
+async fn probe_empty_clientid_connect(ctx: &TestContext, clean_start: bool) -> Result<Probe, anyhow::Error> {
+    let (mut reader, mut writer) =
+        crate::transport::tcp_v5::connect(&ctx.config.broker_addr, ctx.config.connect_timeout).await?;
+
+    let connect =
+        Connect { clean_start, keep_alive: 60, client_id: ByteString::from(""), ..Default::default() };
+
+    writer.send_packet(&Packet::Connect(Box::new(connect))).await?;
+
+    let pkt = tokio::time::timeout(Duration::from_secs(5), reader.read_packet())
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for CONNACK"))??;
+
+    match pkt {
+        Packet::ConnectAck(ack) => {
+            Ok(Probe { reason: ack.reason_code, assigned_client_id: ack.assigned_client_id, reader })
+        }
+        other => Err(anyhow::anyhow!("expected CONNACK, got {:?}", packet_name_v5(&other))),
+    }
+}
+
+/// After a rejected CONNECT the Server MUST close the Network Connection
+/// (MQTT-3.1.3-8). A clean EOF (or no further data within a short window) is
+/// acceptable; receiving an extra MQTT packet is a violation.
+async fn assert_connection_closed(reader: &mut TcpTransportV5Reader) -> Result<(), anyhow::Error> {
+    match tokio::time::timeout(Duration::from_secs(2), reader.read_packet()).await {
+        Ok(Ok(pkt)) => Err(anyhow::anyhow!(
+            "expected the Network Connection to be closed after rejection, \
+             but received an extra packet: {:?}",
+            packet_name_v5(&pkt)
+        )),
+        Ok(Err(_)) => Ok(()), // EOF: connection closed by broker
+        Err(_) => Ok(()),     // lenient: no further data within the window
+    }
+}
+
+/// GitHub issue reproduction: an empty ClientId with CleanStart = 0 MUST be
+/// rejected with `0x85` (ClientIdentifierNotValid) and the connection closed
+/// (MQTT-3.1.3-8). Control: empty ClientId with CleanStart = 1 MUST be
+/// accepted with an assigned ClientId (MQTT-3.1.3-7).
+pub struct EmptyClientIdCleanStart0RejectedV5Test;
+
+impl TestCase for EmptyClientIdCleanStart0RejectedV5Test {
+    fn name(&self) -> &str {
+        "v5_empty_clientid_cleanstart0_rejected"
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(20)
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let result: Result<(), anyhow::Error> = rt.block_on(async {
+            // 1) Empty ClientId + CleanStart = 0 MUST be rejected with 0x85.
+            let p = probe_empty_clientid_connect(ctx, false).await?;
+            if p.reason != ConnectAckReason::ClientIdentifierNotValid {
+                // Actual rmqtt behaviour (the reproduced defect): the connection
+                // is rejected, but with reason 0x88 instead of the required 0x85.
+                return Err(anyhow::anyhow!(
+                    "MQTT-3.1.3-8 violation: empty ClientId with CleanStart = 0 \
+                     must be rejected with reason ClientIdentifierNotValid (0x85), \
+                     but CONNACK reason = {:?} (0x{:02X})",
+                    p.reason,
+                    u8::from(p.reason)
+                ));
+            }
+
+            // 2) After the rejection the server must close the connection.
+            let mut reader = p.reader;
+            assert_connection_closed(&mut reader).await?;
+
+            // 3) Control: empty ClientId + CleanStart = 1 MUST be accepted with
+            //    an assigned ClientId returned in the CONNACK (MQTT-3.1.3-7).
+            let p = probe_empty_clientid_connect(ctx, true).await?;
+            if p.reason != ConnectAckReason::Success {
+                return Err(anyhow::anyhow!(
+                    "control failed: empty ClientId with CleanStart = 1 \
+                     should be accepted, got {:?} (0x{:02X})",
+                    p.reason,
+                    u8::from(p.reason)
+                ));
+            }
+            match p.assigned_client_id {
+                Some(id) if !id.is_empty() => {}
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "control failed: CONNACK for an assigned ClientId \
+                         must carry a non-empty 'Assigned Client Identifier' property, \
+                         got {:?}",
+                        other
+                    ));
+                }
+            }
+
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Err(e) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+        }
+    }
+}

--- a/rmqtt-test/src/tests/functional/mod.rs
+++ b/rmqtt-test/src/tests/functional/mod.rs
@@ -8,6 +8,8 @@ pub mod connect_v311;
 pub mod connect_v5;
 pub mod disconnect_reason_v5;
 pub mod dollar_topics;
+pub mod empty_clientid_cleansession0_v311;
+pub mod empty_clientid_cleanstart0_v5;
 pub mod flow_control_v5;
 pub mod keepalive;
 pub mod last_will;

--- a/rmqtt/src/v3.rs
+++ b/rmqtt/src/v3.rs
@@ -38,6 +38,7 @@ use scopeguard::defer;
 use tokio::io::{AsyncRead, AsyncWrite};
 use uuid::Uuid;
 
+use crate::codec::error::DecodeError;
 use crate::codec::v3::{Connect as ConnectV3, ConnectAckReason as ConnectAckReasonV3};
 use crate::context::ServerContext;
 use crate::net::v3;
@@ -93,6 +94,17 @@ where
 }
 
 #[inline]
+/// Returns true when the error chain contains `DecodeError::InvalidClientId`,
+/// i.e. the client sent a zero-length ClientId while CleanSession was 0
+/// (MQTT-3.1.3-6). Such connections must be rejected with CONNACK return
+/// code 0x02 (Identifier Rejected) instead of a generic ServiceUnavailable.
+fn invalid_client_id(e: &Error) -> bool {
+    e.chain().any(|cause| {
+        cause.downcast_ref::<DecodeError>().is_some_and(|de| matches!(de, DecodeError::InvalidClientId))
+    })
+}
+
+#[inline]
 async fn handshake<Io>(
     scx: &ServerContext,
     sink: &mut v3::MqttStream<Io>,
@@ -108,10 +120,15 @@ where
         ));
     }
 
-    let mut c = sink
-        .recv_connect(sink.cfg.handshake_timeout)
-        .await
-        .map_err(|e| (ConnectAckReason::V3(ConnectAckReasonV3::ServiceUnavailable), e))?;
+    let mut c = sink.recv_connect(sink.cfg.handshake_timeout).await.map_err(|e| {
+        if invalid_client_id(&e) {
+            // [MQTT-3.1.3-6] An empty ClientId with CleanSession = 0 must be
+            // rejected with CONNACK return code 0x02 (Identifier Rejected).
+            (ConnectAckReason::V3(ConnectAckReasonV3::IdentifierRejected), e)
+        } else {
+            (ConnectAckReason::V3(ConnectAckReasonV3::ServiceUnavailable), e)
+        }
+    })?;
 
     log::debug!(
         "new Connection: local_addr: {:?}, remote_addr: {:?}, listen_cfg: {:?}",

--- a/rmqtt/src/v5.rs
+++ b/rmqtt/src/v5.rs
@@ -54,6 +54,7 @@ use scopeguard::defer;
 use tokio::io::{AsyncRead, AsyncWrite};
 use uuid::Uuid;
 
+use crate::codec::error::DecodeError;
 use crate::codec::v5::{Connect as ConnectV5, ConnectAck, ConnectAckReason as ConnectAckReasonV5};
 use crate::context::ServerContext;
 use crate::net::v5;
@@ -109,6 +110,17 @@ where
 }
 
 #[inline]
+/// Returns true when the error chain contains `DecodeError::InvalidClientId`,
+/// i.e. the client sent a zero-length ClientId while CleanStart was 0
+/// (MQTT-3.1.3-8). Such connections must be rejected with CONNACK 0x85
+/// (Client Identifier not valid) instead of a generic ServerUnavailable.
+fn invalid_client_id(e: &Error) -> bool {
+    e.chain().any(|cause| {
+        cause.downcast_ref::<DecodeError>().is_some_and(|de| matches!(de, DecodeError::InvalidClientId))
+    })
+}
+
+#[inline]
 async fn handshake<Io>(
     scx: &ServerContext,
     sink: &mut v5::MqttStream<Io>,
@@ -124,10 +136,15 @@ where
         ));
     }
 
-    let mut c = sink
-        .recv_connect(sink.cfg.handshake_timeout)
-        .await
-        .map_err(|e| (ConnectAckReason::V5(ConnectAckReasonV5::ServerUnavailable), e))?;
+    let mut c = sink.recv_connect(sink.cfg.handshake_timeout).await.map_err(|e| {
+        if invalid_client_id(&e) {
+            // [MQTT-3.1.3-8] An empty ClientId with CleanStart = 0 must be
+            // rejected with CONNACK reason 0x85 (Client Identifier not valid).
+            (ConnectAckReason::V5(ConnectAckReasonV5::ClientIdentifierNotValid), e)
+        } else {
+            (ConnectAckReason::V5(ConnectAckReasonV5::ServerUnavailable), e)
+        }
+    })?;
 
     log::debug!(
         "new Connection: local_addr: {:?}, remote_addr: {:?}, listen_cfg: {:?}",


### PR DESCRIPTION
The MQTT specifications require a Server to reject a CONNECT carrying a zero-length ClientId while CleanStart (v5) / CleanSession (v3.1.1) is 0:

- [MQTT-3.1.3-8] (v5): CONNACK reason 0x85 (Client Identifier not valid)
- [MQTT-3.1.3-6] (3.1.1): CONNACK return code 0x02 (Identifier Rejected)

The check itself already existed at the codec layer (`rmqtt-codec/src/v5/packet/connect.rs` / `rmqtt-codec/src/v3/decode.rs`), which rejects the empty ClientId with `DecodeError::InvalidClientId`. However `rmqtt/src/v5.rs` and `rmqtt/src/v3.rs` mapped that decode error to a generic 0x88 (ServerUnavailable) / 0x03 (ServiceUnavailable), so the CONNACK did not carry the reason code mandated by the specification.

### Fix

- `rmqtt/src/v5.rs`: `handshake()` now maps `DecodeError::InvalidClientId` to `ConnectAckReasonV5::ClientIdentifierNotValid` (0x85); all other decode errors keep the previous ServerUnavailable (0x88) behaviour.
- `rmqtt/src/v3.rs`: `handshake()` now maps `DecodeError::InvalidClientId` to `ConnectAckReasonV3::IdentifierRejected` (0x02); all other decode errors keep the previous ServiceUnavailable (0x03) behaviour.
- Both use a new `invalid_client_id()` helper that inspects the anyhow error chain (`downcast_ref::<DecodeError>()` + exact variant match), so unrelated decode errors are unaffected.

### New tests

- `rmqtt-test/src/tests/functional/empty_clientid_cleanstart0_v5.rs` `EmptyClientIdCleanStart0RejectedV5Test` — asserts CONNACK 0x85 and connection close for empty ClientId + CleanStart = 0, plus a control case (empty ClientId + CleanStart = 1 must be accepted with a non-empty Assigned Client Identifier).
- `rmqtt-test/src/tests/functional/empty_clientid_cleansession0_v311.rs` `EmptyClientIdCleanSession0RejectedV311Test` — asserts CONNACK 0x02 and connection close for empty ClientId + CleanSession = 0, plus a control case (empty ClientId + CleanSession = 1 must be accepted).
- Registered in `rmqtt-test/src/main.rs` (functional_v5 / functional_v311 suites) and `rmqtt-test/src/tests/functional/mod.rs`.

### Verification

- functional_v5: 35 tests, 34 passed, 0 failed (new test passes)
- functional_v311: 37 tests, 37 passed, 0 failed
- functional_v3: 2 tests, 2 passed, 0 failed
- `cargo fmt --check` clean; `cargo clippy -p rmqtt -p rmqtt-test` reports only 2 pre-existing warnings unrelated to this change

### Files changed

- 6 files changed, 339 insertions(+), 8 deletions(-)