### PR TITLE
# docs(rmqtt-test): sync test-suite reference counts and coverage descriptions

### DIFF
--- a/docs/en_US/development/testing.md
+++ b/docs/en_US/development/testing.md
@@ -111,9 +111,9 @@ cargo build -p rmqtt-test --release
 
 | Suite | Cases | What It Tests |
 |-------|-------|---------------|
-| `functional_v3` | 2 | MQTT 3.1 connect/disconnect, QoS 0 pub/sub |
-| `functional_v311` | 10 | MQTT 3.1.1 protocol compliance (connect, QoS 0/1/2, retain, wildcards, unsubscribe, empty client ID) |
-| `functional_v5` | 5 | MQTT 5.0 protocol compliance (connect, reason codes, QoS 0/1/2) |
+| `functional_v3` | 47 | MQTT 3.1 spec conformance: connect (wrong name/level/reserved flag/empty client id/long id), QoS 0/1/2 pub/sub, QoS 2 dedup & PUBREL resend, retained messages, last will, keep alive, session persistence, wildcards (incl. `$SYS`), boundary payloads, protocol errors |
+| `functional_v311` | 64 | MQTT 3.1.1 spec conformance: connect (incl. second-CONNECT rejection [MQTT-3.1.0-2]), QoS 0/1/2, retained edge cases, will QoS2, keep-alive 1.5× timeout, session present/resume, wildcard matching, shared subscriptions, protocol errors |
+| `functional_v5` | 63 | MQTT 5.0 spec conformance: CONNACK capability advertisement, session expiry (incl. DISCONNECT SEI=0 [MQTT-3.14.2-2]), topic alias (incl. unknown alias → 0x94), flow control, max packet size, subscription identifiers, retain handling, will delay, enhanced-auth rejection (0x8C), protocol errors |
 | `stress` | 3 | Connection load (100 clients), publish QPS (1000 msgs), fan-out (1→N) |
 | `chaos` | 6 | Broker restart, connection churn, reconnect storm, QoS 1 reliability, slow consumer |
 

--- a/docs/en_US/testing-report.md
+++ b/docs/en_US/testing-report.md
@@ -76,9 +76,9 @@ The `rmqtt-test` crate provides a custom test harness with additional test suite
 
 | Suite | Cases | Description |
 |-------|-------|-------------|
-| `functional_v3` | 2 | MQTT 3.1 basic operations (connect/disconnect, QoS 0 pub/sub) |
-| `functional_v311` | 10 | MQTT 3.1.1 protocol compliance |
-| `functional_v5` | 5 | MQTT 5.0 protocol compliance |
+| `functional_v3` | 47 | MQTT 3.1 spec conformance (connect edge cases, QoS 0/1/2, QoS 2 dedup/PUBREL resend, retained, will, keep alive, session, wildcards incl. `$SYS`, boundary, protocol errors) |
+| `functional_v311` | 64 | MQTT 3.1.1 spec conformance (incl. second-CONNECT rejection, retained edge cases, session present, protocol errors) |
+| `functional_v5` | 63 | MQTT 5.0 spec conformance (CONNACK capabilities, session expiry incl. DISCONNECT SEI=0, topic alias, flow control, retain handling, protocol errors) |
 | `stress` | 3 | Connection load (100 clients), publish QPS (1000 msgs), fan-out (1→N) |
 | `chaos` | 6 | Broker restart, connection storms, reconnect, QoS 1 reliability, slow consumer |
 

--- a/docs/zh_CN/development/testing.md
+++ b/docs/zh_CN/development/testing.md
@@ -82,9 +82,9 @@ cargo build -p rmqtt-test --release
 
 | 套件 | 用例数 | 测试内容 |
 |-------|--------|----------|
-| `functional_v3` | 2 | MQTT 3.1 连接/断开、QoS 0 发布/订阅 |
-| `functional_v311` | 10 | MQTT 3.1.1 协议合规（连接、QoS 0/1/2、保留、通配符、取消订阅） |
-| `functional_v5` | 5 | MQTT 5.0 协议合规（连接、Reason Code、QoS 0/1/2） |
+| `functional_v3` | 47 | MQTT 3.1 规范符合性：连接（错误协议名/级别/保留位/空 ClientId/超长 ID）、QoS 0/1/2 发布/订阅、QoS 2 去重与 PUBREL 重发、保留消息、遗嘱、Keep Alive、会话持久化、通配符（含 `$SYS`）、边界载荷、协议错误 |
+| `functional_v311` | 64 | MQTT 3.1.1 规范符合性：连接（含二次 CONNECT 拒绝 [MQTT-3.1.0-2]）、QoS 0/1/2、保留消息边界、Will QoS2、Keep Alive 1.5 倍超时、Session Present/恢复、通配符匹配、共享订阅、协议错误 |
+| `functional_v5` | 63 | MQTT 5.0 规范符合性：CONNACK 能力通告、会话过期（含 DISCONNECT SEI=0 [MQTT-3.14.2-2]）、主题别名（含未知别名→0x94）、流控、最大报文大小、订阅标识符、Retain Handling、Will 延迟、增强认证拒绝（0x8C）、协议错误 |
 | `stress` | 3 | 连接负载（100 客户端）、发布 QPS（1000 条）、扇出（1→N） |
 | `chaos` | 6 | Broker 重启、连接抖动、重连风暴、QoS 1 可靠性、慢消费者 |
 

--- a/docs/zh_CN/testing-report.md
+++ b/docs/zh_CN/testing-report.md
@@ -76,9 +76,9 @@ cd paho.mqtt.testing/interoperability
 
 | 套件 | 用例数 | 说明 |
 |-------|--------|------|
-| `functional_v3` | 2 | MQTT 3.1 基本操作 |
-| `functional_v311` | 10 | MQTT 3.1.1 协议合规 |
-| `functional_v5` | 5 | MQTT 5.0 协议合规 |
+| `functional_v3` | 47 | MQTT 3.1 规范符合性（连接边界、QoS 0/1/2、QoS 2 去重/PUBREL 重发、保留消息、遗嘱、Keep Alive、会话、通配符含 `$SYS`、边界、协议错误） |
+| `functional_v311` | 64 | MQTT 3.1.1 规范符合性（含二次 CONNECT 拒绝、保留消息边界、Session Present、协议错误） |
+| `functional_v5` | 63 | MQTT 5.0 规范符合性（CONNACK 能力通告、会话过期含 DISCONNECT SEI=0、主题别名、流控、Retain Handling、协议错误） |
 | `stress` | 3 | 连接负载、发布 QPS、扇出测试 |
 | `chaos` | 6 | Broker 重启、连接风暴、重连、QoS 1 可靠性、慢消费者 |
 

--- a/rmqtt-test/README-CN.md
+++ b/rmqtt-test/README-CN.md
@@ -70,40 +70,56 @@ cargo build -p rmqtt-test --release
 
 ## 📋 测试套件
 
-### functional_v3（2 个用例）— MQTT 3.1
+### functional_v3（47 个用例）— MQTT 3.1
 
-| 用例 | 说明 |
+针对 MQTT v3.1（IBM MQIsdp）的规范符合性套件，覆盖正向、反向与边界场景：
+
+| 类别 | 用例 |
 |------|------|
-| `connect_v3` | MQTT 3.1 连接与断开 |
-| `pubsub_v3_qos0` | QoS 0 发布/订阅 |
+| 连接 | `connect_v3` / `with_options` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `empty_clientid_cleansession0/1` / `long_client_id` / `client_id_max_length` |
+| 发布/订阅 | `pubsub_v3_qos0/1/2` / `publish_v3_wildcard_reject` |
+| QoS 2 一致性 | `qos2_replayed_publish_dedup_v3` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume_v3` [MQTT-4.4.0-1] |
+| 保留消息 | `retain_v3_store_and_deliver` / `empty_payload_deletes` / `overwrite` / `live_message_not_retained` / `will` |
+| 遗嘱消息 | `last_will_v3` / `clean` / `qos2` |
+| Keep Alive | `keepalive_v3_ping` / `zero` / `timeout` |
+| 会话 | `session_v3_persistent` / `clean` / `offline_queue` |
+| 通配符 | `wildcard_v3_plus` / `hash` / `overlap` / `dollar_topics` / `case_sensitive` / `leading_slash` |
+| 边界 | `boundary_v3_empty_payload` / `large_payload` / `long_topic` / `special_chars_topic` / `max_keepalive` / `rapid_subscribe` |
+| 协议错误 | `protocol_error_v3_subscribe_qos3` / `publish_packet_id_zero` / `bad_remaining_length` / `empty_topic_filter` / `reserved_packet_type` / `subscribe_qos0_fixed_header` |
 
-### functional_v311（10 个用例）— MQTT 3.1.1
+> v3.1 客户端通过 `build_connect_bytes` 手工构造 MQIsdp CONNECT 报文（codec 将协议级别硬编码为 4，对 3.1.1/5.0 正确）。
 
-| 用例 | 说明 |
+### functional_v311（64 个用例）— MQTT 3.1.1
+
+| 类别 | 用例 |
 |------|------|
-| `connect_v311` | MQTT 3.1.1 连接与断开 |
-| `connect_empty_client_id` | 空 Client ID 连接（需 Clean Session） |
-| `multiple_connections` | 10 个并发连接 |
-| `pubsub_v311_qos0` | QoS 0 发布/订阅 |
-| `pubsub_v311_qos1` | QoS 1 发布/订阅 |
-| `pubsub_v311_qos2` | QoS 2 发布/订阅（完整四步握手） |
-| `retain_v311_message` | 保留消息存储与获取 |
-| `unsubscribe_v311` | 取消订阅后不再收到消息 |
-| `wildcard_plus` | 单层通配符 `+` 匹配 |
-| `wildcard_hash` | 多层通配符 `#` 匹配 |
+| 连接 | `connect_v311` / `empty_client_id` / `multiple_connections` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` [MQTT-3.1.0-2] / `long_client_id` |
+| 发布/订阅 | `pubsub_v311_qos0/1/2` / `retain_v311_message` / `unsubscribe_v311` |
+| QoS 2 一致性 | `qos2_replayed_publish_dedup_v311` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume_v311` [MQTT-4.4.0-1] / `qos2_duplicate_detection` |
+| 保留消息 | `retain_v311_store_and_deliver` / `empty_payload_deletes` [MQTT-3.3.1-9] / `overwrite` / `live_message_not_retained` / `will` |
+| 遗嘱消息 | `last_will_v311` / `clean` / `unclean` / `qos2` / `keepalive_timeout` |
+| Keep Alive | `keepalive_v311_ping_keeps_alive` / `timeout` / `zero` / `max_value` |
+| 会话 | `clean_session_false` / `offline_queue_v311` / `present_on_resume` [MQTT-3.2.2.1] / `clean_discard` [MQTT-3.1.2-6] |
+| 通配符 | `wildcard_plus` / `hash` / `case_sensitive` / `leading_slash` / `hash_not_last` |
+| 认证 / $SYS / 共享订阅 | `auth_empty_client_id_fail` / `auth_connect_disconnect_sequence` / `dollar_topics` / `shared_sub_v311` |
+| 边界 | `max_client_id` / `long_topic` / `empty_payload` / `large_payload` / `special_chars_topic` / `rapid_subscribe` |
+| 多主题 | `multi_topic_subscribe_v311` / `overlapping_subscriptions` / `message_ordering` |
+| 协议错误 | `invalid_protocol_version` / `empty_topic_filter` / `protocol_error_v311_*`（订阅 QoS3、固定头 QoS、发布 QoS3/pid0、剩余长度、保留类型） |
 
-### functional_v5（34 个用例）— MQTT 5.0
+### functional_v5（63 个用例）— MQTT 5.0
 
-| 用例 | 说明 |
+| 类别 | 用例 |
 |------|------|
-| `connect_v5` / `connect_v5_reason_codes` | MQTT 5.0 连接与 Reason Code 验证 |
-| `pubsub_v5_qos0/1/2` | MQTT 5.0 QoS 0/1/2 发布/订阅 |
-| `session_expiry_v5` / `session_takeover_v5` / `session_clean_start_v5` | 会话过期 / 接管 / Clean Start |
-| `qos2_replayed_publish_dedup` | [MQTT-4.3.3-10] 重放 QoS 2 PUBLISH 去重（issue #456） |
-| `qos2_pubrel_resend_on_resume` | [MQTT-4.4.0-1] 会话恢复时重发欠的 PUBREL（issue #456） |
-| `qos2_pubrel_resume_collision` | **PUBREL 重发与并发 deliver 的 packet-id 冲突（单机版回归测试）** |
-| `flow_control_v5` / `no_local_v5` / `will_delay_v5` | 流控 / 本地不转发 / Will 延迟 |
-| `retain_handling_*_v5` / `shared_sub_v5` / `topic_alias_v5` 等 | V5 特性覆盖（详见 `src/tests/functional/`） |
+| 连接 / CONNACK | `connect_v5` / `reason_codes` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` / `client_id_too_long` / `auth_method_rejected` (0x8C) / `connack_capabilities_v5` / `connack_receive_max_echo_v5` / `connack_assigned_client_id_v5` / `empty_clientid_cleanstart0_rejected` |
+| 发布/订阅 | `pubsub_v5_qos0/1/2` |
+| 会话 | `session_expiry_v5` / `takeover_v5` / `clean_start_v5` / `disconnect_expiry_zero` [MQTT-3.14.2-2] / `expiry_cleanup` |
+| V5 特性 | `flow_control_v5` / `no_local_v5` / `will_delay_v5` / `shared_sub_v5` / `topic_alias_v5`（服务端/客户端/未知别名→0x94）/ `retain_handling_*_v5` / `retain_as_published_v5` / `server_keepalive_v5` / `max_packet_size_v5`（+ 强制）/ `subscribe_identifiers_v5` / `payload_format_v5` / `publication_expiry_v5` / `request_response_v5` / `user_properties_v5` / `wildcard_available_v5` |
+| 保留消息 | `retain_v5_store_and_deliver` / `empty_payload_deletes` / `overwrite` / `live_message_not_retained` / `will` |
+| QoS 2 | `qos2_replayed_publish_dedup` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume` [MQTT-4.4.0-1] / `qos2_pubrel_resume_collision` |
+| 通配符 | `wildcard_v5_case_sensitive` / `leading_slash` |
+| 协议错误 | `protocol_error_v5_*`（订阅 QoS3、固定头 QoS、发布 QoS3/pid0/空主题、剩余长度、保留类型） |
+| 断开原因码 | `disconnect_reason_v5` |
+| Will Retain vs Retain Available | `will_retain_rejected_when_retain_unavailable_v5`（retainer 启用时跳过） |
 
 ### functional_v5_cluster（1 个用例）— 双节点集群端到端复现
 
@@ -152,10 +168,10 @@ rmqtt-test/
     main.rs                      # mqtt_harness 入口，套件注册
     broker/                      # Broker 生命周期管理
     mqtt/                        # 自研 MQTT 客户端（零第三方 MQTT 依赖）
-      v3/                        # MQTT 3.1 客户端（QoS 0）
+      v3/                        # MQTT 3.1 客户端（QoS 0/1/2，手工构造 MQIsdp CONNECT）
       v311/                      # MQTT 3.1.1 客户端（QoS 0/1/2）
       v5/                        # MQTT 5.0 客户端（QoS 0/1/2）
-    transport/                   # 网络传输层
+    transport/                   # 网络传输层（含 raw 字节发送，供负面测试使用）
     framework/                   # 测试框架（TestCase, DAG 调度器, 上下文）
     tests/                       # 测试用例（功能测试、压测、混沌测试）
       functional/                #   functional_v3/v311/v5 用例
@@ -165,6 +181,10 @@ rmqtt-test/
     pubrel-collision/            #   单机：启用 message-storage 的 broker 配置
     pubrel-collision-cluster/    #   集群：node1/node2 双节点配置（1884/1885 MQTT、5364/5365 gRPC）
 ```
+
+> **测试隔离说明**：所有发布保留消息的测试结束后会自行删除（空 payload + RETAIN=1）；
+> `#` 通配符测试会先排空残留保留消息并以轮询方式过滤自己的 payload，因此各套件可
+> 通过 `--workers N` 并发执行而不互相干扰。
 
 ## 📄 许可证
 

--- a/rmqtt-test/README.md
+++ b/rmqtt-test/README.md
@@ -72,39 +72,58 @@ The program will auto-locate `target/release/rmqttd` and start the broker.
 
 ## 📋 Test Suites
 
-### `functional_v3` (2 cases) — MQTT 3.1
+### `functional_v3` (47 cases) — MQTT 3.1
 
-| Case | Description |
-|------|-------------|
-| `connect_v3` | MQTT 3.1 connect/disconnect |
-| `pubsub_v3_qos0` | QoS 0 publish/subscribe |
+Spec-conformance suite for MQTT v3.1 (IBM MQIsdp), covering positive, negative
+and boundary scenarios:
 
-### `functional_v311` (10 cases) — MQTT 3.1.1
+| Category | Cases |
+|----------|-------|
+| Connect | `connect_v3` / `with_options` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `empty_clientid_cleansession0/1` / `long_client_id` / `client_id_max_length` |
+| Pub/Sub | `pubsub_v3_qos0/1/2` / `publish_v3_wildcard_reject` |
+| QoS 2 conformance | `qos2_replayed_publish_dedup_v3` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume_v3` [MQTT-4.4.0-1] |
+| Retained | `retain_v3_store_and_deliver` / `empty_payload_deletes` / `overwrite` / `live_message_not_retained` / `will` |
+| Last Will | `last_will_v3` / `clean` / `qos2` |
+| Keep alive | `keepalive_v3_ping` / `zero` / `timeout` |
+| Session | `session_v3_persistent` / `clean` / `offline_queue` |
+| Wildcard | `wildcard_v3_plus` / `hash` / `overlap` / `dollar_topics` / `case_sensitive` / `leading_slash` |
+| Boundary | `boundary_v3_empty_payload` / `large_payload` / `long_topic` / `special_chars_topic` / `max_keepalive` / `rapid_subscribe` |
+| Protocol errors | `protocol_error_v3_subscribe_qos3` / `publish_packet_id_zero` / `bad_remaining_length` / `empty_topic_filter` / `reserved_packet_type` / `subscribe_qos0_fixed_header` |
 
-| Case | Description |
-|------|-------------|
-| `connect_v311` | MQTT 3.1.1 connect/disconnect |
-| `connect_empty_client_id` | Empty Client ID connection (Clean Session) |
-| `multiple_connections` | 10 concurrent connections |
-| `pubsub_v311_qos0` | QoS 0 publish/subscribe |
-| `pubsub_v311_qos1` | QoS 1 publish/subscribe |
-| `pubsub_v311_qos2` | QoS 2 publish/subscribe (full 4-step handshake) |
-| `retain_v311_message` | Retained message storage and retrieval |
-| `unsubscribe_v311` | No message received after unsubscription |
-| `wildcard_plus` | Single-level wildcard `+` matching |
-| `wildcard_hash` | Multi-level wildcard `#` matching |
+> The v3.1 client hand-builds the MQIsdp CONNECT bytes (`build_connect_bytes`)
+> because the codec hard-codes protocol level 4 (correct for 3.1.1/5.0).
 
-### `functional_v5` (34 cases) — MQTT 5.0
+### `functional_v311` (64 cases) — MQTT 3.1.1
 
-| Case | Description |
-|------|-------------|
-| `connect_v5` / `connect_v5_reason_codes` | MQTT 5.0 connect / Reason Code verification |
-| `pubsub_v5_qos0/1/2` | MQTT 5.0 QoS 0/1/2 publish/subscribe |
-| `session_expiry_v5` / `session_takeover_v5` / `session_clean_start_v5` | Session expiry / takeover / Clean Start |
-| `qos2_replayed_publish_dedup` | [MQTT-4.3.3-10] replayed QoS 2 PUBLISH dedup (issue #456) |
-| `qos2_pubrel_resend_on_resume` | [MQTT-4.4.0-1] owed PUBREL resent on session resume (issue #456) |
-| `qos2_pubrel_resume_collision` | **PUBREL-resume packet-id collision (single-node regression test)** |
-| `flow_control_v5` / `no_local_v5` / `will_delay_v5` / `shared_sub_v5` / `topic_alias_v5` etc. | V5 feature coverage (see `src/tests/functional/`) |
+| Category | Cases |
+|----------|-------|
+| Connect | `connect_v311` / `empty_client_id` / `multiple_connections` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` [MQTT-3.1.0-2] / `long_client_id` |
+| Pub/Sub | `pubsub_v311_qos0/1/2` / `retain_v311_message` / `unsubscribe_v311` |
+| QoS 2 conformance | `qos2_replayed_publish_dedup_v311` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume_v311` [MQTT-4.4.0-1] / `qos2_duplicate_detection` |
+| Retained | `retain_v311_store_and_deliver` / `empty_payload_deletes` [MQTT-3.3.1-9] / `overwrite` / `live_message_not_retained` / `will` |
+| Last Will | `last_will_v311` / `clean` / `unclean` / `qos2` / `keepalive_timeout` |
+| Keep alive | `keepalive_v311_ping_keeps_alive` / `timeout` / `zero` / `max_value` |
+| Session | `clean_session_false` / `offline_queue_v311` / `present_on_resume` [MQTT-3.2.2.1] / `clean_discard` [MQTT-3.1.2-6] |
+| Wildcard | `wildcard_plus` / `hash` / `case_sensitive` / `leading_slash` / `hash_not_last` |
+| Auth / dollar / shared | `auth_empty_client_id_fail` / `auth_connect_disconnect_sequence` / `dollar_topics` / `shared_sub_v311` |
+| Boundary | `max_client_id` / `long_topic` / `empty_payload` / `large_payload` / `special_chars_topic` / `rapid_subscribe` |
+| Multi-topic | `multi_topic_subscribe_v311` / `overlapping_subscriptions` / `message_ordering` |
+| Protocol errors | `invalid_protocol_version` / `empty_topic_filter` / `protocol_error_v311_*` (subscribe qos3, fixed-header QoS, publish qos3/pid0, bad remaining length, reserved type) |
+
+### `functional_v5` (63 cases) — MQTT 5.0
+
+| Category | Cases |
+|----------|-------|
+| Connect / CONNACK | `connect_v5` / `reason_codes` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` / `client_id_too_long` / `auth_method_rejected` (0x8C) / `connack_capabilities_v5` / `connack_receive_max_echo_v5` / `connack_assigned_client_id_v5` / `empty_clientid_cleanstart0_rejected` |
+| Pub/Sub | `pubsub_v5_qos0/1/2` |
+| Session | `session_expiry_v5` / `takeover_v5` / `clean_start_v5` / `disconnect_expiry_zero` [MQTT-3.14.2-2] / `expiry_cleanup` |
+| V5 features | `flow_control_v5` / `no_local_v5` / `will_delay_v5` / `shared_sub_v5` / `topic_alias_v5` (server/client/unknown-alias → 0x94) / `retain_handling_*_v5` / `retain_as_published_v5` / `server_keepalive_v5` / `max_packet_size_v5` (+ enforcement) / `subscribe_identifiers_v5` / `payload_format_v5` / `publication_expiry_v5` / `request_response_v5` / `user_properties_v5` / `wildcard_available_v5` |
+| Retained | `retain_v5_store_and_deliver` / `empty_payload_deletes` / `overwrite` / `live_message_not_retained` / `will` |
+| QoS 2 | `qos2_replayed_publish_dedup` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume` [MQTT-4.4.0-1] / `qos2_pubrel_resume_collision` |
+| Wildcard | `wildcard_v5_case_sensitive` / `leading_slash` |
+| Protocol errors | `protocol_error_v5_*` (subscribe qos3, fixed-header QoS, publish qos3/pid0/empty-topic, bad remaining length, reserved type) |
+| Disconnect | `disconnect_reason_v5` |
+| Will Retain vs Retain Available | `will_retain_rejected_when_retain_unavailable_v5` (skipped when retainer is enabled) |
 
 ### `functional_v5_cluster` (1 case) — two-node cluster end-to-end reproduction
 
@@ -154,10 +173,10 @@ rmqtt-test/
     main.rs                      # mqtt_harness entry point, suite registration
     broker/                      # Broker lifecycle management
     mqtt/                        # Custom MQTT client (zero external MQTT deps)
-      v3/                        # MQTT 3.1 client (QoS 0)
+      v3/                        # MQTT 3.1 client (QoS 0/1/2, hand-built MQIsdp CONNECT)
       v311/                      # MQTT 3.1.1 client (QoS 0/1/2)
       v5/                        # MQTT 5.0 client (QoS 0/1/2)
-    transport/                   # Network transport layer
+    transport/                   # Network transport layer (incl. raw-byte send for negative tests)
     framework/                   # Test framework (TestCase, DAG scheduler, context)
     tests/                       # Test cases (functional, stress, chaos)
       functional/                #   functional_v3/v311/v5 cases
@@ -167,6 +186,11 @@ rmqtt-test/
     pubrel-collision/            #   single node: message-storage enabled broker config
     pubrel-collision-cluster/    #   cluster: node1/node2 configs (1884/1885 MQTT, 5364/5365 gRPC)
 ```
+
+> **Test isolation note**: all tests that publish retained messages delete them
+> afterwards (empty payload + RETAIN=1); `#` wildcard tests drain stale retained
+> messages and poll-filter their own payloads, so suites can run concurrently
+> (with `--workers N`) without cross-test interference.
 
 ## 📄 License
 


### PR DESCRIPTION
Update documentation to reflect the expanded MQTT v3/v3.1.1/v5 spec-conformance test suites (functional_v3: 47, functional_v311: 64, functional_v5: 63) after the test coverage additions in f47da52.

## Changed

- **`rmqtt-test/README.md` / `README-CN.md`**
  - Replace the outdated 2/10/34-case tables with full category-based case listings per suite (connect / pub-sub / QoS 2 conformance / retained / last will / keep alive / session / wildcard / boundary / protocol errors)
  - Update project structure: v3 client now documents full QoS 0/1/2 support and hand-built MQIsdp CONNECT; transport notes raw-byte send
  - Add a "Test isolation" note explaining retained-message self-cleanup and `#`-wildcard drain/filter so suites stay safe under concurrent workers

- **`docs/en_US/development/testing.md` / `docs/zh_CN/development/testing.md`**
  - Test Suite Reference table: sync case counts (2→47, 10→64, 5→63) and describe each suite's spec-coverage scope incl. normative clause refs (MQTT-3.1.0-2, 3.3.1-9, 3.2.2.1, 3.14.2-2, 0x8C/0x94 reason codes)

- **`docs/en_US/testing-report.md` / `docs/zh_CN/testing-report.md`**
  - Sync the integration-harness suite table to the same counts and scope

## Verification

Docs-only change; no code touched. `cargo check -p rmqtt-test` unaffected.