### PR TITLE
# feat(rmqtt-test): switch broker config per test case at suite boundaries

### DIFF
--- a/docs/en_US/development/getting-started.md
+++ b/docs/en_US/development/getting-started.md
@@ -199,6 +199,7 @@ cargo test
 
 # Run integration tests using the test harness
 cargo build -p rmqtt-test --release
+# Starts the broker with the self-contained config rmqtt-test/configs/default/rmqtt.toml
 ./target/release/mqtt_harness --workspace .
 ```
 

--- a/docs/en_US/development/testing.md
+++ b/docs/en_US/development/testing.md
@@ -96,7 +96,7 @@ cargo build -p rmqtt-test --release
 # Run all test suites (auto-starts broker)
 ./target/release/mqtt_harness --workspace .
 
-# Run specific suites
+# Run specific suites (--suites supports prefix matching, see below)
 ./target/release/mqtt_harness --workspace . --suites functional_v5
 ./target/release/mqtt_harness --workspace . --suites stress --suites chaos
 
@@ -106,6 +106,20 @@ cargo build -p rmqtt-test --release
 # Generate reports
 ./target/release/mqtt_harness --workspace . --json report.json --html report.html
 ```
+
+> **Broker config**: the harness uses the self-contained
+> `rmqtt-test/configs/default/rmqtt.toml` by default (independent from the
+> repository-root `rmqtt.toml` / `rmqtt-plugins/*.toml`; all TCP/TLS/WS/WSS/QUIC
+> listeners kept enabled). Test cases that need a different broker config
+> declare it via `TestCase::broker_config()`; at build time they are split into
+> `{suite}@{config}` sub-suites (e.g. `functional_v5@retain-disabled`), and the
+> scheduler restarts the broker to switch configs **only at suite boundaries**.
+> An explicit config can be given:
+>
+> ```bash
+> ./target/release/mqtt_harness --workspace . --config rmqtt-test/configs/retain-disabled/rmqtt.toml
+> ./target/release/mqtt_harness --workspace . --suites functional_v5@retain-disabled
+> ```
 
 ### Test Suite Reference
 
@@ -117,6 +131,13 @@ cargo build -p rmqtt-test --release
 | `stress` | 3 | Connection load (100 clients), publish QPS (1000 msgs), fan-out (1→N) |
 | `chaos` | 6 | Broker restart, connection churn, reconnect storm, QoS 1 reliability, slow consumer |
 
+> Of the 63 `functional_v5` cases, `will_retain_rejected_when_retain_unavailable_v5`
+> (requires the retainer plugin to be disabled) and `qos2_pubrel_resume_collision`
+> (requires message-storage) are automatically split into the
+> `functional_v5@retain-disabled` and `functional_v5@pubrel-collision`
+> sub-suites; the remaining 61 run in the default-config group
+> `functional_v5`. Config switches happen only at suite boundaries.
+
 ### Test Case Architecture
 
 Each test case implements the `TestCase` trait:
@@ -124,8 +145,9 @@ Each test case implements the `TestCase` trait:
 ```rust
 pub trait TestCase: Send + Sync {
     fn name(&self) -> &str;
-    fn suite(&self) -> &str;  // functional_v3, stress, etc.
     fn execute(&self, ctx: &mut TestContext) -> TestResult;
+    fn broker_config(&self) -> Option<PathBuf> { None } // required broker config (grouping hint)
+    // defaults: timeout() = 60s, max_retries() = 0, depends_on() = []
 }
 ```
 

--- a/docs/en_US/testing-report.md
+++ b/docs/en_US/testing-report.md
@@ -82,6 +82,13 @@ The `rmqtt-test` crate provides a custom test harness with additional test suite
 | `stress` | 3 | Connection load (100 clients), publish QPS (1000 msgs), fan-out (1→N) |
 | `chaos` | 6 | Broker restart, connection storms, reconnect, QoS 1 reliability, slow consumer |
 
+> Of the 63 `functional_v5` cases, `will_retain_rejected_when_retain_unavailable_v5`
+> and `qos2_pubrel_resume_collision` need different broker configs and are
+> automatically split into the `functional_v5@retain-disabled` /
+> `functional_v5@pubrel-collision` sub-suites. The default broker config is the
+> self-contained `rmqtt-test/configs/default/rmqtt.toml`; config switches
+> happen only at suite boundaries.
+
 ```bash
 # Run all test suites
 cargo build --release

--- a/docs/zh_CN/development/getting-started.md
+++ b/docs/zh_CN/development/getting-started.md
@@ -93,6 +93,7 @@ cargo test
 
 # 运行集成测试
 cargo build -p rmqtt-test --release
+# 默认使用自包含配置 rmqtt-test/configs/default/rmqtt.toml 启动 Broker
 ./target/release/mqtt_harness --workspace .
 ```
 

--- a/docs/zh_CN/development/rmqtt-test-config-switching.md
+++ b/docs/zh_CN/development/rmqtt-test-config-switching.md
@@ -1,0 +1,230 @@
+# rmqtt-test 按用例自动切换 Broker 配置
+
+> 本文档记录 rmqtt-test（`mqtt_harness`）单机测试框架的配置管理机制调整：
+> **每个用例 / 每组用例可以使用自己的 broker 配置文件**，且测试配置全部
+> **自包含**于 `rmqtt-test/configs/`，不再依赖仓库根的 `rmqtt.toml` 与
+> `rmqtt-plugins/*.toml`。
+
+---
+
+## 1. 背景与问题
+
+调整前，单机测试（非 `--no-broker` 模式）的行为：
+
+- `mqtt_harness` 启动 broker 时，仅当命令行给了 `--config` 才传 `-f <config>`，
+  否则 `rmqttd` 直接读取**仓库根 `rmqtt.toml`**；
+- 整个 harness 进程生命周期内只有**一套** broker 配置，配置只能"整批"指定。
+
+这导致两类用例无法在同一次默认全量运行中共存：
+
+| 用例 | 需要的配置 | 默认配置下的表现 |
+|------|-----------|-----------------|
+| `will_retain_rejected_when_retain_unavailable_v5`（issue #457） | 不加载 retainer 插件（`Retain Available = 0`） | 只能走 `NotApplicable` 分支被跳过 |
+| `qos2_pubrel_resume_collision` | 加载 message-storage 插件 | 无法复现存储消息重载场景 |
+
+**目标**：让用例声明自己需要的配置，框架在合适时机自动切换 broker 配置；
+同时让测试配置自包含，与开发环境配置彻底解耦。
+
+## 2. 方案总览
+
+- **纯 suite 级切换**：调度器只在 **suite 边界**重启 broker 切换配置，不做用例级运行时切换；
+- **构建期自动拆分**：声明了同一非默认配置的用例，在构建套件时自动拆分为独立的
+  `{suite}@{config}` 子套件，每个子套件内配置唯一；
+- **配置自包含**：默认配置与各测试配置都放在 `rmqtt-test/configs/<name>/`，
+  主配置 + 自身 `plugins/` 子目录，不依赖仓库根。
+
+## 3. 配置自包含（`configs/` 目录）
+
+```
+rmqtt-test/configs/
+  default/                  # 默认配置（未指定 --config 时使用）
+    rmqtt.toml              #   以仓库根 rmqtt.toml 为蓝本
+    plugins/                #   全部插件配置模板（26 个）
+  retain-disabled/          # 不加载 retainer 插件（Retain Available = 0）
+    rmqtt.toml
+    plugins/
+  pubrel-collision/         # 加载 message-storage（PUBREL 冲突复现）
+    rmqtt.toml
+    plugins/
+  pubrel-collision-cluster/ # 双节点集群（手动启动，1884/1885 MQTT）—— 不受本机制影响
+```
+
+### 3.1 `configs/default/rmqtt.toml` 与仓库根配置的差异
+
+| 配置项 | 仓库根值 | default 值 | 原因 |
+|---|---|---|---|
+| `plugins.dir` | `"rmqtt-plugins/"` | `"rmqtt-test/configs/default/plugins/"` | 自包含 |
+| `listener.tcp.external.addr` | `"0.0.0.0:1883"` | `"127.0.0.1:1883"` | 匹配 harness 默认 `--addr` |
+| `log.to` / `log.dir` | `"both"` / `/var/log/rmqtt` | `"console"` / `"."` | 测试环境避免写系统目录 |
+| `plugins.default_startups` | retainer / shared-subscription / http-api | **保持不变** | 默认插件集与仓库根一致 |
+
+**保留全部 TCP/TLS/WS/WSS/QUIC 监听**（用户明确要求，为后续 TLS/WS/QUIC 专项测试预留）。
+
+### 3.2 为什么 plugins/ 要放全部插件配置（重要）
+
+`rmqtt-http-api` 插件在 Cargo.toml metadata 中 `default_startup = true`（与
+`rmqtt-acl`、`rmqtt-counter` 一样会自动启动），且**强制要求存在配置文件**——
+缺失时 `rmqttd` 注册插件直接失败（release 版 panic，debug 版卡死）。而
+`rmqtt-acl` / `rmqtt-counter` 缺配置时仅 WARN 并使用默认值。
+
+因此每个 `configs/<name>/plugins/` 目录内**完整拷贝** `rmqtt-plugins/*.toml`
+（26 个文件）。多余文件不会被加载，但保证任何自动启动插件都能找到配置。
+
+## 4. 机制设计
+
+### 4.1 用例级配置声明（仅分组依据）
+
+`TestCase` trait 新增 `broker_config()`：
+
+```rust
+fn broker_config(&self) -> Option<PathBuf> { None }
+```
+
+- 返回 `None` → 使用 harness 默认配置（`--config` 或 `configs/default/rmqtt.toml`）；
+- 返回路径 → 该用例声明需要特定配置，仅作为**构建期分组依据**，调度器不做用例级切换。
+
+辅助函数 `tests::config_path(name)` 生成 `configs/<name>/rmqtt.toml` 的绝对路径
+（基于 `CARGO_MANIFEST_DIR`，与进程工作目录无关）。
+
+### 4.2 构建期自动拆分
+
+`TestSuite` 新增 `config: Option<PathBuf>` 字段；`split_suites_by_config()`
+（`src/framework/suite.rs`）在 `build_suites()` 之后统一执行：
+
+- suite 已有显式 `config`（如集群套件）→ 不拆分；
+- 否则按用例 `broker_config()` 分组（保持组内原始相对顺序）：
+  - 默认组保留原名（如 `functional_v5`），`config = 默认配置路径`；
+  - 特殊组生成 `{suite}@{config名}`（如 `functional_v5@retain-disabled`），
+    `config = 该配置路径`。
+
+拆分后**每个 suite 的 `config` 恒有值**，调度器只需在 suite 边界判断。
+
+### 4.3 Broker 进程配置切换
+
+`src/broker/lifecycle.rs`：
+
+```rust
+pub fn set_config(&mut self, config: Option<PathBuf>);            // 仅更新，不重启
+pub fn config_path(&self) -> Option<&PathBuf>;                    // 当前生效配置
+pub fn restart_with_config(&mut self, config: Option<PathBuf>);   // stop → 换配置 → start
+```
+
+`BrokerProcess::new(workspace)` 默认 `config_path` 指向
+`<workspace>/rmqtt-test/configs/default/rmqtt.toml`（**始终显式 `-f` 启动**，
+不再存在"无配置"路径）。
+
+### 4.4 TestContext 幂等切换
+
+```rust
+pub fn ensure_broker_config(&self, target: &Path) -> Result<(), anyhow::Error>
+```
+
+比较 `BrokerProcess::config_path()` 与 `target`，相同则跳过重启（幂等）；
+不同则 `restart_with_config` 并等待健康检查。`--no-broker` 模式下直接返回 `Ok`
+（由调度器负责告警）。
+
+### 4.5 调度器：suite 边界切换
+
+`src/framework/scheduler.rs` 的 `run()`：每个 suite 执行前，若
+`suite.config` 与当前生效配置不一致则切换：
+
+- 切换失败 → 该 suite 记为 `Error`（critical），跳过执行；
+- `--no-broker` → 忽略所有配置要求并 warn 一次。
+
+### 4.6 main.rs 流程与 CLI 匹配
+
+流程：`resolve_workspace()` → 解析默认配置 → 启动 broker → `build_suites()`
+→ `split_suites_by_config()` → `filter_suites()` → 运行。
+
+- **workspace 解析**：`--workspace` 显式值 → cwd 探测（有 `rmqtt.toml` 且
+  `rmqtt-test/configs/`）→ `CARGO_MANIFEST_DIR` 父目录（编译期仓库根）；
+- **默认配置**：`--config` 或 `<workspace>/rmqtt-test/configs/default/rmqtt.toml`，
+  不存在则报错退出；启动时打印生效配置路径；
+- **`--suites` 前缀匹配**（`should_run` 双向匹配 + `filter_suites` 单向前缀）：
+  - `functional_v5` → 同时命中 `functional_v5` 与 `functional_v5@retain-disabled` 等子套件；
+  - `functional_v5@retain-disabled` → 只跑该子套件（也会注册原套件）；
+  - `functional_v5_cluster` → 仅显式指定时运行，默认全量排除（行为保持）。
+
+## 5. 使用方式
+
+```bash
+# 默认全量运行（默认配置 = configs/default，自动切换特殊子套件）
+./target/release/mqtt_harness --workspace .
+
+# 显式指定整套配置
+./target/release/mqtt_harness --workspace . --config rmqtt-test/configs/retain-disabled/rmqtt.toml
+
+# 只跑某个配置子套件
+./target/release/mqtt_harness --workspace . --suites functional_v5@retain-disabled
+
+# 只跑默认配置组（不跑 @ 子套件）
+./target/release/mqtt_harness --workspace . --suites functional_v5
+```
+
+运行日志中可见拆分与切换过程：
+
+```
+split suite 'functional_v5' -> 'functional_v5' (61 tests, config: .../configs/default/rmqtt.toml)
+split suite 'functional_v5' -> 'functional_v5@retain-disabled' (1 tests, ...)
+split suite 'functional_v5' -> 'functional_v5@pubrel-collision' (1 tests, ...)
+Running suite: functional_v5 (61 tests)
+...
+switching broker config: ...default/rmqtt.toml -> ...retain-disabled/rmqtt.toml
+Broker is healthy at 127.0.0.1:1883
+Running suite: functional_v5@retain-disabled (1 tests)
+```
+
+## 6. 新增一个特殊配置目录的步骤
+
+1. 创建 `rmqtt-test/configs/<name>/rmqtt.toml`（以 `default/rmqtt.toml` 为蓝本，
+   修改 `plugins.default_startups` 与所需参数；监听端口保持 `127.0.0.1:1883`）；
+2. 创建 `rmqtt-test/configs/<name>/plugins/`，拷贝 `rmqtt-plugins/*.toml`（26 个）；
+3. 用例实现 `broker_config()` 返回 `Some(crate::tests::config_path("<name>"))`；
+4. 无需改动调度器——拆分与切换自动生效。
+
+## 7. 约束与注意事项
+
+- **端口一致性**：参与自动切换的配置，`listener.tcp.external.addr` 必须与
+  harness 的 `--addr`（默认 `127.0.0.1:1883`）一致，否则健康检查无法通过；
+- **重启成本**：一次配置切换 = 一次 broker 重启（约 1~2s + 健康检查轮询）。
+  默认全量运行只产生特殊配置组各 1 次切换，且每组只切一次、无需切回；
+- **状态隔离**：切换必然重启 → broker 内存状态清空，天然隔离；跨配置的用例
+  不应有依赖关系（DAG 依赖只在同一配置组内成立）；
+- **并行 suite**：配置切换只发生在 suite 边界，parallel suite 内不切换；
+- **`--no-broker` 模式**：无法切换配置，配置声明被忽略并告警一次；
+- **工作目录**：`plugins.dir` 是相对进程 cwd 解析的，harness 与 rmqttd 都
+  应从仓库根运行（`--workspace .`）。
+
+## 8. 涉及文件
+
+| 文件 | 改动 |
+|---|---|
+| `rmqtt-test/configs/default/rmqtt.toml` + `plugins/*` | 新增：自包含默认配置 |
+| `rmqtt-test/configs/retain-disabled/`、`pubrel-collision/` | `plugins.dir` 指向自身 plugins/ + 补齐插件配置 |
+| `src/broker/lifecycle.rs` | +`set_config` / `restart_with_config` / `config_path`；`new()` 默认配置 |
+| `src/framework/testcase.rs` | trait +`broker_config()` |
+| `src/framework/suite.rs` | +`config` 字段；+`split_suites_by_config()` |
+| `src/framework/context.rs` | +`ensure_broker_config()`（幂等） |
+| `src/framework/scheduler.rs` | suite 边界配置切换；失败记 Error；`--no-broker` 忽略 |
+| `src/main.rs` | workspace 解析、默认配置来源、build→split→filter、前缀匹配、失败路径 `drop(ctx)` 防泄漏 |
+| `src/tests/mod.rs` | +`config_path()` 辅助 |
+| `src/tests/functional/retain_unavailable_v5.rs` | 声明 `retain-disabled` |
+| `src/tests/functional/qos2_pubrel_resume_collision.rs` | 声明 `pubrel-collision` |
+
+## 9. 验证结果
+
+- `cargo build -p rmqtt-test` 零警告；`cargo test -p rmqtt-test`（21 个 CLI 测试）全过；
+- release 全量 `functional_v5`：**63/63 通过**（61 默认组 + 1@retain-disabled +
+  1@pubrel-collision），两次配置切换成功，`will_retain_rejected_when_retain_unavailable_v5`
+  真正执行（不再 skip）。
+
+## 10. 过程中发现并修复的问题
+
+1. **`rmqtt-http-api` 插件强制要求配置文件**（`default_startup=true` 且缺失即
+   启动失败）→ 自包含目录必须全量拷贝插件配置（见 3.2）；
+2. **失败路径进程泄漏**：`main.rs` 原用 `std::process::exit(1)` 直接退出，
+   **不执行 Drop**，导致 broker 子进程残留并占用端口（1883/6060/5363），
+   还会干扰后续运行的健康检查（误连旧进程造成"假失败"）。修复：`exit` 前
+   显式 `drop(ctx)`；
+3. **验证环境坑（Windows）**：Git Bash 中 `taskkill //F` 双斜杠转义失效，
+   杀不掉残留进程，需用 PowerShell `Stop-Process -Name rmqttd -Force`。

--- a/docs/zh_CN/development/testing.md
+++ b/docs/zh_CN/development/testing.md
@@ -68,7 +68,7 @@ cargo build -p rmqtt-test --release
 # 运行所有套件（自动启动 Broker）
 ./target/release/mqtt_harness --workspace .
 
-# 运行特定套件
+# 运行特定套件（--suites 支持前缀匹配，见下）
 ./target/release/mqtt_harness --workspace . --suites functional_v5
 
 # 连接到已运行的 Broker
@@ -77,6 +77,17 @@ cargo build -p rmqtt-test --release
 # 生成报告
 ./target/release/mqtt_harness --workspace . --json report.json --html report.html
 ```
+
+> **Broker 配置**：默认使用自包含配置 `rmqtt-test/configs/default/rmqtt.toml`
+> （不依赖仓库根的 `rmqtt.toml` / `rmqtt-plugins/*.toml`；保留 TCP/TLS/WS/WSS/QUIC
+> 全部监听）。需要特殊配置的用例通过 `TestCase::broker_config()` 声明，构建时自动
+> 拆分为 `{suite}@{config}` 子套件（如 `functional_v5@retain-disabled`），调度器仅在
+> **suite 边界**重启 broker 切换配置。可显式指定配置：
+>
+> ```bash
+> ./target/release/mqtt_harness --workspace . --config rmqtt-test/configs/retain-disabled/rmqtt.toml
+> ./target/release/mqtt_harness --workspace . --suites functional_v5@retain-disabled
+> ```
 
 ### 测试套件参考
 
@@ -87,6 +98,12 @@ cargo build -p rmqtt-test --release
 | `functional_v5` | 63 | MQTT 5.0 规范符合性：CONNACK 能力通告、会话过期（含 DISCONNECT SEI=0 [MQTT-3.14.2-2]）、主题别名（含未知别名→0x94）、流控、最大报文大小、订阅标识符、Retain Handling、Will 延迟、增强认证拒绝（0x8C）、协议错误 |
 | `stress` | 3 | 连接负载（100 客户端）、发布 QPS（1000 条）、扇出（1→N） |
 | `chaos` | 6 | Broker 重启、连接抖动、重连风暴、QoS 1 可靠性、慢消费者 |
+
+> functional_v5 的 63 个用例中，`will_retain_rejected_when_retain_unavailable_v5`
+> （需不加载 retainer 插件）与 `qos2_pubrel_resume_collision`（需加载
+> message-storage 插件）会自动拆分为 `functional_v5@retain-disabled` 与
+> `functional_v5@pubrel-collision` 两个子套件，其余 61 个在默认配置组
+> `functional_v5` 中运行；配置切换仅发生在 suite 边界。
 
 ---
 
@@ -133,6 +150,8 @@ mod tests {
 ### 添加集成测试用例
 
 实现 `TestCase` trait 并在测试入口注册。详情见 [rmqtt-test](../../../rmqtt-test/README-CN.md)。
+需要特殊 broker 配置的用例通过 `broker_config()` 声明，机制说明见
+[rmqtt-test 按用例自动切换 Broker 配置](./rmqtt-test-config-switching.md)。
 
 ---
 

--- a/docs/zh_CN/testing-report.md
+++ b/docs/zh_CN/testing-report.md
@@ -82,6 +82,12 @@ cd paho.mqtt.testing/interoperability
 | `stress` | 3 | 连接负载、发布 QPS、扇出测试 |
 | `chaos` | 6 | Broker 重启、连接风暴、重连、QoS 1 可靠性、慢消费者 |
 
+> functional_v5 的 63 个用例中，`will_retain_rejected_when_retain_unavailable_v5`
+> 与 `qos2_pubrel_resume_collision` 因需要不同的 broker 配置，自动拆分为
+> `functional_v5@retain-disabled` / `functional_v5@pubrel-collision` 子套件；
+> 默认 broker 配置为自包含的 `rmqtt-test/configs/default/rmqtt.toml`，
+> 配置切换仅发生在 suite 边界。
+
 ```bash
 # 运行所有测试套件
 cargo build --release

--- a/rmqtt-test/README-CN.md
+++ b/rmqtt-test/README-CN.md
@@ -36,7 +36,20 @@ cargo build -p rmqtt-test --release
 ./target/release/mqtt_harness --workspace .
 ```
 
-程序会自动查找 `target/release/rmqttd` 并启动 Broker。
+程序会自动查找 `target/release/rmqttd` 并启动 Broker，**默认使用自包含配置
+`rmqtt-test/configs/default/rmqtt.toml`**（不依赖仓库根的 `rmqtt.toml` /
+`rmqtt-plugins/*.toml`；保留 TCP/TLS/WS/WSS/QUIC 全部监听，便于后续添加
+TLS/WS/QUIC 专项测试）。
+
+### 使用其他 Broker 配置
+
+```bash
+# 显式指定配置文件（整批测试共用）
+./target/release/mqtt_harness --workspace . --config rmqtt-test/configs/retain-disabled/rmqtt.toml
+
+# 仅运行某个按配置拆分的子套件
+./target/release/mqtt_harness --workspace . --suites functional_v5@retain-disabled
+```
 
 ### 连接已运行的 Broker
 
@@ -67,6 +80,35 @@ cargo build -p rmqtt-test --release
 # 多个套件（可多次使用 --suites 参数）
 ./target/release/mqtt_harness --workspace . --suites functional_v3 --suites functional_v311
 ```
+
+> `--suites` 支持前缀匹配：`functional_v5` 会同时命中其按配置拆出的所有子套件
+> （如 `functional_v5@retain-disabled`）；`functional_v5_cluster` 双节点集群套件
+> 仅当显式指定时才运行，不参与默认全量。
+
+## ⚙️ Broker 配置（configs/ 自包含约定）
+
+所有测试用 broker 配置均位于 `rmqtt-test/configs/<name>/`，**自包含**（主配置 +
+自身 `plugins/` 子目录），不依赖仓库根的 `rmqtt.toml` / `rmqtt-plugins/*.toml`：
+
+```
+configs/
+  default/                  # 默认配置（未指定 --config 时使用）
+    rmqtt.toml              #   以仓库根 rmqtt.toml 为蓝本，保留全部 listener
+    plugins/                #   retainer / shared-subscription / http-api
+  retain-disabled/          # 不加载 retainer 插件（Retain Available = 0）
+  pubrel-collision/         # 加载 message-storage（PUBREL 冲突复现）
+  pubrel-collision-cluster/ # 双节点集群（手动启动，1884/1885 MQTT）
+```
+
+**按用例自动切换配置**：用例可通过 `TestCase::broker_config()` 声明所需配置
+（如 `WillRetainRejectedWhenRetainUnavailableV5Test` 声明 `retain-disabled`、
+`Qos2PubrelResumeCollisionTest` 声明 `pubrel-collision`）。构建套件时，
+声明了同一配置的用例会被自动拆分为独立的 `{suite}@{config}` 子套件
+（如 `functional_v5@retain-disabled`），调度器仅在 **suite 边界**切换配置
+（重启 broker），默认配置组保持原名不变、零额外重启开销。
+
+端口约束：参与自动切换的配置，`listener.tcp.external.addr` 必须与 harness 的
+`--addr`（默认 `127.0.0.1:1883`）一致，否则健康检查无法通过。
 
 ## 📋 测试套件
 
@@ -119,7 +161,12 @@ cargo build -p rmqtt-test --release
 | 通配符 | `wildcard_v5_case_sensitive` / `leading_slash` |
 | 协议错误 | `protocol_error_v5_*`（订阅 QoS3、固定头 QoS、发布 QoS3/pid0/空主题、剩余长度、保留类型） |
 | 断开原因码 | `disconnect_reason_v5` |
-| Will Retain vs Retain Available | `will_retain_rejected_when_retain_unavailable_v5`（retainer 启用时跳过） |
+| Will Retain vs Retain Available | `will_retain_rejected_when_retain_unavailable_v5`（在 `functional_v5@retain-disabled` 子套件中真正执行） |
+
+> functional_v5 共 63 个用例：默认配置组运行其中 61 个；
+> `will_retain_rejected_when_retain_unavailable_v5` 与 `qos2_pubrel_resume_collision`
+> 因需要不同的 broker 配置，构建时自动拆分为 `functional_v5@retain-disabled` 与
+> `functional_v5@pubrel-collision` 两个子套件执行（见上方「Broker 配置」章节）。
 
 ### functional_v5_cluster（1 个用例）— 双节点集群端到端复现
 
@@ -177,7 +224,9 @@ rmqtt-test/
       functional/                #   functional_v3/v311/v5 用例
       functional/qos2_pubrel_resume_collision_cluster.rs  # 集群复现用例
     report/                      # 报告系统（控制台、JSON、HTML、详细日志）
-  configs/                       # 测试用 broker 配置
+  configs/                       # 测试用 broker 配置（全部自包含）
+    default/                     #   默认配置：rmqtt.toml + plugins/（retainer/shared-subscription/http-api）
+    retain-disabled/             #   不加载 retainer 插件（Retain Available = 0）
     pubrel-collision/            #   单机：启用 message-storage 的 broker 配置
     pubrel-collision-cluster/    #   集群：node1/node2 双节点配置（1884/1885 MQTT、5364/5365 gRPC）
 ```

--- a/rmqtt-test/README.md
+++ b/rmqtt-test/README.md
@@ -39,6 +39,20 @@ Artifact located at `target/release/mqtt_harness` (`mqtt_harness.exe` on Windows
 ```
 
 The program will auto-locate `target/release/rmqttd` and start the broker.
+By default it uses the **self-contained config**
+`rmqtt-test/configs/default/rmqtt.toml` (independent from the repository-root
+`rmqtt.toml` / `rmqtt-plugins/*.toml`; all TCP/TLS/WS/WSS/QUIC listeners are
+kept enabled for the upcoming TLS/WS/QUIC test suites).
+
+### Use a Different Broker Config
+
+```bash
+# Explicit config for the whole run
+./target/release/mqtt_harness --workspace . --config rmqtt-test/configs/retain-disabled/rmqtt.toml
+
+# Run only one config-split sub-suite
+./target/release/mqtt_harness --workspace . --suites functional_v5@retain-disabled
+```
 
 ### Connect to a Running Broker
 
@@ -69,6 +83,39 @@ The program will auto-locate `target/release/rmqttd` and start the broker.
 # Multiple suites
 ./target/release/mqtt_harness --workspace . --suites functional_v3 --suites functional_v311
 ```
+
+> `--suites` supports prefix matching: `functional_v5` also selects every
+> config-split sub-suite (e.g. `functional_v5@retain-disabled`). The
+> `functional_v5_cluster` two-node suite only runs when explicitly requested
+> and is never part of the default full run.
+
+## ⚙️ Broker Configs (self-contained `configs/`)
+
+All test broker configs live under `rmqtt-test/configs/<name>/` and are
+**self-contained** (main config + own `plugins/` sub-dir), independent from
+the repository-root `rmqtt.toml` / `rmqtt-plugins/*.toml`:
+
+```
+configs/
+  default/                  # default config (used when --config is omitted)
+    rmqtt.toml              #   based on the repo-root config, all listeners kept
+    plugins/                #   retainer / shared-subscription / http-api
+  retain-disabled/          # retainer plugin NOT loaded (Retain Available = 0)
+  pubrel-collision/         # message-storage loaded (PUBREL collision repro)
+  pubrel-collision-cluster/ # two-node cluster (manual start, 1884/1885 MQTT)
+```
+
+**Per-test config switching**: a test case can declare its required config via
+`TestCase::broker_config()` (e.g. `WillRetainRejectedWhenRetainUnavailableV5Test`
+→ `retain-disabled`, `Qos2PubrelResumeCollisionTest` → `pubrel-collision`).
+At suite build time, cases declaring the same non-default config are split
+into a dedicated `{suite}@{config}` sub-suite (e.g.
+`functional_v5@retain-disabled`); the scheduler switches the broker config
+(restart) only at **suite boundaries**, and the default-config group keeps
+its original name with zero extra restarts.
+
+Port constraint: configs participating in auto-switching must listen on the
+harness `--addr` (default `127.0.0.1:1883`), otherwise the health check fails.
 
 ## 📋 Test Suites
 
@@ -123,7 +170,14 @@ and boundary scenarios:
 | Wildcard | `wildcard_v5_case_sensitive` / `leading_slash` |
 | Protocol errors | `protocol_error_v5_*` (subscribe qos3, fixed-header QoS, publish qos3/pid0/empty-topic, bad remaining length, reserved type) |
 | Disconnect | `disconnect_reason_v5` |
-| Will Retain vs Retain Available | `will_retain_rejected_when_retain_unavailable_v5` (skipped when retainer is enabled) |
+| Will Retain vs Retain Available | `will_retain_rejected_when_retain_unavailable_v5` (executed in the `functional_v5@retain-disabled` sub-suite) |
+
+> `functional_v5` totals 63 cases: the default-config group runs 61 of them;
+> `will_retain_rejected_when_retain_unavailable_v5` and
+> `qos2_pubrel_resume_collision` require different broker configs and are
+> automatically split into the `functional_v5@retain-disabled` and
+> `functional_v5@pubrel-collision` sub-suites at build time (see the
+> "Broker Configs" section above).
 
 ### `functional_v5_cluster` (1 case) — two-node cluster end-to-end reproduction
 
@@ -182,7 +236,9 @@ rmqtt-test/
       functional/                #   functional_v3/v311/v5 cases
       functional/qos2_pubrel_resume_collision_cluster.rs  # cluster reproduction case
     report/                      # Report system (console, JSON, HTML, detail log)
-  configs/                       # Test broker configs
+  configs/                       # Test broker configs (all self-contained)
+    default/                     #   default config: rmqtt.toml + plugins/ (retainer/shared-subscription/http-api)
+    retain-disabled/             #   retainer plugin NOT loaded (Retain Available = 0)
     pubrel-collision/            #   single node: message-storage enabled broker config
     pubrel-collision-cluster/    #   cluster: node1/node2 configs (1884/1885 MQTT, 5364/5365 gRPC)
 ```

--- a/rmqtt-test/configs/default/plugins/Cargo.toml
+++ b/rmqtt-test/configs/default/plugins/Cargo.toml
@@ -1,0 +1,138 @@
+[package]
+name = "rmqtt-plugins"
+version.workspace = true
+description = "Plugin collection for rmqtt, providing authentication, storage, bridges, clustering, and other extensions."
+repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins"
+edition.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = []
+full = [
+    "retainer-ram",
+    "retainer-sled",
+    "retainer-redis",
+
+    "message-storage-ram",
+    "message-storage-redis",
+    "message-storage-redis-cluster",
+
+    "session-storage-sled",
+    "session-storage-redis",
+    "session-storage-redis-cluster",
+
+    "acl",
+    "http-api",
+    "counter",
+    "auth-http",
+    "auth-jwt",
+    "auto-subscription",
+
+    "bridge-egress-kafka",
+    "bridge-ingress-kafka",
+    "bridge-egress-mqtt",
+    "bridge-ingress-mqtt",
+    "bridge-egress-pulsar",
+    "bridge-ingress-pulsar",
+    "bridge-ingress-nats",
+    "bridge-egress-nats",
+    "bridge-egress-reductstore",
+    "bridge-origin",
+
+    "p2p-messaging",
+
+    "shared-subscription",
+
+    "sys-topic",
+    "topic-rewrite",
+    "web-hook",
+
+    "cluster-raft",
+    "cluster-broadcast",
+]
+
+# ---- storage sub-features ----
+retainer-ram = ["rmqtt-retainer/ram"]
+retainer-sled = ["rmqtt-retainer/sled"]
+retainer-redis = ["rmqtt-retainer/redis"]
+retainer = ["retainer-ram", "retainer-sled", "retainer-redis"]
+
+message-storage-ram = ["rmqtt-message-storage/ram"]
+message-storage-redis = ["rmqtt-message-storage/redis"]
+message-storage-redis-cluster = ["rmqtt-message-storage/redis-cluster"]
+message-storage = ["message-storage-ram", "message-storage-redis", "message-storage-redis-cluster"]
+
+session-storage-sled = ["rmqtt-session-storage/sled"]
+session-storage-redis = ["rmqtt-session-storage/redis"]
+session-storage-redis-cluster = ["rmqtt-session-storage/redis-cluster"]
+session-storage = ["session-storage-sled", "session-storage-redis", "session-storage-redis-cluster"]
+
+# ---- http-api sub-features ----
+http-api-sled = ["rmqtt-http-api/sled"]
+http-api-redis = ["rmqtt-http-api/redis"]
+http-api-redis-cluster = ["http-api-redis", "rmqtt-http-api/redis-cluster"]
+http-api-redb = ["rmqtt-http-api/redb"]
+http-api = ["http-api-sled", "http-api-redis", "http-api-redis-cluster", "http-api-redb"]
+
+# ---- core plugins ----
+acl = ["rmqtt-acl"]
+counter = ["rmqtt-counter"]
+auth-http = ["rmqtt-auth-http"]
+auth-jwt = ["rmqtt-auth-jwt"]
+auto-subscription = ["rmqtt-auto-subscription"]
+
+# ---- bridge plugins ----
+bridge-egress-kafka = ["rmqtt-bridge-egress-kafka"]
+bridge-ingress-kafka = ["rmqtt-bridge-ingress-kafka"]
+bridge-egress-mqtt = ["rmqtt-bridge-egress-mqtt"]
+bridge-ingress-mqtt = ["rmqtt-bridge-ingress-mqtt"]
+bridge-egress-pulsar = ["rmqtt-bridge-egress-pulsar"]
+bridge-ingress-pulsar = ["rmqtt-bridge-ingress-pulsar"]
+bridge-ingress-nats = ["rmqtt-bridge-ingress-nats"]
+bridge-egress-nats = ["rmqtt-bridge-egress-nats"]
+bridge-egress-reductstore = ["rmqtt-bridge-egress-reductstore"]
+bridge-origin = ["rmqtt-bridge-origin"]
+
+# ---- other plugins ----
+shared-subscription = ["rmqtt-shared-subscription"]
+sys-topic = ["rmqtt-sys-topic"]
+topic-rewrite = ["rmqtt-topic-rewrite"]
+web-hook = ["rmqtt-web-hook"]
+p2p-messaging = ["rmqtt-p2p-messaging"]
+
+# ---- cluster plugins ----
+cluster-raft = ["rmqtt-cluster-raft"]
+cluster-broadcast = ["rmqtt-cluster-broadcast"]
+
+[dependencies]
+rmqtt-acl = { workspace = true, optional = true }
+rmqtt-retainer = { workspace = true, optional = true }
+rmqtt-http-api = { workspace = true, optional = true }
+rmqtt-counter = { workspace = true, optional = true }
+rmqtt-auth-http = { workspace = true, optional = true }
+rmqtt-auth-jwt = { workspace = true, optional = true }
+rmqtt-auto-subscription = { workspace = true, optional = true }
+rmqtt-bridge-egress-kafka = { workspace = true, optional = true }
+rmqtt-bridge-ingress-kafka = { workspace = true, optional = true }
+rmqtt-bridge-egress-mqtt = { workspace = true, optional = true }
+rmqtt-bridge-ingress-mqtt = { workspace = true, optional = true }
+rmqtt-bridge-egress-pulsar = { workspace = true, optional = true }
+rmqtt-bridge-ingress-pulsar = { workspace = true, optional = true }
+rmqtt-bridge-ingress-nats = { workspace = true, optional = true }
+rmqtt-bridge-egress-nats = { workspace = true, optional = true }
+rmqtt-bridge-egress-reductstore = { workspace = true, optional = true }
+rmqtt-bridge-origin = { workspace = true, optional = true }
+rmqtt-message-storage = { workspace = true, optional = true }
+rmqtt-session-storage = { workspace = true, optional = true }
+rmqtt-sys-topic = { workspace = true, optional = true }
+rmqtt-shared-subscription = { workspace = true, optional = true }
+rmqtt-topic-rewrite = { workspace = true, optional = true }
+rmqtt-web-hook = { workspace = true, optional = true }
+rmqtt-cluster-raft = { workspace = true, optional = true }
+rmqtt-cluster-broadcast = { workspace = true, optional = true }
+rmqtt-p2p-messaging = { workspace = true, optional = true }

--- a/rmqtt-test/configs/default/plugins/rmqtt-acl.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-acl.toml
@@ -1,0 +1,18 @@
+##--------------------------------------------------------------------
+## rmqtt-acl
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/acl.md
+
+#Disconnect if publishing is rejected
+disconnect_if_pub_rejected = true
+
+rules = [
+    #["deny", "all", "subscribe", ["test/nosubscribe"]],
+    ["allow", { user = "dashboard" }, "subscribe", ["$SYS/#"]],
+    ["allow", { ipaddr = "127.0.0.1" }, "pubsub", ["$SYS/#", "#"]],
+    ["deny", "all", "subscribe", ["$SYS/#", { eq = "#" }]],
+    ["allow", "all"]
+    #["deny", "all"]
+]
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-auth-http.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-auth-http.toml
@@ -1,0 +1,71 @@
+##--------------------------------------------------------------------
+## rmqtt-auth-http
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auth-http.md
+
+http_timeout = "5s"
+http_headers.accept = "*/*"
+http_headers.Cache-Control = "no-cache"
+http_headers.User-Agent = "RMQTT/0.15.0"
+http_headers.Connection = "keep-alive"
+
+## Disconnect if publishing is rejected
+##
+## Value: true | false
+## Default: true
+disconnect_if_pub_rejected = true
+
+## Disconnect After Expiration
+##
+## Value: true | false
+## Default: false
+disconnect_if_expiry = false
+
+## Return 'Deny' if http request error otherwise 'Ignore'
+##
+## Value: true | false
+## Default: true
+deny_if_error = true
+
+
+##--------------------------------------------------------------------
+## Authentication request.
+##
+## Variables:
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %P: password
+##
+## Value: URL
+http_auth_req.url = "http://127.0.0.1:9090/mqtt/auth"
+## Value: post | get | put
+http_auth_req.method = "post"
+## HTTP request header of authentication request
+## Content-Type Currently supported values: application/x-www-form-urlencoded, application/json
+http_auth_req.headers = { content-type = "application/x-www-form-urlencoded" }
+#http_auth_req.headers.content-type="application/json"
+## Value: Params
+http_auth_req.params = { clientid = "%c", username = "%u", password = "%P", protocol = "%r" }
+
+
+##--------------------------------------------------------------------
+## ACL request.
+##
+## Variables:
+##  - %A: 1 | 2, 1 = sub, 2 = pub
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %t: topic
+##
+## Value: URL
+http_acl_req.url = "http://127.0.0.1:9090/mqtt/acl"
+## Value: post | get | put
+http_acl_req.method = "post"
+## Value: Params
+http_acl_req.params = { access = "%A", username = "%u", clientid = "%c", ipaddr = "%a", topic = "%t", protocol = "%r" }
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-auth-jwt.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-auth-jwt.toml
@@ -1,0 +1,79 @@
+##--------------------------------------------------------------------
+## rmqtt-auth-jwt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auth-jwt.md
+# Generate a test JWT. See https://jwt.io/#debugger-io
+
+## Disconnect if publishing is rejected
+##
+## Value: true | false
+## Default: true
+disconnect_if_pub_rejected = true
+
+## Disconnect After Expiration
+##
+## Value: true | false
+## Default: false
+disconnect_if_expiry = false
+
+## From where the JWT string can be got
+## Value: username | password
+## Default: password
+from = "password"
+
+## Encryption method
+## Value: hmac-based | public-key
+## Default: hmac-based
+encrypt = "hmac-based"
+
+## HMAC Hash Secret.
+##
+## Value: String
+hmac_secret = "rmqttsecret"
+#hmac_secret = "cm1xdHRzZWNyZXQ="
+
+## Secret Base64 Encode
+##
+## Value: true | false
+## Default: false
+hmac_base64 = false
+
+## RSA or ECDSA public key file.
+##
+## Value: File
+#public_key = "./rmqtt-bin/jwt_public_key_rsa.pem"
+#public_key = "./rmqtt-bin/jwt_public_key_es256.pem"
+#public_key = "./rmqtt-bin/jwt_public_key_es384.pem"
+
+
+## The checklist of claims to validate
+##
+## Value: String
+## validate_claims.$name = expected
+##
+## Placeholder:
+##  - ${username}: username
+##  - ${clientid}: clientid
+##  - ${ipaddr}: client ip addr
+##  - ${protocol}: MQTT protocol version: 3 = 3.1, 4 = 3.1.1, or 5 = 5.0
+
+### Basic Validation
+## > Validate the token's expiration by comparing the exp claim to the current UTC time.
+validate_claims.exp = true
+## < Ensure the token is not used before its nbf claim.
+#validate_claims.nbf = true
+## Ensure the token's subject (sub claim) is as expected.
+#validate_claims.sub = "user@rmqtt.com"
+## Validate the token's issuer by comparing the iss claim to the known issuer.
+#validate_claims.iss = ["https://rmqtt.com1", "https://rmqtt.com"]
+## Verify that the token's audience (aud claim) matches the intended recipient.
+#validate_claims.aud = ["https://your-api.com", "mobile_app", "web_app"]
+
+### Extended Validation
+#validate_claims.clientid = "${clientid}"
+#validate_claims.username = "${username}"
+#validate_claims.ipaddr = "${ipaddr}"
+#validate_claims.protocol = "${protocol}"
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-auto-subscription.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-auto-subscription.toml
@@ -1,0 +1,14 @@
+##--------------------------------------------------------------------
+## rmqtt-auto-subscription
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auto-subscription.md
+
+# Expressions can use ${clientid} to represent the client ID and ${username} to represent the client username.
+
+subscribes = [
+    { topic_filter = "x/+/#", qos = 1, no_local = false, retain_as_published = false, retain_handling = 0 },
+    { topic_filter = "foo/${clientid}/#", qos = 1, no_local = false, retain_as_published = false, retain_handling = 0 },
+    { topic_filter = "iot/${username}/#", qos = 1 }
+]
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-kafka.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-kafka.toml
@@ -1,0 +1,48 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-kafka
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-kafka.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_kafka_1"
+
+# The list of broker (server) addresses for the Kafka cluster.
+#servers = "127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094"
+servers = "127.0.0.1:9092"
+# client.id
+client_id_prefix = "kafka_001"
+
+# Maximum limit of clients connected to the remote kafka broker
+concurrent_client_limit = 3
+
+# See more properties and their definitions at https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+[bridges.properties]
+"message.timeout.ms" = "5000"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "remote-topic1-egress-${local.topic}"
+#The queue_timeout parameter controls how long to retry for if the librdkafka producer queue is full. 0 to never block.
+remote.queue_timeout = "0m"
+#Sets the destination partition of the record.
+#remote.partition = 0
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "remote-topic2-egress"
+#remote.queue_timeout = "0m"
+#remote.partition = 0
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-mqtt.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-mqtt.toml
@@ -1,0 +1,161 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-mqtt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-mqtt.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_1"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+#username = "${ENV:MQTT_USER}"
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+#password = "${ENV:MQTT_PASS}"
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+# Specifies the maximum number of messages that the channel can hold simultaneously.
+message_channel_capacity = 100_000
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v5"
+
+# The following configurations are specific to the protocol version
+# Clear session state
+v4.clean_session = true
+# Last will message configuration, optional
+# Message encoding method, supports plain and base64, default: plain
+v4.last_will = {qos = 0, retain = false, topic = "a/b/c", message = "message content", encoding = "plain"}
+# Or
+# Clear session state on connection
+v5.clean_start = true
+# Session expiry interval, 0 means the session will end immediately upon network disconnection
+v5.session_expiry_interval = "0s"
+# Limit the maximum number of QoS 1 and QoS 2 messages the client can handle simultaneously
+v5.receive_maximum = 16
+# Negotiate the maximum packet size with the client and server
+v5.maximum_packet_size = "1M"
+# Negotiate the maximum number of topic aliases with the client and server
+v5.topic_alias_maximum = 0
+# Last will message configuration, optional
+v5.last_will = {qos = 0, retain = false, topic = "a/b/c", message = "message content", encoding = "plain"}
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/${local.topic}"
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/a"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/a/${local.topic}"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/a/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/a/a/${local.topic}"
+
+
+#-----------------------------------------------------------
+[[bridges]]
+# Whether to enable
+enable = false
+# Bridge name
+name = "bridge_name_2"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v4"
+
+# The following configurations are specific to the protocol version
+# Clear session state
+v4.clean_session = true
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+#remote.qos = 1
+# true/false, default: false
+#remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic2/egress/${local.topic}"
+
+
+
+
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-nats.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-nats.toml
@@ -1,0 +1,58 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-nats
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-nats.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_nats_1"
+# The address of the NATS broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 4222.
+servers = "nats://127.0.0.1:4222"
+#servers = "tls://127.0.0.1:4433"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+## See https://github.com/nats-io/nats.rs/blob/main/async-nats/src/options.rs
+#no_echo = true
+#ping_interval = "60s"
+#connection_timeout = "10s"
+#tls_required = true
+#tls_first = true
+#root_certificates = ""
+#client_cert = ""
+#client_key = ""
+#sender_capacity = 256
+#auth.jwt = ""
+#auth.jwt_seed = ""
+#auth.nkey = ""
+#auth.username = ""
+#auth.password = ""
+#auth.token = ""
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "test1"
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+#remote.forward_all_from = true
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+#remote.forward_all_publish = true
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "test2"
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-pulsar.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-pulsar.toml
@@ -1,0 +1,80 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-pulsar
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-pulsar.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_pulsar_1"
+# The address of the Pulsar broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 6650.
+servers = "pulsar://127.0.0.1:6650"
+# The address of the Pulsar broker that the client would connect to using SSL/TLS.
+# Uncomment this line to enable a secure connection to the local broker at port 6651.
+#servers = "pulsar+ssl://127.0.0.1:6651"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+# add a custom certificate chain from a file to authenticate the server in TLS connections
+#cert_chain_file = "./rmqtt-bin/rmqtt.fullchain.pem"
+#allow insecure TLS connection if set to true, defaults to false
+#allow_insecure_connection = false
+#whether hostname verification is enabled when insecure TLS connection is allowed, defaults to true
+#tls_hostname_verification_enabled = true
+
+#token(JWT, Biscuit)/ or oauth2
+#auth.name = "token"
+#auth.data = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiZXhwIjoxNjI2NzY5MjAwLCJpYXQiOjE2MjY3NjU2MDB9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+#auth.name = "oauth2"
+#auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "non-persistent://public/default/test1"
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+#remote.forward_all_from = false
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+#remote.forward_all_publish = false
+
+#determines the target partition of the message. Messages with the same partition_key will be sent to the same partition.
+#remote.partition_key = ""
+
+#this affects the order of messages within a specific partition, not across partitions. If messages have the same ordering_key, they will be consumed in the order they were sent.
+#Values: clientid, uuid, random or {type="random", len=10}
+# clientid - use mqtt clientid
+# uuid - uuid
+# random - randomly generated
+#remote.ordering_key = "clientid"
+#remote.ordering_key = {type="random", len=10}
+
+#Override namespace's replication
+#remote.replicate_to = []
+
+#current version of the schema
+#remote.schema_version = ""
+
+#user defined properties added to all messages
+#remote.options.metadata = {}
+#algorithm used to compress the messages, value: lz4,zlib,zstd,snappy
+#remote.options.compression = "lz4"
+#producer access mode: shared = 0, exclusive = 1, waitforexclusive = 2, exclusivewithoutfencing = 3
+#remote.options.access_mode = 0
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "non-persistent://public/default/test2"
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-reductstore.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-egress-reductstore.toml
@@ -1,0 +1,59 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-reductstore
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-reductstore.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_reductstore_1"
+# The address of the reductstore broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 8383.
+servers = "http://127.0.0.1:8383"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+# Set the API token to use for authentication.
+#api_token = ""
+# Set the timeout for HTTP requests.
+#timeout = "15s"
+# Set the SSL verification to false.
+#verify_ssl = false
+
+[[bridges.entries]]
+# Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+# The name of the bucket
+remote.bucket = "bucket1"
+remote.entry = "test1"
+# Set the quota size.
+remote.quota_size = 1_000_000_000
+# Don't fail if the bucket already exists.
+remote.exist_ok = true
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+remote.forward_all_from = true
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+remote.forward_all_publish = true
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+# Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.bucket = "bucket2"
+remote.entry = "test2"
+# Set the quota size.
+remote.quota_size = 1_000_000_000
+# Don't fail if the bucket already exists.
+remote.exist_ok = true
+
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -1,0 +1,58 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-kafka
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-kafka.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_kafka_1"
+
+# The list of broker (server) addresses for the Kafka cluster.
+#servers = "127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094"
+servers = "127.0.0.1:9092"
+# client.id
+client_id_prefix = "kafka_001"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# See more properties and their definitions at https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+[bridges.properties]
+"message.timeout.ms" = "5000"
+#"enable.auto.commit" = "false"
+
+[[bridges.entries]]
+remote.topic = "remote-topic1-ingress"
+remote.group_id = "group_id_001"
+#remote.start_partition = -1
+#remote.stop_partition = -1
+# "beginning", "end", "stored" or "<offset>", "<-offset>"
+#remote.offset = "beginning"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+#local.qos = 1
+local.topic = "local/topic1/ingress/${kafka.key}"
+# true/false, default: false
+#local.retain = true
+
+[[bridges.entries]]
+remote.topic = "remote-topic2-ingress"
+remote.group_id = "group_id_002"
+#remote.start_partition = -1
+#remote.stop_partition = -1
+# "beginning", "end", "stored" or "<offset>", "<-offset>"
+#remote.offset = "beginning"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic2/ingress"
+local.retain = false
+
+
+
+
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-ingress-mqtt.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-ingress-mqtt.toml
@@ -1,0 +1,148 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-mqtt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-mqtt.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_1"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+# or "tcp://127.0.0.1:1883" or "tls://127.0.0.1:8883"
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+#username = "${ENV:MQTT_USER}"
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+#password = "${ENV:MQTT_PASS}"
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v4"
+
+## The following configuration is related to specific protocol versions
+# Clean session
+v4.clean_session = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2, default: 0
+remote.qos = 1
+remote.topic = "$share/g/remote/topic1/ingress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+local.qos = 1
+local.topic = "local/topic1/ingress/${remote.topic}"
+# true/false, default: false
+local.retain = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2
+remote.qos = 1
+remote.topic = "$share/g/remote/topic2/ingress"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic2/ingress"
+local.retain = false
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_2"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+# or "tcp://127.0.0.1:1883" or "tls://127.0.0.1:8883"
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+
+
+# Username to connect to the remote MQTT broker
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v5"
+
+## The following configuration is related to specific protocol versions
+# Clean start
+v5.clean_start = true
+# Session expiry interval, 0 means the session ends immediately after the network disconnection
+v5.session_expiry_interval = "0s"
+# Limit the maximum number of QoS 1 and QoS 2 messages the client can process simultaneously
+v5.receive_maximum = 16
+# The maximum packet size negotiated between client and server
+v5.maximum_packet_size = "1M"
+# The maximum number of topic aliases negotiated between client and server
+v5.topic_alias_maximum = 0
+
+[[bridges.entries]]
+# Choose 0, 1, 2, default: 0
+remote.qos = 0
+remote.topic = "$share/g/remote/topic3/ingress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+local.qos = 1
+local.topic = "local/topic3/ingress/${remote.topic}"
+# true/false, default: false
+local.retain = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2
+remote.qos = 1
+remote.topic = "$share/g/remote/topic4/ingress"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic4/ingress"
+local.retain = false
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-ingress-nats.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-ingress-nats.toml
@@ -1,0 +1,69 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-nats
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-nats.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_nats_1"
+# The address of the NATS broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 4222.
+servers = "nats://127.0.0.1:4222"
+#servers = "tls://127.0.0.1:4433"
+
+# Consumer name prefix
+consumer_name_prefix = "consumer_1"
+
+## See https://github.com/nats-io/nats.rs/blob/main/async-nats/src/options.rs
+#no_echo = true
+#ping_interval = "60s"
+#connection_timeout = "10s"
+#tls_required = true
+#tls_first = true
+#root_certificates = ""
+#client_cert = ""
+#client_key = ""
+#sender_capacity = 256
+#auth.jwt = ""
+#auth.jwt_seed = ""
+#auth.nkey = ""
+#auth.username = ""
+#auth.password = ""
+#auth.token = ""
+
+[[bridges.entries]]
+
+remote.topic = "test1"
+#remote.group = "group1"
+
+local.topic = "local/topic1/ingress/${remote.topic}"
+
+## Choose 0, 1, 2, or not set (follow message QoS, i.e. user-defined properties "qos")
+##
+## Value: 0 | 1 | 2
+#local.qos = 1
+
+## Choose true or false, or not set (follow message Retain, i.e. user-defined properties "retain")
+##
+## Value: true | false
+## Default: false
+#local.retain = false
+
+## Allow forwarding of empty messages
+##
+## Value: true | false
+## Default: true
+#local.allow_empty_forward = false
+
+[[bridges.entries]]
+remote.topic = "test2"
+#remote.group = "group2"
+
+local.topic = "local/topic2/ingress"
+#local.qos = 0
+#local.retain = false
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-ingress-pulsar.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-ingress-pulsar.toml
@@ -1,0 +1,216 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-pulsar
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-pulsar.md
+
+[[bridges]]
+
+## Whether to enable
+##
+## Value: true | false
+## Default: false
+enable = true
+
+## Bridge name
+##
+## Value: String
+name = "bridge_pulsar_1"
+
+## The address of the Pulsar broker that the client will connect to using plain TCP.
+## In this case, it's connecting to the local broker at port 6650.
+##
+## The address of the Pulsar broker that the client would connect to using SSL/TLS.
+## Uncomment this line to enable a secure connection to the local broker at port 6651.
+##
+## Value: URL
+#servers = "pulsar+ssl://127.0.0.1:6651"
+servers = "pulsar://127.0.0.1:6650"
+
+## Consumer name prefix
+##
+## Value: String
+consumer_name_prefix = "consumer_1"
+
+## Add a custom certificate chain from a file to authenticate the server in TLS connections
+##
+## Value: String
+#cert_chain_file = "./rmqtt-bin/rmqtt.fullchain.pem"
+
+## Allow insecure TLS connection if set to true, defaults to false
+##
+## Value: true | false
+## Default: false
+#allow_insecure_connection = false
+
+## Whether hostname verification is enabled when insecure TLS connection is allowed, defaults to true
+##
+## Value: true | false
+## Default: true
+#tls_hostname_verification_enabled = true
+
+## Auth Configuration
+##
+## Value: token(JWT, Biscuit)/ or oauth2
+#auth.name = "token"
+#auth.data = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiZXhwIjoxNjI2NzY5MjAwLCJpYXQiOjE2MjY3NjU2MDB9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+#auth.name = "oauth2"
+#auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
+
+## Message expiration time, 0 means no expiration
+##
+## Value: Duration
+## Default: "5m"
+expiry_interval = "5m"
+
+[[bridges.entries]]
+
+## Sets the consumer's topic or add one to the list of topics
+##
+## Value: String
+remote.topic = "non-persistent://public/default/test"
+
+## Adds a list of topics to the future consumer
+##
+## Value: String
+#remote.topics = ["non-persistent://public/default/test1", "non-persistent://public/default/test2"]
+
+## Sets up a consumer that will listen on all topics matching the regular expression
+##
+## Value: String
+#remote.topic_regex = "non-persistent://public/default/.*"
+
+## Sets the kind of subscription
+##
+## Value: "exclusive", "shared", "failover", "key_shared"
+#remote.subscription_type = "shared"
+
+## Sets the subscription's name
+##
+## Value: String
+#remote.subscription = ""
+
+## Tenant/Namespace to be used when matching against a regex. For other consumers, specify namespace using the
+## `<persistent|non-persistent://<tenant>/<namespace>/<topic>` topic format.
+##
+## Defaults to `public/default` if not specifid
+##
+## Value: String
+#lookup_namespace = ""
+
+## Interval for refreshing the topics when using a topic regex. Unused otherwise.
+##
+## Value: Duration
+#topic_refresh_interval = "10s"
+
+## Sets the consumer id for this consumer
+##
+## Value: u64
+#consumer_id = 1
+
+## Sets the batch size
+## batch messages containing more than the configured batch size will not be sent by Pulsar
+##
+## Value: u64
+## Default: 1000
+#batch_size = 1000
+
+## Sets the dead letter policy
+##
+## Value: Object
+#remote.dead_letter_policy = {max_redeliver_count = 10, dead_letter_topic = "test_topic"}
+
+## The time after which a message is dropped without being acknowledged or nacked
+## that the message is resent. If `None`, messages will only be resent when a
+## consumer disconnects with pending unacknowledged messages.
+##
+## Value: Duration
+#remote.unacked_message_resend_delay = "20s"
+
+
+### Configuration options for consumers
+
+## Sets the priority level
+##
+## Value: i32
+#remote.options.priority_level = 3
+
+## Signal whether the subscription should be backed by a durable cursor or not
+##
+## Value: true | false
+#remote.options.durable = false
+
+## Read compacted
+##
+## Value: true | false
+#remote.options.read_compacted = false
+
+## Signal whether the subscription will initialize on latest
+## or earliest message (default on latest)
+##
+## Value: earliest | latest
+## latest - start at the most recent message
+## earliest - start at the oldest message
+#remote.options.initial_position = "latest"
+
+## User defined properties added to all messages
+##
+## Value: Object
+#remote.options.metadata = {}
+
+## Payload data format
+##
+## Value: bytes | json
+## Default: bytes
+#remote.payload_format = "json"
+
+## Payload Path
+##
+## Extract the publish payload from the Pulsar message payload. This config item is only supported when
+## `remote.payload_format` is set to JSON. For example: `/msg` or `/data/msg`
+##
+## Value: String
+#remote.payload_path = "msg"
+
+## MQTT publish message topic,
+##
+## Value: String
+##
+## Placeholder:
+##  - ${remote.topic}: pulsar message topic.
+##  - ${remote.properties.xxxx}: user-defined properties "topic". ${remote.properties.topic}
+##  - ${remote.payload.xxxx}: Extract the topic from the Pulsar message payload. If the topic is an array, the message will be
+##                     forwarded to each target topic individually. This placeholder is only supported when
+##                     `remote.payload_format` is set to JSON. For example: `${remote.payload.topics}`
+##
+local.topic = "local/topic1/ingress/${remote.topic}"
+#local.topics = ["local/topic1/ingress/${remote.properties.topic1}", "${remote.properties.topic2}", "${remote.payload.topic}", "${remote.payload.topics}"]
+
+## Choose 0, 1, 2, or not set (follow message QoS, i.e. user-defined properties "qos")
+##
+## Value: 0 | 1 | 2
+#local.qos = 1
+
+## Choose true or false, or not set (follow message Retain, i.e. user-defined properties "retain")
+##
+## Value: true | false
+## Default: false
+#local.retain = false
+
+## Allow forwarding of empty messages
+##
+## Value: true | false
+## Default: true
+#local.allow_empty_forward = false
+
+[[bridges.entries]]
+
+remote.topic = "non-persistent://public/default/test9"
+
+local.topic = "local/topic2/ingress"
+#local.qos = 0
+#local.retain = false
+
+
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-bridge-origin.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-bridge-origin.toml
@@ -1,0 +1,28 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-origin
+##--------------------------------------------------------------------
+##
+## This plugin identifies whether an MQTT client originates from a
+## bridge-ingress-mqtt or bridge-egress-mqtt connection by checking
+## the client_id against configurable markers.
+##
+## The identified bridge origin is stored in session.extra_attrs
+## under the configurable attr_key, making it available to other
+## plugins (e.g., for anti-loop or routing decisions).
+##
+## See: https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-origin.md
+##--------------------------------------------------------------------
+
+# Marker string to identify ingress bridge clients.
+# If a client_id contains this substring, it is treated as an ingress bridge client.
+# Default: ":ingress:"
+#ingress_marker = ":ingress:"
+
+# Marker string to identify egress bridge clients.
+# If a client_id contains this substring, it is treated as an egress bridge client.
+# Default: ":egress:"
+#egress_marker = ":egress:"
+
+# Key used to store BridgeOrigin in session.extra_attrs.
+# Default: "bridge_origin"
+#attr_key = "bridge_origin"

--- a/rmqtt-test/configs/default/plugins/rmqtt-cluster-broadcast.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-cluster-broadcast.toml
@@ -1,0 +1,24 @@
+##--------------------------------------------------------------------
+## rmqtt-cluster-broadcast
+##--------------------------------------------------------------------
+
+#grpc message type
+message_type = 98
+# The list of gRPC addresses for the nodes in the cluster.
+# Each entry contains the node ID (e.g., 1, 2, 3) followed by the corresponding IP address and port.
+# These addresses are used for inter-node communication within the cluster.
+node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+#Maximum number of messages sent in batch
+node_grpc_batch_size = 128
+##Client concurrent request limit
+node_grpc_client_concurrency_limit = 128
+##Connect and send to server timeout
+node_grpc_client_timeout = "15s"
+
+##Task execution queue workers
+task_exec_queue_workers = 500
+
+##Task execution queue max capacity
+task_exec_queue_max = 100_000
+
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-cluster-raft.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-cluster-raft.toml
@@ -1,0 +1,87 @@
+##--------------------------------------------------------------------
+## rmqtt-cluster-raft
+##--------------------------------------------------------------------
+
+#cluster raft worker threads
+worker_threads = 6
+
+#grpc message type
+message_type = 198
+# The list of gRPC addresses for the nodes in the cluster.
+# Each entry contains the node ID (e.g., 1, 2, 3) followed by the corresponding IP address and port.
+# These addresses are used for communication between the nodes using gRPC.
+node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+#Maximum number of messages sent in batch
+node_grpc_batch_size = 128
+##Client concurrent request limit
+node_grpc_client_concurrency_limit = 128
+##Connect and send to server timeout
+node_grpc_client_timeout = "10s"
+
+# The list of Raft peer addresses for the nodes in the cluster.
+# Each entry contains the node ID and the corresponding IP address and port for Raft consensus communication.
+# These addresses are used by the Raft protocol to maintain consistency and coordination across the nodes.
+raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+
+#Raft cluster listening address
+#If this listening address is not specified, the address of the node corresponding to `raft_peer_addrs` will be used.
+#laddr = "0.0.0.0:6003"
+
+# Specify the leader node ID.
+#
+# This option is primarily intended for single-host pseudo-cluster deployments,
+# where multiple cluster nodes run on the same machine for testing or development.
+#
+# In a real distributed cluster, leader election is performed automatically and
+# this option is typically unnecessary.
+#
+# When the value is 0 or not specified, the first node in the cluster
+# configuration will be designated as the Leader.
+#
+# It can also be overridden via the CLI flag `--raft-leader-id`.
+#
+# Default value: 0
+leader_id = 0
+
+#Handshake lock timeout
+try_lock_timeout = "10s"
+task_exec_queue_workers = 500
+task_exec_queue_max = 100_000
+
+#algorithm used to compress the snapshot, value: zstd,lz4,zlib,snappy
+compression = "zstd"
+
+#Check the health of the node, and automatically terminate the program if the node is abnormal.
+#Default value: false
+health.exit_on_node_unavailable = false
+#Exit code on program termination.
+#Default value: -1
+health.exit_code = -1
+#When exit_on_node_unavailable is enabled, the program will terminate after a specified number of consecutive node failures.
+#Default value: 2
+health.max_continuous_unavailable_count = 2
+#Cluster node unavailability check interval.
+#Default value: 2 seconds
+health.unavailable_check_interval = "2s"
+
+raft.grpc_timeout = "6s"
+raft.grpc_concurrency_limit = 200
+raft.grpc_breaker_threshold = 5
+raft.grpc_breaker_retry_interval = "2500ms"
+raft.proposal_batch_size = 60
+raft.proposal_batch_timeout = "200ms"
+raft.snapshot_interval = "300s"
+raft.heartbeat = "100ms"
+
+raft.election_tick = 10
+raft.heartbeat_tick = 5
+raft.max_size_per_msg = 0
+raft.max_inflight_msgs = 256
+raft.check_quorum = true
+raft.pre_vote = true
+raft.min_election_tick = 0
+raft.max_election_tick = 0
+raft.read_only_option = "Safe"
+raft.skip_bcast_commit = false
+raft.batch_append = false
+raft.priority = 0

--- a/rmqtt-test/configs/default/plugins/rmqtt-http-api.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-http-api.toml
@@ -1,0 +1,102 @@
+##--------------------------------------------------------------------
+## rmqtt-http-api
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
+## Max Row Limit
+max_row_limit = 10_000
+## HTTP Listener address
+http_laddr = "0.0.0.0:6060"
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
+
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory (optional).
+##
+## By default (when unset), the Dashboard SPA is served from assets
+## embedded directly into the binary via rust-embed at compile time,
+## so no external files are needed.
+##
+## If set, the http-api plugin loads the Dashboard SPA from this
+## external directory at the `/dashboard/` path instead, which allows
+## swapping the frontend build without recompiling the binary.
+# dashboard_static_dir = "/path/to/dashboard/dist"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##─── Redb backend ──────────────────────────────────────────────────────
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##─── Sled backend (default) ─────────────────────────────────────────────
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##─── Redis backend ──────────────────────────────────────────────────────
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##─── Redis Cluster backend ──────────────────────────────────────────────
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##─── Flush interval (how often to snapshot Stats/Metrics) ───────────────
+## Default: "5s"
+# flush_interval = "5s"
+
+##─── History retention (TTL for each data point) ────────────────────────
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/rmqtt-test/configs/default/plugins/rmqtt-message-storage.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-message-storage.toml
@@ -1,0 +1,37 @@
+##--------------------------------------------------------------------
+## rmqtt-message-storage
+##--------------------------------------------------------------------
+
+##ram, redis, redis-cluster
+storage.type = "ram"
+
+##ram
+storage.ram.cache_capacity = "3G"
+storage.ram.cache_max_count = 1_000_000
+storage.ram.encode = false
+
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "message-{node}"
+
+##redis-cluster
+storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
+storage.redis-cluster.prefix = "message-{node}"
+
+##Quantity of expired messages cleared during each cleanup cycle.
+cleanup_count = 5000
+
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
+
+##─── Circuit breaker ────────────────────────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##The per-operation timeout uses `backend_timeout` above.

--- a/rmqtt-test/configs/default/plugins/rmqtt-p2p-messaging.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-p2p-messaging.toml
@@ -1,0 +1,8 @@
+##--------------------------------------------------------------------
+## rmqtt-p2p-messaging
+##--------------------------------------------------------------------
+
+#"prefix": `p2p/{clientid}/{topic}` — the `p2p` identifier is at the start.
+#"suffix": `{topic}/p2p/{clientid}` — the `p2p` identifier is at the end.
+#"both": supports both prefix and suffix formats.
+mode = "prefix"

--- a/rmqtt-test/configs/default/plugins/rmqtt-retainer.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-retainer.toml
@@ -1,0 +1,44 @@
+##--------------------------------------------------------------------
+## rmqtt-retainer
+##--------------------------------------------------------------------
+#
+# Single node mode         - ram, sled, redis
+# Multi-node cluster mode  - ram, sled, redis
+#
+
+##ram, sled, redis
+storage.type = "ram"
+
+##sled
+storage.sled.path = "/var/log/rmqtt/.cache/retain/{node}"
+storage.sled.cache_capacity = "3G"
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "retain"
+
+# The maximum number of retained messages, where 0 indicates no limit. After the number of reserved messages exceeds
+# the maximum limit, existing reserved messages can be replaced, but reserved messages cannot be stored for new topics.
+max_retained_messages = 0
+
+# The maximum Payload value for retaining messages. After the Payload size exceeds the maximum value, the RMQTT
+# message server will process the received reserved message as a regular message.
+max_payload_size = "1MB"
+
+# TTL for retained messages. Set to 0 for no expiration.
+# If not specified, the message expiration time will be used by default.
+retained_message_ttl = "0m"
+
+# Maximum number of messages per batch (default: 500).
+batch_messages_limit = 500
+
+##─── Backend timeout (circuit breaker) ──────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##Only the backend operation timeout can be overridden here.
+##
+##Backend storage operation timeout. If a storage call (Sled/Redis)
+##exceeds this duration it is aborted and counted as a failure by the
+##circuit breaker. Set to "0s" to disable.
+##Default: "8s"
+#backend_timeout = "8s"

--- a/rmqtt-test/configs/default/plugins/rmqtt-session-storage.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-session-storage.toml
@@ -1,0 +1,29 @@
+##--------------------------------------------------------------------
+## rmqtt-session-storage
+##--------------------------------------------------------------------
+
+##sled, redis, redis-cluster
+storage.type = "sled"
+
+##sled
+storage.sled.path = "/var/log/rmqtt/.cache/session/{node}"
+storage.sled.cache_capacity = "3G"
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "session-{node}"
+
+##redis-cluster
+storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
+storage.redis-cluster.prefix = "session-{node}"
+
+##─── Backend timeout (circuit breaker) ──────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##Only the backend operation timeout can be overridden here.
+
+##Backend storage operation timeout. If a storage call (Sled/Redis)
+##exceeds this duration it is aborted and counted as a failure by the
+##circuit breaker. Set to "0s" to disable.
+##Default: "15s"
+#backend_timeout = "15s"

--- a/rmqtt-test/configs/default/plugins/rmqtt-shared-subscription.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-shared-subscription.toml
@@ -1,0 +1,19 @@
+# rmqtt-shared-subscription Plugin Configuration
+#
+# Supported strategies:
+#   random              - Random subscriber selection (basic load balancing)
+#   round_robin         - Sequential round-robin (default)
+#   round_robin_per_group - Per-node independent round-robin (large cluster)
+#   sticky              - Fixed subscriber per publisher (stateful processing)
+#   local               - Prefer publisher's node (reduce cross-node traffic)
+#   hash_clientid       - Hash by publisher ClientId (per-device ordering)
+#   hash_topic          - Hash by topic (topic sharding)
+
+# Selection strategy
+# Default: round_robin
+strategy = "round_robin"
+
+# Maximum sticky bindings in the LRU cache (only applies to "sticky" strategy).
+# When the cache fills up, the least recently used binding is evicted.
+# Default: 100000
+sticky_cache_size = 100000

--- a/rmqtt-test/configs/default/plugins/rmqtt-sys-topic.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/rmqtt-test/configs/default/plugins/rmqtt-topic-rewrite.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-topic-rewrite.toml
@@ -1,0 +1,22 @@
+##--------------------------------------------------------------------
+## rmqtt-topic-rewrite
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/topic-rewrite.md
+
+# action - Options are publish, subscribe, or all
+# source_topic_filter - Topic filter for subscribing, unsubscribing, or publishing messages
+# dest_topic - Destination topic
+# regex - Regular expression
+
+# Expressions can use ${clientid} to represent the client ID and ${username} to represent the client username.
+
+rules = [
+#    { action = "all", source_topic_filter = "x/+/#", dest_topic = "xx/$1/$2", regex = "^x/(.+)/(.+)$" },
+#    { action = "all", source_topic_filter = "x/y/1", dest_topic = "xx/y/1" },
+#    { action = "all", source_topic_filter = "x/y/#", dest_topic = "xx/y/$1", regex = "^x/y/(.+)$" },
+#    { action = "all", source_topic_filter = "iot/cid/#", dest_topic = "iot/${clientid}/$1", regex = "^iot/cid/(.+)$" },
+#    { action = "all", source_topic_filter = "iot/uname/#", dest_topic = "iot/${username}/$1", regex = "^iot/uname/(.+)$" },
+#    { action = "all", source_topic_filter = "a/+/+/+", dest_topic = "aa/$1/$2/$3", regex = "^a/(.+)/(.+)/(.+)$" }
+]
+

--- a/rmqtt-test/configs/default/plugins/rmqtt-web-hook.toml
+++ b/rmqtt-test/configs/default/plugins/rmqtt-web-hook.toml
@@ -1,0 +1,53 @@
+##--------------------------------------------------------------------
+## rmqtt-web-hook
+##--------------------------------------------------------------------
+## http
+#    Method: POST
+#    Body: <JSON>
+#    Payload: BASE64
+## file
+#    None
+#
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/web-hook.md
+
+##--------------------------------------------------------------------
+## Hook General Config
+##--------------------------------------------------------------------
+# Maximum number of tasks that can be queued before new tasks are rejected.
+# Changing this value requires restarting the service to take effect.
+queue_capacity = 300_000
+
+# Maximum number of tasks that can be executed concurrently.
+# Changing this value requires restarting the service to take effect.
+concurrency_limit = 128
+
+
+## Default urls, supports http and file protocols
+#urls = ["file:///var/log/rmqtt/hook.log", "http://127.0.0.1:5656/mqtt/webhook"]
+urls = ["file:///var/log/rmqtt/hook.log"]
+
+## Http config
+http_timeout = "8s"
+#If it fails, try again after approximately 2, 4, 7, 11, 18, or 42 seconds
+retry_max_elapsed_time = "60s"
+retry_multiplier = 2.5
+
+## Hook rules config
+rule.session_created = [{action = "session_created" } ]
+rule.session_terminated = [{action = "session_terminated" } ]
+rule.session_subscribed = [{action = "session_subscribed"  } ]
+rule.session_unsubscribed = [{action = "session_unsubscribed" } ]
+
+rule.client_connect = [{action = "client_connect"}]
+rule.client_connack = [{action = "client_connack"} ]
+rule.client_connected = [{action = "client_connected" } ]
+rule.client_disconnected = [{action = "client_disconnected" } ]
+rule.client_subscribe = [{action = "client_subscribe" } ]
+rule.client_unsubscribe = [{action = "client_unsubscribe" } ]
+
+rule.message_publish = [{action = "message_publish", topics=["#", "$SYS/#"] }]
+rule.message_delivered = [{action = "message_delivered", topics=["#", "$SYS/#"] } ]
+rule.message_acked = [{action = "message_acked", topics=["#", "$SYS/#"] } ]
+rule.message_dropped = [{action = "message_dropped" } ]
+rule.offline_message = [{action = "offline_message", topics=["#", "$SYS/#"] }]

--- a/rmqtt-test/configs/default/rmqtt.toml
+++ b/rmqtt-test/configs/default/rmqtt.toml
@@ -1,0 +1,324 @@
+##--------------------------------------------------------------------
+## rmqtt-test default broker config (self-contained)
+##
+## This is the DEFAULT configuration used by `mqtt_harness` when no
+## `--config` is given. It mirrors the repository-root `rmqtt.toml`
+## (same default plugin set, same TLS/WS/QUIC listeners) but is fully
+## self-contained under `rmqtt-test/configs/`:
+##   - plugins.dir points at this directory's own plugins/ sub-dir, so
+##     tests do NOT depend on the repository-root `rmqtt-plugins/*.toml`;
+##   - log goes to console only (no /var/log/rmqtt writes);
+##   - the external TCP listener binds 127.0.0.1:1883 to match the
+##     harness default `--addr`.
+##
+## Keep the default plugin set in sync with the repository-root
+## rmqtt.toml so the test behaviour matches a stock deployment.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+## Task
+##--------------------------------------------------------------------
+#Concurrent task count for global task executor.
+task.exec_workers = 2000
+#Queue capacity for global task executor.
+task.exec_queue_max = 300_000
+
+
+##--------------------------------------------------------------------
+## Node
+##--------------------------------------------------------------------
+#Node id
+node.id = 1
+
+#Busy status check switch.
+#default value: false
+node.busy.check_enable = false
+#Busy status update interval.
+#default value: 2s
+node.busy.update_interval = "2s"
+#The threshold for the 1-minute average system load used to determine system busyness.
+#Value range: 0.0-100.0, default value: 80.0
+node.busy.loadavg = 80.0
+#The threshold for average CPU load used to determine system busyness.
+#Value range: 0.0-100.0, default value: 90.0
+node.busy.cpuloadavg = 90.0
+#The threshold for determining high-concurrency connection handshakes in progress.
+node.busy.handshaking = 0
+
+##--------------------------------------------------------------------
+## RPC (Remote Procedure Call) Configuration Section
+##--------------------------------------------------------------------
+# gRPC server listening address
+# Format: "IP:PORT"
+# "0.0.0.0" means listen on all available network interfaces
+# 5363 is the default listening port
+rpc.server_addr = "0.0.0.0:5363"
+
+# Enable SO_REUSEADDR socket option
+# true allows immediate reuse of addresses in TIME_WAIT state (useful for fast service restart)
+rpc.reuseaddr = true
+
+# Enable SO_REUSEPORT socket option
+# false prevents multiple sockets from binding to same IP+PORT combination
+# (Linux 3.9+ kernel feature, can be used for load balancing)
+rpc.reuseport = false
+
+##--------------------------------------------------------------------
+## Log
+##--------------------------------------------------------------------
+# Value: off | file | console | both
+log.to = "console"
+# Value: trace, debug, info, warn, error
+log.level = "info"
+log.dir = "."
+log.file = "rmqtt.log"
+
+
+##--------------------------------------------------------------------
+## Plugins
+##--------------------------------------------------------------------
+#Plug in configuration file directory (self-contained, relative to the
+#repository root from which mqtt_harness / rmqttd are launched)
+plugins.dir = "rmqtt-test/configs/default/plugins/"
+#Plug in started by default, when the mqtt server is started
+plugins.default_startups = [
+    "rmqtt-retainer",
+    "rmqtt-shared-subscription",
+    "rmqtt-http-api"
+]
+plugins.disabled_default_startups = []
+
+
+##--------------------------------------------------------------------
+## MQTT
+##--------------------------------------------------------------------
+#Delayed message send limit
+mqtt.delayed_publish_max = 100_000
+#Send immediately when limit exceeded, true/false,
+#true -  message will be sent immediately,
+#false - message will be discarded,
+#default: true
+mqtt.delayed_publish_immediate = true
+
+#Maximum session limit, 0: no limit, default value: 0.
+mqtt.max_sessions = 0
+
+##--------------------------------------------------------------------
+## Circuit breaker
+##--------------------------------------------------------------------
+##Uncomment the following section to customize circuit-breaker behaviour.
+##When the whole section is absent, the upstream default is used verbatim.
+
+##Failure rate threshold (0.0 – 1.0). When exceeded, circuit opens.
+##Default: 0.35
+#circuit_breaker.failure_rate_threshold = 0.35
+
+##Sliding window type: "CountBased" or "TimeBased".
+##  CountBased — window slides after N calls (sliding_window_size).
+##  TimeBased  — window slides after a fixed duration (e.g. 45s).
+##Default: "TimeBased"
+#circuit_breaker.sliding_window_type = "TimeBased"
+
+##Sliding window size (number of calls) for CountBased type.
+##For TimeBased, this value sets the max tracked calls (fallback for minimum_number_of_calls).
+##Default: 20
+#circuit_breaker.sliding_window_size = 20
+
+##Sliding window duration for TimeBased type (e.g. "45s").
+##Only used when sliding_window_type is "TimeBased".
+##Default: "45s"
+#circuit_breaker.sliding_window_duration = "45s"
+
+##Minimum calls before the breaker can trip.
+##Default: 10
+#circuit_breaker.minimum_number_of_calls = 10
+
+##Duration in OPEN state before transitioning to HALF_OPEN (probe).
+##Default: "30s"
+#circuit_breaker.wait_duration_in_open = "30s"
+
+##Slow call duration threshold.
+##Default: "2s"
+#circuit_breaker.slow_call_duration_threshold = "2s"
+
+##Slow call rate threshold (0.0 – 1.0). 1.0 = disabled.
+##Default: 1.0
+#circuit_breaker.slow_call_rate_threshold = 1.0
+
+##--------------------------------------------------------------------
+## Listeners
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+## MQTT/TCP - External TCP Listener for MQTT Protocol
+listener.tcp.external.addr = "127.0.0.1:1883"
+#Number of worker threads (currently unused)
+listener.tcp.external.workers = 8
+#The maximum number of concurrent connections allowed by the listener.
+listener.tcp.external.max_connections = 1024000
+#Maximum concurrent handshake limit, Default: 500
+listener.tcp.external.max_handshaking_limit = 500
+#Handshake timeout.
+listener.tcp.external.handshake_timeout = "30s"
+#Maximum allowed mqtt message length. 0 means unlimited, default: 1MB
+listener.tcp.external.max_packet_size = "1MB"
+#The maximum length of the TCP connection queue.
+#It indicates the maximum number of TCP connection queues that are being handshaked three times in the system
+listener.tcp.external.backlog = 1024
+#Sets the value of the TCP_NODELAY option on this socket.
+#default: false
+listener.tcp.external.nodelay = false
+#Whether anonymous login is allowed. Default: true
+listener.tcp.external.allow_anonymous = true
+#A value of zero indicates disabling the keep-alive feature, where the server
+#doesn't need to disconnect due to client inactivity, default: true
+listener.tcp.external.allow_zero_keepalive = true
+#Minimum allowable keepalive value for mqtt connection,
+#less than this value will reject the connection(MQTT V3),
+#less than this value will set keepalive to this value in CONNACK (MQTT V5),
+#default: 0, unit: seconds
+listener.tcp.external.min_keepalive = 0
+#Maximum allowable keepalive value for mqtt connection,
+#greater than this value will reject the connection(MQTT V3),
+#greater than this value will set keepalive to this value in CONNACK (MQTT V5),
+#default value: 65535, unit: seconds
+listener.tcp.external.max_keepalive = 65535
+# > 0.5, Keepalive * backoff * 2
+listener.tcp.external.keepalive_backoff = 0.75
+#Flight window size. The flight window is used to store the unanswered QoS 1 and QoS 2 messages
+listener.tcp.external.max_inflight = 16
+#Maximum length of message queue
+listener.tcp.external.max_mqueue_len = 1000
+#The rate at which messages are ejected from the message queue,
+#default value: "u32::max_value(),1s"
+listener.tcp.external.mqueue_rate_limit = "1000,1s"
+#Maximum length of client ID allowed, Default: 65535
+listener.tcp.external.max_clientid_len = 65535
+#The maximum QoS level that clients are allowed to publish. default value: 2
+listener.tcp.external.max_qos_allowed = 2
+#The maximum level at which clients are allowed to subscribe to topics.
+#0 means unlimited. default value: 0
+listener.tcp.external.max_topic_levels = 0
+#Duration before inactive sessions expire, default value: 2 hours
+listener.tcp.external.session_expiry_interval = "2h"
+#The upper limit for how long a session can remain valid before it must expire,
+#regardless of the client's requested session expiry interval
+#default value: 0 hours (unlimited)
+listener.tcp.external.max_session_expiry_interval = "0h"
+#QoS 1/2 message retry interval, 0 means no resend
+listener.tcp.external.message_retry_interval = "20s"
+#Message expiration time, 0 means no expiration, default value: 5 minutes
+listener.tcp.external.message_expiry_interval = "5m"
+#The maximum number of topics that a single client is allowed to subscribe to
+#0 means unlimited, default value: 0
+listener.tcp.external.max_subscriptions = 0
+#topic alias maximum, default value: 0, topic aliases not enabled. (MQTT 5.0)
+listener.tcp.external.max_topic_aliases = 32
+#Limit subscription switch, default value: false
+listener.tcp.external.limit_subscription = false
+#Delayed publish switch, default value: false
+listener.tcp.external.delayed_publish = false
+#Proxy Protocol switch, default value: false
+listener.tcp.external.proxy_protocol = false
+#Proxy Protocol timeout, default value: 5s
+listener.tcp.external.proxy_protocol_timeout = "5s"
+
+##--------------------------------------------------------------------
+## MQTT/TCP - Internal TCP Listener for MQTT Protocol
+listener.tcp.internal.enable = true
+listener.tcp.internal.addr = "0.0.0.0:11883"
+listener.tcp.internal.max_connections = 102400
+listener.tcp.internal.max_handshaking_limit = 500
+listener.tcp.internal.handshake_timeout = "30s"
+listener.tcp.internal.max_packet_size = "1M"
+listener.tcp.internal.backlog = 512
+listener.tcp.internal.nodelay = false
+listener.tcp.internal.allow_anonymous = true
+listener.tcp.internal.allow_zero_keepalive = true
+listener.tcp.internal.min_keepalive = 0
+listener.tcp.internal.max_keepalive = 65535
+listener.tcp.internal.keepalive_backoff = 0.75
+listener.tcp.internal.max_inflight = 128
+listener.tcp.internal.max_mqueue_len = 1000
+listener.tcp.internal.mqueue_rate_limit = "5000,1s"
+listener.tcp.internal.max_clientid_len = 65535
+listener.tcp.internal.max_qos_allowed = 2
+listener.tcp.internal.max_topic_levels = 0
+listener.tcp.internal.session_expiry_interval = "2h"
+listener.tcp.internal.max_session_expiry_interval = "0h"
+listener.tcp.internal.message_retry_interval = "30s"
+listener.tcp.internal.message_expiry_interval = "5m"
+listener.tcp.internal.max_subscriptions = 0
+listener.tcp.internal.max_topic_aliases = 0
+listener.tcp.internal.limit_subscription = false
+
+##--------------------------------------------------------------------
+## MQTT/TLS - External TLS Listener for MQTT Protocol, (TLSv1.2)
+## NOTE: kept enabled on purpose - TLS/WS/QUIC tests will be added later.
+listener.tls.external.addr = "0.0.0.0:8883"
+
+# Whether to use the Common Name (CN) field from the client certificate as the username
+# true  - enable this feature; the username will be extracted from the certificate CN field
+# false - disable this feature; the username must be provided in the CONNECT packet
+# Default: false
+listener.tls.external.cert_cn_as_username = false
+
+# Whether to use the Subject Distinguished Name (DN) from the client certificate as the username
+# true  - enable this feature; the username will be extracted from the certificate Subject DN
+# false - disable this feature; the username must be provided in the CONNECT packet
+# Default: false
+listener.tls.external.cert_subject_dn_as_username = false
+
+# Whether to collect client certificate information (cert_info) and
+# include it in the MQTT connection metadata
+# true  - enable this feature; cert_info will be added to the MQTT CONNECT
+#         connection context for further authentication/authorization use
+# false - disable this feature; no certificate information will be attached
+# Default: false
+listener.tls.external.collect_cert_info = false
+
+#Whether to enable cross-certification, default value: false
+listener.tls.external.cross_certificate = false
+#This certificate is used to authenticate the server during TLS handshakes.
+listener.tls.external.cert = "./rmqtt-bin/rmqtt.pem"
+#This key is used to establish a secure connection with the client.
+listener.tls.external.key = "./rmqtt-bin/rmqtt.key"
+
+#The following is the configuration using cross-certification
+#listener.tls.external.cross_certificate = true
+#listener.tls.external.cert = "./rmqtt-bin/rmqtt.pem"
+#listener.tls.external.key = "./rmqtt-bin/rmqtt.key"
+#listener.tls.external.client_ca_certs = "./rmqtt-bin/rmqtt.fullchain.pem"
+
+##--------------------------------------------------------------------
+## MQTT/WebSocket - External WebSocket Listener for MQTT Protocol
+listener.ws.external.addr = "0.0.0.0:8080"
+
+##--------------------------------------------------------------------
+## MQTT/TLS-WebSocket - External TLS-WebSocket Listener for MQTT Protocol, (TLSv1.2)
+listener.wss.external.addr = "0.0.0.0:8443"
+listener.wss.external.cross_certificate = false
+listener.wss.external.cert = "./rmqtt-bin/rmqtt.pem"
+listener.wss.external.key = "./rmqtt-bin/rmqtt.key"
+#listener.wss.external.cross_certificate = true
+#listener.wss.external.cert = "./rmqtt-bin/rmqtt.fullchain.pem"
+#listener.wss.external.key = "./rmqtt-bin/rmqtt.key"
+
+##--------------------------------------------------------------------
+## MQTT/QUIC - External QUIC Listener for MQTT Protocol, (TLSv1.3)
+listener.quic.external.addr = "0.0.0.0:9443"
+
+#quic max_idle_timeout, default value: 90s
+listener.quic.external.idle_timeout = "120s"
+
+#Whether to enable cross-certification, default value: false
+listener.quic.external.cross_certificate = false
+#This certificate is used to authenticate the server during TLS handshakes.
+listener.quic.external.cert = "./rmqtt-bin/rmqtt.pem"
+#This key is used to establish a secure connection with the client.
+listener.quic.external.key = "./rmqtt-bin/rmqtt.key"
+
+#The following is the configuration using cross-certification
+#listener.quic.external.cross_certificate = true
+#listener.quic.external.cert = "./rmqtt-bin/rmqtt.fullchain.pem"
+#listener.quic.external.key = "./rmqtt-bin/rmqtt.key"

--- a/rmqtt-test/configs/pubrel-collision/plugins/Cargo.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/Cargo.toml
@@ -1,0 +1,138 @@
+[package]
+name = "rmqtt-plugins"
+version.workspace = true
+description = "Plugin collection for rmqtt, providing authentication, storage, bridges, clustering, and other extensions."
+repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins"
+edition.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = []
+full = [
+    "retainer-ram",
+    "retainer-sled",
+    "retainer-redis",
+
+    "message-storage-ram",
+    "message-storage-redis",
+    "message-storage-redis-cluster",
+
+    "session-storage-sled",
+    "session-storage-redis",
+    "session-storage-redis-cluster",
+
+    "acl",
+    "http-api",
+    "counter",
+    "auth-http",
+    "auth-jwt",
+    "auto-subscription",
+
+    "bridge-egress-kafka",
+    "bridge-ingress-kafka",
+    "bridge-egress-mqtt",
+    "bridge-ingress-mqtt",
+    "bridge-egress-pulsar",
+    "bridge-ingress-pulsar",
+    "bridge-ingress-nats",
+    "bridge-egress-nats",
+    "bridge-egress-reductstore",
+    "bridge-origin",
+
+    "p2p-messaging",
+
+    "shared-subscription",
+
+    "sys-topic",
+    "topic-rewrite",
+    "web-hook",
+
+    "cluster-raft",
+    "cluster-broadcast",
+]
+
+# ---- storage sub-features ----
+retainer-ram = ["rmqtt-retainer/ram"]
+retainer-sled = ["rmqtt-retainer/sled"]
+retainer-redis = ["rmqtt-retainer/redis"]
+retainer = ["retainer-ram", "retainer-sled", "retainer-redis"]
+
+message-storage-ram = ["rmqtt-message-storage/ram"]
+message-storage-redis = ["rmqtt-message-storage/redis"]
+message-storage-redis-cluster = ["rmqtt-message-storage/redis-cluster"]
+message-storage = ["message-storage-ram", "message-storage-redis", "message-storage-redis-cluster"]
+
+session-storage-sled = ["rmqtt-session-storage/sled"]
+session-storage-redis = ["rmqtt-session-storage/redis"]
+session-storage-redis-cluster = ["rmqtt-session-storage/redis-cluster"]
+session-storage = ["session-storage-sled", "session-storage-redis", "session-storage-redis-cluster"]
+
+# ---- http-api sub-features ----
+http-api-sled = ["rmqtt-http-api/sled"]
+http-api-redis = ["rmqtt-http-api/redis"]
+http-api-redis-cluster = ["http-api-redis", "rmqtt-http-api/redis-cluster"]
+http-api-redb = ["rmqtt-http-api/redb"]
+http-api = ["http-api-sled", "http-api-redis", "http-api-redis-cluster", "http-api-redb"]
+
+# ---- core plugins ----
+acl = ["rmqtt-acl"]
+counter = ["rmqtt-counter"]
+auth-http = ["rmqtt-auth-http"]
+auth-jwt = ["rmqtt-auth-jwt"]
+auto-subscription = ["rmqtt-auto-subscription"]
+
+# ---- bridge plugins ----
+bridge-egress-kafka = ["rmqtt-bridge-egress-kafka"]
+bridge-ingress-kafka = ["rmqtt-bridge-ingress-kafka"]
+bridge-egress-mqtt = ["rmqtt-bridge-egress-mqtt"]
+bridge-ingress-mqtt = ["rmqtt-bridge-ingress-mqtt"]
+bridge-egress-pulsar = ["rmqtt-bridge-egress-pulsar"]
+bridge-ingress-pulsar = ["rmqtt-bridge-ingress-pulsar"]
+bridge-ingress-nats = ["rmqtt-bridge-ingress-nats"]
+bridge-egress-nats = ["rmqtt-bridge-egress-nats"]
+bridge-egress-reductstore = ["rmqtt-bridge-egress-reductstore"]
+bridge-origin = ["rmqtt-bridge-origin"]
+
+# ---- other plugins ----
+shared-subscription = ["rmqtt-shared-subscription"]
+sys-topic = ["rmqtt-sys-topic"]
+topic-rewrite = ["rmqtt-topic-rewrite"]
+web-hook = ["rmqtt-web-hook"]
+p2p-messaging = ["rmqtt-p2p-messaging"]
+
+# ---- cluster plugins ----
+cluster-raft = ["rmqtt-cluster-raft"]
+cluster-broadcast = ["rmqtt-cluster-broadcast"]
+
+[dependencies]
+rmqtt-acl = { workspace = true, optional = true }
+rmqtt-retainer = { workspace = true, optional = true }
+rmqtt-http-api = { workspace = true, optional = true }
+rmqtt-counter = { workspace = true, optional = true }
+rmqtt-auth-http = { workspace = true, optional = true }
+rmqtt-auth-jwt = { workspace = true, optional = true }
+rmqtt-auto-subscription = { workspace = true, optional = true }
+rmqtt-bridge-egress-kafka = { workspace = true, optional = true }
+rmqtt-bridge-ingress-kafka = { workspace = true, optional = true }
+rmqtt-bridge-egress-mqtt = { workspace = true, optional = true }
+rmqtt-bridge-ingress-mqtt = { workspace = true, optional = true }
+rmqtt-bridge-egress-pulsar = { workspace = true, optional = true }
+rmqtt-bridge-ingress-pulsar = { workspace = true, optional = true }
+rmqtt-bridge-ingress-nats = { workspace = true, optional = true }
+rmqtt-bridge-egress-nats = { workspace = true, optional = true }
+rmqtt-bridge-egress-reductstore = { workspace = true, optional = true }
+rmqtt-bridge-origin = { workspace = true, optional = true }
+rmqtt-message-storage = { workspace = true, optional = true }
+rmqtt-session-storage = { workspace = true, optional = true }
+rmqtt-sys-topic = { workspace = true, optional = true }
+rmqtt-shared-subscription = { workspace = true, optional = true }
+rmqtt-topic-rewrite = { workspace = true, optional = true }
+rmqtt-web-hook = { workspace = true, optional = true }
+rmqtt-cluster-raft = { workspace = true, optional = true }
+rmqtt-cluster-broadcast = { workspace = true, optional = true }
+rmqtt-p2p-messaging = { workspace = true, optional = true }

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-acl.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-acl.toml
@@ -1,0 +1,18 @@
+##--------------------------------------------------------------------
+## rmqtt-acl
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/acl.md
+
+#Disconnect if publishing is rejected
+disconnect_if_pub_rejected = true
+
+rules = [
+    #["deny", "all", "subscribe", ["test/nosubscribe"]],
+    ["allow", { user = "dashboard" }, "subscribe", ["$SYS/#"]],
+    ["allow", { ipaddr = "127.0.0.1" }, "pubsub", ["$SYS/#", "#"]],
+    ["deny", "all", "subscribe", ["$SYS/#", { eq = "#" }]],
+    ["allow", "all"]
+    #["deny", "all"]
+]
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-auth-http.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-auth-http.toml
@@ -1,0 +1,71 @@
+##--------------------------------------------------------------------
+## rmqtt-auth-http
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auth-http.md
+
+http_timeout = "5s"
+http_headers.accept = "*/*"
+http_headers.Cache-Control = "no-cache"
+http_headers.User-Agent = "RMQTT/0.15.0"
+http_headers.Connection = "keep-alive"
+
+## Disconnect if publishing is rejected
+##
+## Value: true | false
+## Default: true
+disconnect_if_pub_rejected = true
+
+## Disconnect After Expiration
+##
+## Value: true | false
+## Default: false
+disconnect_if_expiry = false
+
+## Return 'Deny' if http request error otherwise 'Ignore'
+##
+## Value: true | false
+## Default: true
+deny_if_error = true
+
+
+##--------------------------------------------------------------------
+## Authentication request.
+##
+## Variables:
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %P: password
+##
+## Value: URL
+http_auth_req.url = "http://127.0.0.1:9090/mqtt/auth"
+## Value: post | get | put
+http_auth_req.method = "post"
+## HTTP request header of authentication request
+## Content-Type Currently supported values: application/x-www-form-urlencoded, application/json
+http_auth_req.headers = { content-type = "application/x-www-form-urlencoded" }
+#http_auth_req.headers.content-type="application/json"
+## Value: Params
+http_auth_req.params = { clientid = "%c", username = "%u", password = "%P", protocol = "%r" }
+
+
+##--------------------------------------------------------------------
+## ACL request.
+##
+## Variables:
+##  - %A: 1 | 2, 1 = sub, 2 = pub
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %t: topic
+##
+## Value: URL
+http_acl_req.url = "http://127.0.0.1:9090/mqtt/acl"
+## Value: post | get | put
+http_acl_req.method = "post"
+## Value: Params
+http_acl_req.params = { access = "%A", username = "%u", clientid = "%c", ipaddr = "%a", topic = "%t", protocol = "%r" }
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-auth-jwt.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-auth-jwt.toml
@@ -1,0 +1,79 @@
+##--------------------------------------------------------------------
+## rmqtt-auth-jwt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auth-jwt.md
+# Generate a test JWT. See https://jwt.io/#debugger-io
+
+## Disconnect if publishing is rejected
+##
+## Value: true | false
+## Default: true
+disconnect_if_pub_rejected = true
+
+## Disconnect After Expiration
+##
+## Value: true | false
+## Default: false
+disconnect_if_expiry = false
+
+## From where the JWT string can be got
+## Value: username | password
+## Default: password
+from = "password"
+
+## Encryption method
+## Value: hmac-based | public-key
+## Default: hmac-based
+encrypt = "hmac-based"
+
+## HMAC Hash Secret.
+##
+## Value: String
+hmac_secret = "rmqttsecret"
+#hmac_secret = "cm1xdHRzZWNyZXQ="
+
+## Secret Base64 Encode
+##
+## Value: true | false
+## Default: false
+hmac_base64 = false
+
+## RSA or ECDSA public key file.
+##
+## Value: File
+#public_key = "./rmqtt-bin/jwt_public_key_rsa.pem"
+#public_key = "./rmqtt-bin/jwt_public_key_es256.pem"
+#public_key = "./rmqtt-bin/jwt_public_key_es384.pem"
+
+
+## The checklist of claims to validate
+##
+## Value: String
+## validate_claims.$name = expected
+##
+## Placeholder:
+##  - ${username}: username
+##  - ${clientid}: clientid
+##  - ${ipaddr}: client ip addr
+##  - ${protocol}: MQTT protocol version: 3 = 3.1, 4 = 3.1.1, or 5 = 5.0
+
+### Basic Validation
+## > Validate the token's expiration by comparing the exp claim to the current UTC time.
+validate_claims.exp = true
+## < Ensure the token is not used before its nbf claim.
+#validate_claims.nbf = true
+## Ensure the token's subject (sub claim) is as expected.
+#validate_claims.sub = "user@rmqtt.com"
+## Validate the token's issuer by comparing the iss claim to the known issuer.
+#validate_claims.iss = ["https://rmqtt.com1", "https://rmqtt.com"]
+## Verify that the token's audience (aud claim) matches the intended recipient.
+#validate_claims.aud = ["https://your-api.com", "mobile_app", "web_app"]
+
+### Extended Validation
+#validate_claims.clientid = "${clientid}"
+#validate_claims.username = "${username}"
+#validate_claims.ipaddr = "${ipaddr}"
+#validate_claims.protocol = "${protocol}"
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-auto-subscription.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-auto-subscription.toml
@@ -1,0 +1,14 @@
+##--------------------------------------------------------------------
+## rmqtt-auto-subscription
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auto-subscription.md
+
+# Expressions can use ${clientid} to represent the client ID and ${username} to represent the client username.
+
+subscribes = [
+    { topic_filter = "x/+/#", qos = 1, no_local = false, retain_as_published = false, retain_handling = 0 },
+    { topic_filter = "foo/${clientid}/#", qos = 1, no_local = false, retain_as_published = false, retain_handling = 0 },
+    { topic_filter = "iot/${username}/#", qos = 1 }
+]
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-kafka.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-kafka.toml
@@ -1,0 +1,48 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-kafka
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-kafka.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_kafka_1"
+
+# The list of broker (server) addresses for the Kafka cluster.
+#servers = "127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094"
+servers = "127.0.0.1:9092"
+# client.id
+client_id_prefix = "kafka_001"
+
+# Maximum limit of clients connected to the remote kafka broker
+concurrent_client_limit = 3
+
+# See more properties and their definitions at https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+[bridges.properties]
+"message.timeout.ms" = "5000"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "remote-topic1-egress-${local.topic}"
+#The queue_timeout parameter controls how long to retry for if the librdkafka producer queue is full. 0 to never block.
+remote.queue_timeout = "0m"
+#Sets the destination partition of the record.
+#remote.partition = 0
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "remote-topic2-egress"
+#remote.queue_timeout = "0m"
+#remote.partition = 0
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-mqtt.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-mqtt.toml
@@ -1,0 +1,161 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-mqtt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-mqtt.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_1"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+#username = "${ENV:MQTT_USER}"
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+#password = "${ENV:MQTT_PASS}"
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+# Specifies the maximum number of messages that the channel can hold simultaneously.
+message_channel_capacity = 100_000
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v5"
+
+# The following configurations are specific to the protocol version
+# Clear session state
+v4.clean_session = true
+# Last will message configuration, optional
+# Message encoding method, supports plain and base64, default: plain
+v4.last_will = {qos = 0, retain = false, topic = "a/b/c", message = "message content", encoding = "plain"}
+# Or
+# Clear session state on connection
+v5.clean_start = true
+# Session expiry interval, 0 means the session will end immediately upon network disconnection
+v5.session_expiry_interval = "0s"
+# Limit the maximum number of QoS 1 and QoS 2 messages the client can handle simultaneously
+v5.receive_maximum = 16
+# Negotiate the maximum packet size with the client and server
+v5.maximum_packet_size = "1M"
+# Negotiate the maximum number of topic aliases with the client and server
+v5.topic_alias_maximum = 0
+# Last will message configuration, optional
+v5.last_will = {qos = 0, retain = false, topic = "a/b/c", message = "message content", encoding = "plain"}
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/${local.topic}"
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/a"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/a/${local.topic}"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/a/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/a/a/${local.topic}"
+
+
+#-----------------------------------------------------------
+[[bridges]]
+# Whether to enable
+enable = false
+# Bridge name
+name = "bridge_name_2"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v4"
+
+# The following configurations are specific to the protocol version
+# Clear session state
+v4.clean_session = true
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+#remote.qos = 1
+# true/false, default: false
+#remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic2/egress/${local.topic}"
+
+
+
+
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-nats.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-nats.toml
@@ -1,0 +1,58 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-nats
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-nats.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_nats_1"
+# The address of the NATS broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 4222.
+servers = "nats://127.0.0.1:4222"
+#servers = "tls://127.0.0.1:4433"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+## See https://github.com/nats-io/nats.rs/blob/main/async-nats/src/options.rs
+#no_echo = true
+#ping_interval = "60s"
+#connection_timeout = "10s"
+#tls_required = true
+#tls_first = true
+#root_certificates = ""
+#client_cert = ""
+#client_key = ""
+#sender_capacity = 256
+#auth.jwt = ""
+#auth.jwt_seed = ""
+#auth.nkey = ""
+#auth.username = ""
+#auth.password = ""
+#auth.token = ""
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "test1"
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+#remote.forward_all_from = true
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+#remote.forward_all_publish = true
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "test2"
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-pulsar.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-pulsar.toml
@@ -1,0 +1,80 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-pulsar
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-pulsar.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_pulsar_1"
+# The address of the Pulsar broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 6650.
+servers = "pulsar://127.0.0.1:6650"
+# The address of the Pulsar broker that the client would connect to using SSL/TLS.
+# Uncomment this line to enable a secure connection to the local broker at port 6651.
+#servers = "pulsar+ssl://127.0.0.1:6651"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+# add a custom certificate chain from a file to authenticate the server in TLS connections
+#cert_chain_file = "./rmqtt-bin/rmqtt.fullchain.pem"
+#allow insecure TLS connection if set to true, defaults to false
+#allow_insecure_connection = false
+#whether hostname verification is enabled when insecure TLS connection is allowed, defaults to true
+#tls_hostname_verification_enabled = true
+
+#token(JWT, Biscuit)/ or oauth2
+#auth.name = "token"
+#auth.data = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiZXhwIjoxNjI2NzY5MjAwLCJpYXQiOjE2MjY3NjU2MDB9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+#auth.name = "oauth2"
+#auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "non-persistent://public/default/test1"
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+#remote.forward_all_from = false
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+#remote.forward_all_publish = false
+
+#determines the target partition of the message. Messages with the same partition_key will be sent to the same partition.
+#remote.partition_key = ""
+
+#this affects the order of messages within a specific partition, not across partitions. If messages have the same ordering_key, they will be consumed in the order they were sent.
+#Values: clientid, uuid, random or {type="random", len=10}
+# clientid - use mqtt clientid
+# uuid - uuid
+# random - randomly generated
+#remote.ordering_key = "clientid"
+#remote.ordering_key = {type="random", len=10}
+
+#Override namespace's replication
+#remote.replicate_to = []
+
+#current version of the schema
+#remote.schema_version = ""
+
+#user defined properties added to all messages
+#remote.options.metadata = {}
+#algorithm used to compress the messages, value: lz4,zlib,zstd,snappy
+#remote.options.compression = "lz4"
+#producer access mode: shared = 0, exclusive = 1, waitforexclusive = 2, exclusivewithoutfencing = 3
+#remote.options.access_mode = 0
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "non-persistent://public/default/test2"
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-reductstore.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-egress-reductstore.toml
@@ -1,0 +1,59 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-reductstore
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-reductstore.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_reductstore_1"
+# The address of the reductstore broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 8383.
+servers = "http://127.0.0.1:8383"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+# Set the API token to use for authentication.
+#api_token = ""
+# Set the timeout for HTTP requests.
+#timeout = "15s"
+# Set the SSL verification to false.
+#verify_ssl = false
+
+[[bridges.entries]]
+# Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+# The name of the bucket
+remote.bucket = "bucket1"
+remote.entry = "test1"
+# Set the quota size.
+remote.quota_size = 1_000_000_000
+# Don't fail if the bucket already exists.
+remote.exist_ok = true
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+remote.forward_all_from = true
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+remote.forward_all_publish = true
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+# Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.bucket = "bucket2"
+remote.entry = "test2"
+# Set the quota size.
+remote.quota_size = 1_000_000_000
+# Don't fail if the bucket already exists.
+remote.exist_ok = true
+
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -1,0 +1,58 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-kafka
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-kafka.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_kafka_1"
+
+# The list of broker (server) addresses for the Kafka cluster.
+#servers = "127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094"
+servers = "127.0.0.1:9092"
+# client.id
+client_id_prefix = "kafka_001"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# See more properties and their definitions at https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+[bridges.properties]
+"message.timeout.ms" = "5000"
+#"enable.auto.commit" = "false"
+
+[[bridges.entries]]
+remote.topic = "remote-topic1-ingress"
+remote.group_id = "group_id_001"
+#remote.start_partition = -1
+#remote.stop_partition = -1
+# "beginning", "end", "stored" or "<offset>", "<-offset>"
+#remote.offset = "beginning"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+#local.qos = 1
+local.topic = "local/topic1/ingress/${kafka.key}"
+# true/false, default: false
+#local.retain = true
+
+[[bridges.entries]]
+remote.topic = "remote-topic2-ingress"
+remote.group_id = "group_id_002"
+#remote.start_partition = -1
+#remote.stop_partition = -1
+# "beginning", "end", "stored" or "<offset>", "<-offset>"
+#remote.offset = "beginning"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic2/ingress"
+local.retain = false
+
+
+
+
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-ingress-mqtt.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-ingress-mqtt.toml
@@ -1,0 +1,148 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-mqtt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-mqtt.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_1"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+# or "tcp://127.0.0.1:1883" or "tls://127.0.0.1:8883"
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+#username = "${ENV:MQTT_USER}"
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+#password = "${ENV:MQTT_PASS}"
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v4"
+
+## The following configuration is related to specific protocol versions
+# Clean session
+v4.clean_session = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2, default: 0
+remote.qos = 1
+remote.topic = "$share/g/remote/topic1/ingress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+local.qos = 1
+local.topic = "local/topic1/ingress/${remote.topic}"
+# true/false, default: false
+local.retain = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2
+remote.qos = 1
+remote.topic = "$share/g/remote/topic2/ingress"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic2/ingress"
+local.retain = false
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_2"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+# or "tcp://127.0.0.1:1883" or "tls://127.0.0.1:8883"
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+
+
+# Username to connect to the remote MQTT broker
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v5"
+
+## The following configuration is related to specific protocol versions
+# Clean start
+v5.clean_start = true
+# Session expiry interval, 0 means the session ends immediately after the network disconnection
+v5.session_expiry_interval = "0s"
+# Limit the maximum number of QoS 1 and QoS 2 messages the client can process simultaneously
+v5.receive_maximum = 16
+# The maximum packet size negotiated between client and server
+v5.maximum_packet_size = "1M"
+# The maximum number of topic aliases negotiated between client and server
+v5.topic_alias_maximum = 0
+
+[[bridges.entries]]
+# Choose 0, 1, 2, default: 0
+remote.qos = 0
+remote.topic = "$share/g/remote/topic3/ingress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+local.qos = 1
+local.topic = "local/topic3/ingress/${remote.topic}"
+# true/false, default: false
+local.retain = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2
+remote.qos = 1
+remote.topic = "$share/g/remote/topic4/ingress"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic4/ingress"
+local.retain = false
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-ingress-nats.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-ingress-nats.toml
@@ -1,0 +1,69 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-nats
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-nats.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_nats_1"
+# The address of the NATS broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 4222.
+servers = "nats://127.0.0.1:4222"
+#servers = "tls://127.0.0.1:4433"
+
+# Consumer name prefix
+consumer_name_prefix = "consumer_1"
+
+## See https://github.com/nats-io/nats.rs/blob/main/async-nats/src/options.rs
+#no_echo = true
+#ping_interval = "60s"
+#connection_timeout = "10s"
+#tls_required = true
+#tls_first = true
+#root_certificates = ""
+#client_cert = ""
+#client_key = ""
+#sender_capacity = 256
+#auth.jwt = ""
+#auth.jwt_seed = ""
+#auth.nkey = ""
+#auth.username = ""
+#auth.password = ""
+#auth.token = ""
+
+[[bridges.entries]]
+
+remote.topic = "test1"
+#remote.group = "group1"
+
+local.topic = "local/topic1/ingress/${remote.topic}"
+
+## Choose 0, 1, 2, or not set (follow message QoS, i.e. user-defined properties "qos")
+##
+## Value: 0 | 1 | 2
+#local.qos = 1
+
+## Choose true or false, or not set (follow message Retain, i.e. user-defined properties "retain")
+##
+## Value: true | false
+## Default: false
+#local.retain = false
+
+## Allow forwarding of empty messages
+##
+## Value: true | false
+## Default: true
+#local.allow_empty_forward = false
+
+[[bridges.entries]]
+remote.topic = "test2"
+#remote.group = "group2"
+
+local.topic = "local/topic2/ingress"
+#local.qos = 0
+#local.retain = false
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-ingress-pulsar.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-ingress-pulsar.toml
@@ -1,0 +1,216 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-pulsar
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-pulsar.md
+
+[[bridges]]
+
+## Whether to enable
+##
+## Value: true | false
+## Default: false
+enable = true
+
+## Bridge name
+##
+## Value: String
+name = "bridge_pulsar_1"
+
+## The address of the Pulsar broker that the client will connect to using plain TCP.
+## In this case, it's connecting to the local broker at port 6650.
+##
+## The address of the Pulsar broker that the client would connect to using SSL/TLS.
+## Uncomment this line to enable a secure connection to the local broker at port 6651.
+##
+## Value: URL
+#servers = "pulsar+ssl://127.0.0.1:6651"
+servers = "pulsar://127.0.0.1:6650"
+
+## Consumer name prefix
+##
+## Value: String
+consumer_name_prefix = "consumer_1"
+
+## Add a custom certificate chain from a file to authenticate the server in TLS connections
+##
+## Value: String
+#cert_chain_file = "./rmqtt-bin/rmqtt.fullchain.pem"
+
+## Allow insecure TLS connection if set to true, defaults to false
+##
+## Value: true | false
+## Default: false
+#allow_insecure_connection = false
+
+## Whether hostname verification is enabled when insecure TLS connection is allowed, defaults to true
+##
+## Value: true | false
+## Default: true
+#tls_hostname_verification_enabled = true
+
+## Auth Configuration
+##
+## Value: token(JWT, Biscuit)/ or oauth2
+#auth.name = "token"
+#auth.data = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiZXhwIjoxNjI2NzY5MjAwLCJpYXQiOjE2MjY3NjU2MDB9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+#auth.name = "oauth2"
+#auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
+
+## Message expiration time, 0 means no expiration
+##
+## Value: Duration
+## Default: "5m"
+expiry_interval = "5m"
+
+[[bridges.entries]]
+
+## Sets the consumer's topic or add one to the list of topics
+##
+## Value: String
+remote.topic = "non-persistent://public/default/test"
+
+## Adds a list of topics to the future consumer
+##
+## Value: String
+#remote.topics = ["non-persistent://public/default/test1", "non-persistent://public/default/test2"]
+
+## Sets up a consumer that will listen on all topics matching the regular expression
+##
+## Value: String
+#remote.topic_regex = "non-persistent://public/default/.*"
+
+## Sets the kind of subscription
+##
+## Value: "exclusive", "shared", "failover", "key_shared"
+#remote.subscription_type = "shared"
+
+## Sets the subscription's name
+##
+## Value: String
+#remote.subscription = ""
+
+## Tenant/Namespace to be used when matching against a regex. For other consumers, specify namespace using the
+## `<persistent|non-persistent://<tenant>/<namespace>/<topic>` topic format.
+##
+## Defaults to `public/default` if not specifid
+##
+## Value: String
+#lookup_namespace = ""
+
+## Interval for refreshing the topics when using a topic regex. Unused otherwise.
+##
+## Value: Duration
+#topic_refresh_interval = "10s"
+
+## Sets the consumer id for this consumer
+##
+## Value: u64
+#consumer_id = 1
+
+## Sets the batch size
+## batch messages containing more than the configured batch size will not be sent by Pulsar
+##
+## Value: u64
+## Default: 1000
+#batch_size = 1000
+
+## Sets the dead letter policy
+##
+## Value: Object
+#remote.dead_letter_policy = {max_redeliver_count = 10, dead_letter_topic = "test_topic"}
+
+## The time after which a message is dropped without being acknowledged or nacked
+## that the message is resent. If `None`, messages will only be resent when a
+## consumer disconnects with pending unacknowledged messages.
+##
+## Value: Duration
+#remote.unacked_message_resend_delay = "20s"
+
+
+### Configuration options for consumers
+
+## Sets the priority level
+##
+## Value: i32
+#remote.options.priority_level = 3
+
+## Signal whether the subscription should be backed by a durable cursor or not
+##
+## Value: true | false
+#remote.options.durable = false
+
+## Read compacted
+##
+## Value: true | false
+#remote.options.read_compacted = false
+
+## Signal whether the subscription will initialize on latest
+## or earliest message (default on latest)
+##
+## Value: earliest | latest
+## latest - start at the most recent message
+## earliest - start at the oldest message
+#remote.options.initial_position = "latest"
+
+## User defined properties added to all messages
+##
+## Value: Object
+#remote.options.metadata = {}
+
+## Payload data format
+##
+## Value: bytes | json
+## Default: bytes
+#remote.payload_format = "json"
+
+## Payload Path
+##
+## Extract the publish payload from the Pulsar message payload. This config item is only supported when
+## `remote.payload_format` is set to JSON. For example: `/msg` or `/data/msg`
+##
+## Value: String
+#remote.payload_path = "msg"
+
+## MQTT publish message topic,
+##
+## Value: String
+##
+## Placeholder:
+##  - ${remote.topic}: pulsar message topic.
+##  - ${remote.properties.xxxx}: user-defined properties "topic". ${remote.properties.topic}
+##  - ${remote.payload.xxxx}: Extract the topic from the Pulsar message payload. If the topic is an array, the message will be
+##                     forwarded to each target topic individually. This placeholder is only supported when
+##                     `remote.payload_format` is set to JSON. For example: `${remote.payload.topics}`
+##
+local.topic = "local/topic1/ingress/${remote.topic}"
+#local.topics = ["local/topic1/ingress/${remote.properties.topic1}", "${remote.properties.topic2}", "${remote.payload.topic}", "${remote.payload.topics}"]
+
+## Choose 0, 1, 2, or not set (follow message QoS, i.e. user-defined properties "qos")
+##
+## Value: 0 | 1 | 2
+#local.qos = 1
+
+## Choose true or false, or not set (follow message Retain, i.e. user-defined properties "retain")
+##
+## Value: true | false
+## Default: false
+#local.retain = false
+
+## Allow forwarding of empty messages
+##
+## Value: true | false
+## Default: true
+#local.allow_empty_forward = false
+
+[[bridges.entries]]
+
+remote.topic = "non-persistent://public/default/test9"
+
+local.topic = "local/topic2/ingress"
+#local.qos = 0
+#local.retain = false
+
+
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-origin.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-bridge-origin.toml
@@ -1,0 +1,28 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-origin
+##--------------------------------------------------------------------
+##
+## This plugin identifies whether an MQTT client originates from a
+## bridge-ingress-mqtt or bridge-egress-mqtt connection by checking
+## the client_id against configurable markers.
+##
+## The identified bridge origin is stored in session.extra_attrs
+## under the configurable attr_key, making it available to other
+## plugins (e.g., for anti-loop or routing decisions).
+##
+## See: https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-origin.md
+##--------------------------------------------------------------------
+
+# Marker string to identify ingress bridge clients.
+# If a client_id contains this substring, it is treated as an ingress bridge client.
+# Default: ":ingress:"
+#ingress_marker = ":ingress:"
+
+# Marker string to identify egress bridge clients.
+# If a client_id contains this substring, it is treated as an egress bridge client.
+# Default: ":egress:"
+#egress_marker = ":egress:"
+
+# Key used to store BridgeOrigin in session.extra_attrs.
+# Default: "bridge_origin"
+#attr_key = "bridge_origin"

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-cluster-broadcast.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-cluster-broadcast.toml
@@ -1,0 +1,24 @@
+##--------------------------------------------------------------------
+## rmqtt-cluster-broadcast
+##--------------------------------------------------------------------
+
+#grpc message type
+message_type = 98
+# The list of gRPC addresses for the nodes in the cluster.
+# Each entry contains the node ID (e.g., 1, 2, 3) followed by the corresponding IP address and port.
+# These addresses are used for inter-node communication within the cluster.
+node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+#Maximum number of messages sent in batch
+node_grpc_batch_size = 128
+##Client concurrent request limit
+node_grpc_client_concurrency_limit = 128
+##Connect and send to server timeout
+node_grpc_client_timeout = "15s"
+
+##Task execution queue workers
+task_exec_queue_workers = 500
+
+##Task execution queue max capacity
+task_exec_queue_max = 100_000
+
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-cluster-raft.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-cluster-raft.toml
@@ -1,0 +1,87 @@
+##--------------------------------------------------------------------
+## rmqtt-cluster-raft
+##--------------------------------------------------------------------
+
+#cluster raft worker threads
+worker_threads = 6
+
+#grpc message type
+message_type = 198
+# The list of gRPC addresses for the nodes in the cluster.
+# Each entry contains the node ID (e.g., 1, 2, 3) followed by the corresponding IP address and port.
+# These addresses are used for communication between the nodes using gRPC.
+node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+#Maximum number of messages sent in batch
+node_grpc_batch_size = 128
+##Client concurrent request limit
+node_grpc_client_concurrency_limit = 128
+##Connect and send to server timeout
+node_grpc_client_timeout = "10s"
+
+# The list of Raft peer addresses for the nodes in the cluster.
+# Each entry contains the node ID and the corresponding IP address and port for Raft consensus communication.
+# These addresses are used by the Raft protocol to maintain consistency and coordination across the nodes.
+raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+
+#Raft cluster listening address
+#If this listening address is not specified, the address of the node corresponding to `raft_peer_addrs` will be used.
+#laddr = "0.0.0.0:6003"
+
+# Specify the leader node ID.
+#
+# This option is primarily intended for single-host pseudo-cluster deployments,
+# where multiple cluster nodes run on the same machine for testing or development.
+#
+# In a real distributed cluster, leader election is performed automatically and
+# this option is typically unnecessary.
+#
+# When the value is 0 or not specified, the first node in the cluster
+# configuration will be designated as the Leader.
+#
+# It can also be overridden via the CLI flag `--raft-leader-id`.
+#
+# Default value: 0
+leader_id = 0
+
+#Handshake lock timeout
+try_lock_timeout = "10s"
+task_exec_queue_workers = 500
+task_exec_queue_max = 100_000
+
+#algorithm used to compress the snapshot, value: zstd,lz4,zlib,snappy
+compression = "zstd"
+
+#Check the health of the node, and automatically terminate the program if the node is abnormal.
+#Default value: false
+health.exit_on_node_unavailable = false
+#Exit code on program termination.
+#Default value: -1
+health.exit_code = -1
+#When exit_on_node_unavailable is enabled, the program will terminate after a specified number of consecutive node failures.
+#Default value: 2
+health.max_continuous_unavailable_count = 2
+#Cluster node unavailability check interval.
+#Default value: 2 seconds
+health.unavailable_check_interval = "2s"
+
+raft.grpc_timeout = "6s"
+raft.grpc_concurrency_limit = 200
+raft.grpc_breaker_threshold = 5
+raft.grpc_breaker_retry_interval = "2500ms"
+raft.proposal_batch_size = 60
+raft.proposal_batch_timeout = "200ms"
+raft.snapshot_interval = "300s"
+raft.heartbeat = "100ms"
+
+raft.election_tick = 10
+raft.heartbeat_tick = 5
+raft.max_size_per_msg = 0
+raft.max_inflight_msgs = 256
+raft.check_quorum = true
+raft.pre_vote = true
+raft.min_election_tick = 0
+raft.max_election_tick = 0
+raft.read_only_option = "Safe"
+raft.skip_bcast_commit = false
+raft.batch_append = false
+raft.priority = 0

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-http-api.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-http-api.toml
@@ -1,0 +1,102 @@
+##--------------------------------------------------------------------
+## rmqtt-http-api
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
+## Max Row Limit
+max_row_limit = 10_000
+## HTTP Listener address
+http_laddr = "0.0.0.0:6060"
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
+
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory (optional).
+##
+## By default (when unset), the Dashboard SPA is served from assets
+## embedded directly into the binary via rust-embed at compile time,
+## so no external files are needed.
+##
+## If set, the http-api plugin loads the Dashboard SPA from this
+## external directory at the `/dashboard/` path instead, which allows
+## swapping the frontend build without recompiling the binary.
+# dashboard_static_dir = "/path/to/dashboard/dist"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##─── Redb backend ──────────────────────────────────────────────────────
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##─── Sled backend (default) ─────────────────────────────────────────────
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##─── Redis backend ──────────────────────────────────────────────────────
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##─── Redis Cluster backend ──────────────────────────────────────────────
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##─── Flush interval (how often to snapshot Stats/Metrics) ───────────────
+## Default: "5s"
+# flush_interval = "5s"
+
+##─── History retention (TTL for each data point) ────────────────────────
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-message-storage.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-message-storage.toml
@@ -1,0 +1,37 @@
+##--------------------------------------------------------------------
+## rmqtt-message-storage
+##--------------------------------------------------------------------
+
+##ram, redis, redis-cluster
+storage.type = "ram"
+
+##ram
+storage.ram.cache_capacity = "3G"
+storage.ram.cache_max_count = 1_000_000
+storage.ram.encode = false
+
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "message-{node}"
+
+##redis-cluster
+storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
+storage.redis-cluster.prefix = "message-{node}"
+
+##Quantity of expired messages cleared during each cleanup cycle.
+cleanup_count = 5000
+
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
+
+##─── Circuit breaker ────────────────────────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##The per-operation timeout uses `backend_timeout` above.

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-p2p-messaging.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-p2p-messaging.toml
@@ -1,0 +1,8 @@
+##--------------------------------------------------------------------
+## rmqtt-p2p-messaging
+##--------------------------------------------------------------------
+
+#"prefix": `p2p/{clientid}/{topic}` — the `p2p` identifier is at the start.
+#"suffix": `{topic}/p2p/{clientid}` — the `p2p` identifier is at the end.
+#"both": supports both prefix and suffix formats.
+mode = "prefix"

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-retainer.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-retainer.toml
@@ -1,0 +1,44 @@
+##--------------------------------------------------------------------
+## rmqtt-retainer
+##--------------------------------------------------------------------
+#
+# Single node mode         - ram, sled, redis
+# Multi-node cluster mode  - ram, sled, redis
+#
+
+##ram, sled, redis
+storage.type = "ram"
+
+##sled
+storage.sled.path = "/var/log/rmqtt/.cache/retain/{node}"
+storage.sled.cache_capacity = "3G"
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "retain"
+
+# The maximum number of retained messages, where 0 indicates no limit. After the number of reserved messages exceeds
+# the maximum limit, existing reserved messages can be replaced, but reserved messages cannot be stored for new topics.
+max_retained_messages = 0
+
+# The maximum Payload value for retaining messages. After the Payload size exceeds the maximum value, the RMQTT
+# message server will process the received reserved message as a regular message.
+max_payload_size = "1MB"
+
+# TTL for retained messages. Set to 0 for no expiration.
+# If not specified, the message expiration time will be used by default.
+retained_message_ttl = "0m"
+
+# Maximum number of messages per batch (default: 500).
+batch_messages_limit = 500
+
+##─── Backend timeout (circuit breaker) ──────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##Only the backend operation timeout can be overridden here.
+##
+##Backend storage operation timeout. If a storage call (Sled/Redis)
+##exceeds this duration it is aborted and counted as a failure by the
+##circuit breaker. Set to "0s" to disable.
+##Default: "8s"
+#backend_timeout = "8s"

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-session-storage.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-session-storage.toml
@@ -1,0 +1,29 @@
+##--------------------------------------------------------------------
+## rmqtt-session-storage
+##--------------------------------------------------------------------
+
+##sled, redis, redis-cluster
+storage.type = "sled"
+
+##sled
+storage.sled.path = "/var/log/rmqtt/.cache/session/{node}"
+storage.sled.cache_capacity = "3G"
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "session-{node}"
+
+##redis-cluster
+storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
+storage.redis-cluster.prefix = "session-{node}"
+
+##─── Backend timeout (circuit breaker) ──────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##Only the backend operation timeout can be overridden here.
+
+##Backend storage operation timeout. If a storage call (Sled/Redis)
+##exceeds this duration it is aborted and counted as a failure by the
+##circuit breaker. Set to "0s" to disable.
+##Default: "15s"
+#backend_timeout = "15s"

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-shared-subscription.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-shared-subscription.toml
@@ -1,0 +1,19 @@
+# rmqtt-shared-subscription Plugin Configuration
+#
+# Supported strategies:
+#   random              - Random subscriber selection (basic load balancing)
+#   round_robin         - Sequential round-robin (default)
+#   round_robin_per_group - Per-node independent round-robin (large cluster)
+#   sticky              - Fixed subscriber per publisher (stateful processing)
+#   local               - Prefer publisher's node (reduce cross-node traffic)
+#   hash_clientid       - Hash by publisher ClientId (per-device ordering)
+#   hash_topic          - Hash by topic (topic sharding)
+
+# Selection strategy
+# Default: round_robin
+strategy = "round_robin"
+
+# Maximum sticky bindings in the LRU cache (only applies to "sticky" strategy).
+# When the cache fills up, the least recently used binding is evicted.
+# Default: 100000
+sticky_cache_size = 100000

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-sys-topic.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-topic-rewrite.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-topic-rewrite.toml
@@ -1,0 +1,22 @@
+##--------------------------------------------------------------------
+## rmqtt-topic-rewrite
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/topic-rewrite.md
+
+# action - Options are publish, subscribe, or all
+# source_topic_filter - Topic filter for subscribing, unsubscribing, or publishing messages
+# dest_topic - Destination topic
+# regex - Regular expression
+
+# Expressions can use ${clientid} to represent the client ID and ${username} to represent the client username.
+
+rules = [
+#    { action = "all", source_topic_filter = "x/+/#", dest_topic = "xx/$1/$2", regex = "^x/(.+)/(.+)$" },
+#    { action = "all", source_topic_filter = "x/y/1", dest_topic = "xx/y/1" },
+#    { action = "all", source_topic_filter = "x/y/#", dest_topic = "xx/y/$1", regex = "^x/y/(.+)$" },
+#    { action = "all", source_topic_filter = "iot/cid/#", dest_topic = "iot/${clientid}/$1", regex = "^iot/cid/(.+)$" },
+#    { action = "all", source_topic_filter = "iot/uname/#", dest_topic = "iot/${username}/$1", regex = "^iot/uname/(.+)$" },
+#    { action = "all", source_topic_filter = "a/+/+/+", dest_topic = "aa/$1/$2/$3", regex = "^a/(.+)/(.+)/(.+)$" }
+]
+

--- a/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-web-hook.toml
+++ b/rmqtt-test/configs/pubrel-collision/plugins/rmqtt-web-hook.toml
@@ -1,0 +1,53 @@
+##--------------------------------------------------------------------
+## rmqtt-web-hook
+##--------------------------------------------------------------------
+## http
+#    Method: POST
+#    Body: <JSON>
+#    Payload: BASE64
+## file
+#    None
+#
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/web-hook.md
+
+##--------------------------------------------------------------------
+## Hook General Config
+##--------------------------------------------------------------------
+# Maximum number of tasks that can be queued before new tasks are rejected.
+# Changing this value requires restarting the service to take effect.
+queue_capacity = 300_000
+
+# Maximum number of tasks that can be executed concurrently.
+# Changing this value requires restarting the service to take effect.
+concurrency_limit = 128
+
+
+## Default urls, supports http and file protocols
+#urls = ["file:///var/log/rmqtt/hook.log", "http://127.0.0.1:5656/mqtt/webhook"]
+urls = ["file:///var/log/rmqtt/hook.log"]
+
+## Http config
+http_timeout = "8s"
+#If it fails, try again after approximately 2, 4, 7, 11, 18, or 42 seconds
+retry_max_elapsed_time = "60s"
+retry_multiplier = 2.5
+
+## Hook rules config
+rule.session_created = [{action = "session_created" } ]
+rule.session_terminated = [{action = "session_terminated" } ]
+rule.session_subscribed = [{action = "session_subscribed"  } ]
+rule.session_unsubscribed = [{action = "session_unsubscribed" } ]
+
+rule.client_connect = [{action = "client_connect"}]
+rule.client_connack = [{action = "client_connack"} ]
+rule.client_connected = [{action = "client_connected" } ]
+rule.client_disconnected = [{action = "client_disconnected" } ]
+rule.client_subscribe = [{action = "client_subscribe" } ]
+rule.client_unsubscribe = [{action = "client_unsubscribe" } ]
+
+rule.message_publish = [{action = "message_publish", topics=["#", "$SYS/#"] }]
+rule.message_delivered = [{action = "message_delivered", topics=["#", "$SYS/#"] } ]
+rule.message_acked = [{action = "message_acked", topics=["#", "$SYS/#"] } ]
+rule.message_dropped = [{action = "message_dropped" } ]
+rule.offline_message = [{action = "offline_message", topics=["#", "$SYS/#"] }]

--- a/rmqtt-test/configs/pubrel-collision/rmqtt.toml
+++ b/rmqtt-test/configs/pubrel-collision/rmqtt.toml
@@ -39,7 +39,8 @@ log.file = "rmqtt.log"
 ##--------------------------------------------------------------------
 ## Plugins
 ##--------------------------------------------------------------------
-plugins.dir = "rmqtt-plugins/"
+# Self-contained: plugin configs live in this directory's plugins/ sub-dir.
+plugins.dir = "rmqtt-test/configs/pubrel-collision/plugins/"
 # Only the message-storage plugin is required for the reproduction.
 plugins.default_startups = [
     "rmqtt-message-storage",

--- a/rmqtt-test/configs/retain-disabled/plugins/Cargo.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/Cargo.toml
@@ -1,0 +1,138 @@
+[package]
+name = "rmqtt-plugins"
+version.workspace = true
+description = "Plugin collection for rmqtt, providing authentication, storage, bridges, clustering, and other extensions."
+repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-plugins"
+edition.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = []
+full = [
+    "retainer-ram",
+    "retainer-sled",
+    "retainer-redis",
+
+    "message-storage-ram",
+    "message-storage-redis",
+    "message-storage-redis-cluster",
+
+    "session-storage-sled",
+    "session-storage-redis",
+    "session-storage-redis-cluster",
+
+    "acl",
+    "http-api",
+    "counter",
+    "auth-http",
+    "auth-jwt",
+    "auto-subscription",
+
+    "bridge-egress-kafka",
+    "bridge-ingress-kafka",
+    "bridge-egress-mqtt",
+    "bridge-ingress-mqtt",
+    "bridge-egress-pulsar",
+    "bridge-ingress-pulsar",
+    "bridge-ingress-nats",
+    "bridge-egress-nats",
+    "bridge-egress-reductstore",
+    "bridge-origin",
+
+    "p2p-messaging",
+
+    "shared-subscription",
+
+    "sys-topic",
+    "topic-rewrite",
+    "web-hook",
+
+    "cluster-raft",
+    "cluster-broadcast",
+]
+
+# ---- storage sub-features ----
+retainer-ram = ["rmqtt-retainer/ram"]
+retainer-sled = ["rmqtt-retainer/sled"]
+retainer-redis = ["rmqtt-retainer/redis"]
+retainer = ["retainer-ram", "retainer-sled", "retainer-redis"]
+
+message-storage-ram = ["rmqtt-message-storage/ram"]
+message-storage-redis = ["rmqtt-message-storage/redis"]
+message-storage-redis-cluster = ["rmqtt-message-storage/redis-cluster"]
+message-storage = ["message-storage-ram", "message-storage-redis", "message-storage-redis-cluster"]
+
+session-storage-sled = ["rmqtt-session-storage/sled"]
+session-storage-redis = ["rmqtt-session-storage/redis"]
+session-storage-redis-cluster = ["rmqtt-session-storage/redis-cluster"]
+session-storage = ["session-storage-sled", "session-storage-redis", "session-storage-redis-cluster"]
+
+# ---- http-api sub-features ----
+http-api-sled = ["rmqtt-http-api/sled"]
+http-api-redis = ["rmqtt-http-api/redis"]
+http-api-redis-cluster = ["http-api-redis", "rmqtt-http-api/redis-cluster"]
+http-api-redb = ["rmqtt-http-api/redb"]
+http-api = ["http-api-sled", "http-api-redis", "http-api-redis-cluster", "http-api-redb"]
+
+# ---- core plugins ----
+acl = ["rmqtt-acl"]
+counter = ["rmqtt-counter"]
+auth-http = ["rmqtt-auth-http"]
+auth-jwt = ["rmqtt-auth-jwt"]
+auto-subscription = ["rmqtt-auto-subscription"]
+
+# ---- bridge plugins ----
+bridge-egress-kafka = ["rmqtt-bridge-egress-kafka"]
+bridge-ingress-kafka = ["rmqtt-bridge-ingress-kafka"]
+bridge-egress-mqtt = ["rmqtt-bridge-egress-mqtt"]
+bridge-ingress-mqtt = ["rmqtt-bridge-ingress-mqtt"]
+bridge-egress-pulsar = ["rmqtt-bridge-egress-pulsar"]
+bridge-ingress-pulsar = ["rmqtt-bridge-ingress-pulsar"]
+bridge-ingress-nats = ["rmqtt-bridge-ingress-nats"]
+bridge-egress-nats = ["rmqtt-bridge-egress-nats"]
+bridge-egress-reductstore = ["rmqtt-bridge-egress-reductstore"]
+bridge-origin = ["rmqtt-bridge-origin"]
+
+# ---- other plugins ----
+shared-subscription = ["rmqtt-shared-subscription"]
+sys-topic = ["rmqtt-sys-topic"]
+topic-rewrite = ["rmqtt-topic-rewrite"]
+web-hook = ["rmqtt-web-hook"]
+p2p-messaging = ["rmqtt-p2p-messaging"]
+
+# ---- cluster plugins ----
+cluster-raft = ["rmqtt-cluster-raft"]
+cluster-broadcast = ["rmqtt-cluster-broadcast"]
+
+[dependencies]
+rmqtt-acl = { workspace = true, optional = true }
+rmqtt-retainer = { workspace = true, optional = true }
+rmqtt-http-api = { workspace = true, optional = true }
+rmqtt-counter = { workspace = true, optional = true }
+rmqtt-auth-http = { workspace = true, optional = true }
+rmqtt-auth-jwt = { workspace = true, optional = true }
+rmqtt-auto-subscription = { workspace = true, optional = true }
+rmqtt-bridge-egress-kafka = { workspace = true, optional = true }
+rmqtt-bridge-ingress-kafka = { workspace = true, optional = true }
+rmqtt-bridge-egress-mqtt = { workspace = true, optional = true }
+rmqtt-bridge-ingress-mqtt = { workspace = true, optional = true }
+rmqtt-bridge-egress-pulsar = { workspace = true, optional = true }
+rmqtt-bridge-ingress-pulsar = { workspace = true, optional = true }
+rmqtt-bridge-ingress-nats = { workspace = true, optional = true }
+rmqtt-bridge-egress-nats = { workspace = true, optional = true }
+rmqtt-bridge-egress-reductstore = { workspace = true, optional = true }
+rmqtt-bridge-origin = { workspace = true, optional = true }
+rmqtt-message-storage = { workspace = true, optional = true }
+rmqtt-session-storage = { workspace = true, optional = true }
+rmqtt-sys-topic = { workspace = true, optional = true }
+rmqtt-shared-subscription = { workspace = true, optional = true }
+rmqtt-topic-rewrite = { workspace = true, optional = true }
+rmqtt-web-hook = { workspace = true, optional = true }
+rmqtt-cluster-raft = { workspace = true, optional = true }
+rmqtt-cluster-broadcast = { workspace = true, optional = true }
+rmqtt-p2p-messaging = { workspace = true, optional = true }

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-acl.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-acl.toml
@@ -1,0 +1,18 @@
+##--------------------------------------------------------------------
+## rmqtt-acl
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/acl.md
+
+#Disconnect if publishing is rejected
+disconnect_if_pub_rejected = true
+
+rules = [
+    #["deny", "all", "subscribe", ["test/nosubscribe"]],
+    ["allow", { user = "dashboard" }, "subscribe", ["$SYS/#"]],
+    ["allow", { ipaddr = "127.0.0.1" }, "pubsub", ["$SYS/#", "#"]],
+    ["deny", "all", "subscribe", ["$SYS/#", { eq = "#" }]],
+    ["allow", "all"]
+    #["deny", "all"]
+]
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-auth-http.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-auth-http.toml
@@ -1,0 +1,71 @@
+##--------------------------------------------------------------------
+## rmqtt-auth-http
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auth-http.md
+
+http_timeout = "5s"
+http_headers.accept = "*/*"
+http_headers.Cache-Control = "no-cache"
+http_headers.User-Agent = "RMQTT/0.15.0"
+http_headers.Connection = "keep-alive"
+
+## Disconnect if publishing is rejected
+##
+## Value: true | false
+## Default: true
+disconnect_if_pub_rejected = true
+
+## Disconnect After Expiration
+##
+## Value: true | false
+## Default: false
+disconnect_if_expiry = false
+
+## Return 'Deny' if http request error otherwise 'Ignore'
+##
+## Value: true | false
+## Default: true
+deny_if_error = true
+
+
+##--------------------------------------------------------------------
+## Authentication request.
+##
+## Variables:
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %P: password
+##
+## Value: URL
+http_auth_req.url = "http://127.0.0.1:9090/mqtt/auth"
+## Value: post | get | put
+http_auth_req.method = "post"
+## HTTP request header of authentication request
+## Content-Type Currently supported values: application/x-www-form-urlencoded, application/json
+http_auth_req.headers = { content-type = "application/x-www-form-urlencoded" }
+#http_auth_req.headers.content-type="application/json"
+## Value: Params
+http_auth_req.params = { clientid = "%c", username = "%u", password = "%P", protocol = "%r" }
+
+
+##--------------------------------------------------------------------
+## ACL request.
+##
+## Variables:
+##  - %A: 1 | 2, 1 = sub, 2 = pub
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %t: topic
+##
+## Value: URL
+http_acl_req.url = "http://127.0.0.1:9090/mqtt/acl"
+## Value: post | get | put
+http_acl_req.method = "post"
+## Value: Params
+http_acl_req.params = { access = "%A", username = "%u", clientid = "%c", ipaddr = "%a", topic = "%t", protocol = "%r" }
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-auth-jwt.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-auth-jwt.toml
@@ -1,0 +1,79 @@
+##--------------------------------------------------------------------
+## rmqtt-auth-jwt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auth-jwt.md
+# Generate a test JWT. See https://jwt.io/#debugger-io
+
+## Disconnect if publishing is rejected
+##
+## Value: true | false
+## Default: true
+disconnect_if_pub_rejected = true
+
+## Disconnect After Expiration
+##
+## Value: true | false
+## Default: false
+disconnect_if_expiry = false
+
+## From where the JWT string can be got
+## Value: username | password
+## Default: password
+from = "password"
+
+## Encryption method
+## Value: hmac-based | public-key
+## Default: hmac-based
+encrypt = "hmac-based"
+
+## HMAC Hash Secret.
+##
+## Value: String
+hmac_secret = "rmqttsecret"
+#hmac_secret = "cm1xdHRzZWNyZXQ="
+
+## Secret Base64 Encode
+##
+## Value: true | false
+## Default: false
+hmac_base64 = false
+
+## RSA or ECDSA public key file.
+##
+## Value: File
+#public_key = "./rmqtt-bin/jwt_public_key_rsa.pem"
+#public_key = "./rmqtt-bin/jwt_public_key_es256.pem"
+#public_key = "./rmqtt-bin/jwt_public_key_es384.pem"
+
+
+## The checklist of claims to validate
+##
+## Value: String
+## validate_claims.$name = expected
+##
+## Placeholder:
+##  - ${username}: username
+##  - ${clientid}: clientid
+##  - ${ipaddr}: client ip addr
+##  - ${protocol}: MQTT protocol version: 3 = 3.1, 4 = 3.1.1, or 5 = 5.0
+
+### Basic Validation
+## > Validate the token's expiration by comparing the exp claim to the current UTC time.
+validate_claims.exp = true
+## < Ensure the token is not used before its nbf claim.
+#validate_claims.nbf = true
+## Ensure the token's subject (sub claim) is as expected.
+#validate_claims.sub = "user@rmqtt.com"
+## Validate the token's issuer by comparing the iss claim to the known issuer.
+#validate_claims.iss = ["https://rmqtt.com1", "https://rmqtt.com"]
+## Verify that the token's audience (aud claim) matches the intended recipient.
+#validate_claims.aud = ["https://your-api.com", "mobile_app", "web_app"]
+
+### Extended Validation
+#validate_claims.clientid = "${clientid}"
+#validate_claims.username = "${username}"
+#validate_claims.ipaddr = "${ipaddr}"
+#validate_claims.protocol = "${protocol}"
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-auto-subscription.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-auto-subscription.toml
@@ -1,0 +1,14 @@
+##--------------------------------------------------------------------
+## rmqtt-auto-subscription
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/auto-subscription.md
+
+# Expressions can use ${clientid} to represent the client ID and ${username} to represent the client username.
+
+subscribes = [
+    { topic_filter = "x/+/#", qos = 1, no_local = false, retain_as_published = false, retain_handling = 0 },
+    { topic_filter = "foo/${clientid}/#", qos = 1, no_local = false, retain_as_published = false, retain_handling = 0 },
+    { topic_filter = "iot/${username}/#", qos = 1 }
+]
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-kafka.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-kafka.toml
@@ -1,0 +1,48 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-kafka
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-kafka.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_kafka_1"
+
+# The list of broker (server) addresses for the Kafka cluster.
+#servers = "127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094"
+servers = "127.0.0.1:9092"
+# client.id
+client_id_prefix = "kafka_001"
+
+# Maximum limit of clients connected to the remote kafka broker
+concurrent_client_limit = 3
+
+# See more properties and their definitions at https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+[bridges.properties]
+"message.timeout.ms" = "5000"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "remote-topic1-egress-${local.topic}"
+#The queue_timeout parameter controls how long to retry for if the librdkafka producer queue is full. 0 to never block.
+remote.queue_timeout = "0m"
+#Sets the destination partition of the record.
+#remote.partition = 0
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "remote-topic2-egress"
+#remote.queue_timeout = "0m"
+#remote.partition = 0
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-mqtt.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-mqtt.toml
@@ -1,0 +1,161 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-mqtt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-mqtt.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_1"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+#username = "${ENV:MQTT_USER}"
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+#password = "${ENV:MQTT_PASS}"
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+# Specifies the maximum number of messages that the channel can hold simultaneously.
+message_channel_capacity = 100_000
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v5"
+
+# The following configurations are specific to the protocol version
+# Clear session state
+v4.clean_session = true
+# Last will message configuration, optional
+# Message encoding method, supports plain and base64, default: plain
+v4.last_will = {qos = 0, retain = false, topic = "a/b/c", message = "message content", encoding = "plain"}
+# Or
+# Clear session state on connection
+v5.clean_start = true
+# Session expiry interval, 0 means the session will end immediately upon network disconnection
+v5.session_expiry_interval = "0s"
+# Limit the maximum number of QoS 1 and QoS 2 messages the client can handle simultaneously
+v5.receive_maximum = 16
+# Negotiate the maximum packet size with the client and server
+v5.maximum_packet_size = "1M"
+# Negotiate the maximum number of topic aliases with the client and server
+v5.topic_alias_maximum = 0
+# Last will message configuration, optional
+v5.last_will = {qos = 0, retain = false, topic = "a/b/c", message = "message content", encoding = "plain"}
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/${local.topic}"
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/a"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/a/${local.topic}"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/a/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+remote.qos = 1
+# true/false, default: false
+remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic/egress/a/a/${local.topic}"
+
+
+#-----------------------------------------------------------
+[[bridges]]
+# Whether to enable
+enable = false
+# Bridge name
+name = "bridge_name_2"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v4"
+
+# The following configurations are specific to the protocol version
+# Clear session state
+v4.clean_session = true
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic/egress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+#remote.qos = 1
+# true/false, default: false
+#remote.retain = false
+# Topic for messages forwarded to the remote MQTT server, where ${local.topic} represents the original topic of the forwarded message.
+remote.topic = "remote/topic2/egress/${local.topic}"
+
+
+
+
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-nats.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-nats.toml
@@ -1,0 +1,58 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-nats
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-nats.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_nats_1"
+# The address of the NATS broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 4222.
+servers = "nats://127.0.0.1:4222"
+#servers = "tls://127.0.0.1:4433"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+## See https://github.com/nats-io/nats.rs/blob/main/async-nats/src/options.rs
+#no_echo = true
+#ping_interval = "60s"
+#connection_timeout = "10s"
+#tls_required = true
+#tls_first = true
+#root_certificates = ""
+#client_cert = ""
+#client_key = ""
+#sender_capacity = 256
+#auth.jwt = ""
+#auth.jwt_seed = ""
+#auth.nkey = ""
+#auth.username = ""
+#auth.password = ""
+#auth.token = ""
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "test1"
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+#remote.forward_all_from = true
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+#remote.forward_all_publish = true
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "test2"
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-pulsar.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-pulsar.toml
@@ -1,0 +1,80 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-pulsar
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-pulsar.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_pulsar_1"
+# The address of the Pulsar broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 6650.
+servers = "pulsar://127.0.0.1:6650"
+# The address of the Pulsar broker that the client would connect to using SSL/TLS.
+# Uncomment this line to enable a secure connection to the local broker at port 6651.
+#servers = "pulsar+ssl://127.0.0.1:6651"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+# add a custom certificate chain from a file to authenticate the server in TLS connections
+#cert_chain_file = "./rmqtt-bin/rmqtt.fullchain.pem"
+#allow insecure TLS connection if set to true, defaults to false
+#allow_insecure_connection = false
+#whether hostname verification is enabled when insecure TLS connection is allowed, defaults to true
+#tls_hostname_verification_enabled = true
+
+#token(JWT, Biscuit)/ or oauth2
+#auth.name = "token"
+#auth.data = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiZXhwIjoxNjI2NzY5MjAwLCJpYXQiOjE2MjY3NjU2MDB9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+#auth.name = "oauth2"
+#auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+remote.topic = "non-persistent://public/default/test1"
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+#remote.forward_all_from = false
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+#remote.forward_all_publish = false
+
+#determines the target partition of the message. Messages with the same partition_key will be sent to the same partition.
+#remote.partition_key = ""
+
+#this affects the order of messages within a specific partition, not across partitions. If messages have the same ordering_key, they will be consumed in the order they were sent.
+#Values: clientid, uuid, random or {type="random", len=10}
+# clientid - use mqtt clientid
+# uuid - uuid
+# random - randomly generated
+#remote.ordering_key = "clientid"
+#remote.ordering_key = {type="random", len=10}
+
+#Override namespace's replication
+#remote.replicate_to = []
+
+#current version of the schema
+#remote.schema_version = ""
+
+#user defined properties added to all messages
+#remote.options.metadata = {}
+#algorithm used to compress the messages, value: lz4,zlib,zstd,snappy
+#remote.options.compression = "lz4"
+#producer access mode: shared = 0, exclusive = 1, waitforexclusive = 2, exclusivewithoutfencing = 3
+#remote.options.access_mode = 0
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+#Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.topic = "non-persistent://public/default/test2"
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-reductstore.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-egress-reductstore.toml
@@ -1,0 +1,59 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-egress-reductstore
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-egress-reductstore.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_reductstore_1"
+# The address of the reductstore broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 8383.
+servers = "http://127.0.0.1:8383"
+
+# producer name prefix
+producer_name_prefix = "producer_1"
+
+# Set the API token to use for authentication.
+#api_token = ""
+# Set the timeout for HTTP requests.
+#timeout = "15s"
+# Set the SSL verification to false.
+#verify_ssl = false
+
+[[bridges.entries]]
+# Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic1/egress/#"
+
+# The name of the bucket
+remote.bucket = "bucket1"
+remote.entry = "test1"
+# Set the quota size.
+remote.quota_size = 1_000_000_000
+# Don't fail if the bucket already exists.
+remote.exist_ok = true
+# forward all from data, including: from_type, from_node, from_ipaddress, from_clientid, from_username
+remote.forward_all_from = true
+# forward all publish data, including: dup, retain, qos, packet_id, topic (required to forward), payload (required to forward)
+remote.forward_all_publish = true
+
+# Number of leading topic levels to skip when substituting ${local.topic} in `remote.topic`.
+# For example, if the local topic is `a/b/c/d` and skip_local_topic_levels = 2,
+# ${local.topic} will resolve to `c/d`.
+#remote.skip_levels = 0
+
+[[bridges.entries]]
+# Local topic filter: All messages matching this topic filter will be forwarded.
+local.topic_filter = "local/topic2/egress/#"
+
+remote.bucket = "bucket2"
+remote.entry = "test2"
+# Set the quota size.
+remote.quota_size = 1_000_000_000
+# Don't fail if the bucket already exists.
+remote.exist_ok = true
+
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-ingress-kafka.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-ingress-kafka.toml
@@ -1,0 +1,58 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-kafka
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-kafka.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_kafka_1"
+
+# The list of broker (server) addresses for the Kafka cluster.
+#servers = "127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094"
+servers = "127.0.0.1:9092"
+# client.id
+client_id_prefix = "kafka_001"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# See more properties and their definitions at https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+[bridges.properties]
+"message.timeout.ms" = "5000"
+#"enable.auto.commit" = "false"
+
+[[bridges.entries]]
+remote.topic = "remote-topic1-ingress"
+remote.group_id = "group_id_001"
+#remote.start_partition = -1
+#remote.stop_partition = -1
+# "beginning", "end", "stored" or "<offset>", "<-offset>"
+#remote.offset = "beginning"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+#local.qos = 1
+local.topic = "local/topic1/ingress/${kafka.key}"
+# true/false, default: false
+#local.retain = true
+
+[[bridges.entries]]
+remote.topic = "remote-topic2-ingress"
+remote.group_id = "group_id_002"
+#remote.start_partition = -1
+#remote.stop_partition = -1
+# "beginning", "end", "stored" or "<offset>", "<-offset>"
+#remote.offset = "beginning"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic2/ingress"
+local.retain = false
+
+
+
+
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-ingress-mqtt.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-ingress-mqtt.toml
@@ -1,0 +1,148 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-mqtt
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-mqtt.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_1"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+# or "tcp://127.0.0.1:1883" or "tls://127.0.0.1:8883"
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+# Username to connect to the remote MQTT broker
+#username = "${ENV:MQTT_USER}"
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+#password = "${ENV:MQTT_PASS}"
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v4"
+
+## The following configuration is related to specific protocol versions
+# Clean session
+v4.clean_session = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2, default: 0
+remote.qos = 1
+remote.topic = "$share/g/remote/topic1/ingress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+local.qos = 1
+local.topic = "local/topic1/ingress/${remote.topic}"
+# true/false, default: false
+local.retain = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2
+remote.qos = 1
+remote.topic = "$share/g/remote/topic2/ingress"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic2/ingress"
+local.retain = false
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_name_2"
+# Client ID prefix
+client_id_prefix = "prefix"
+# Address and port of the remote MQTT broker
+# or "tcp://127.0.0.1:1883" or "tls://127.0.0.1:8883"
+server = "tcp://127.0.0.1:2883"
+#server = "tls://127.0.0.1:9883"
+##SSL / TLS Certificate Type
+#CA signed server certificate
+#root_cert = "./rmqtt-bin/root.pem"
+##CA or Self signed certificates
+#Client Certificate File
+#client_cert = "./rmqtt-bin/client.pem"
+#Client key file
+#client_key = "./rmqtt-bin/client.key"
+
+
+
+# Username to connect to the remote MQTT broker
+username = "rmqtt_u"
+# Password to connect to the remote MQTT broker
+password = "public"
+
+# Maximum limit of clients connected to the remote MQTT broker
+concurrent_client_limit = 5
+# Connection timeout
+connect_timeout = "20s"
+# Keepalive interval
+keepalive = "60s"
+# Automatic reconnection interval
+reconnect_interval = "5s"
+
+## Message expiration time, 0 means no expiration
+expiry_interval = "5m"
+
+# MQTT protocol version to use: v4, v5 corresponding to MQTT 3.1.1, 5.0
+mqtt_ver = "v5"
+
+## The following configuration is related to specific protocol versions
+# Clean start
+v5.clean_start = true
+# Session expiry interval, 0 means the session ends immediately after the network disconnection
+v5.session_expiry_interval = "0s"
+# Limit the maximum number of QoS 1 and QoS 2 messages the client can process simultaneously
+v5.receive_maximum = 16
+# The maximum packet size negotiated between client and server
+v5.maximum_packet_size = "1M"
+# The maximum number of topic aliases negotiated between client and server
+v5.topic_alias_maximum = 0
+
+[[bridges.entries]]
+# Choose 0, 1, 2, default: 0
+remote.qos = 0
+remote.topic = "$share/g/remote/topic3/ingress/#"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+local.qos = 1
+local.topic = "local/topic3/ingress/${remote.topic}"
+# true/false, default: false
+local.retain = true
+
+[[bridges.entries]]
+# Choose 0, 1, 2
+remote.qos = 1
+remote.topic = "$share/g/remote/topic4/ingress"
+
+# Choose 0, 1, 2, or not set (follow message QoS)
+# local.qos = 0
+local.topic = "local/topic4/ingress"
+local.retain = false
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-ingress-nats.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-ingress-nats.toml
@@ -1,0 +1,69 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-nats
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-nats.md
+
+[[bridges]]
+# Whether to enable
+enable = true
+# Bridge name
+name = "bridge_nats_1"
+# The address of the NATS broker that the client will connect to using plain TCP.
+# In this case, it's connecting to the local broker at port 4222.
+servers = "nats://127.0.0.1:4222"
+#servers = "tls://127.0.0.1:4433"
+
+# Consumer name prefix
+consumer_name_prefix = "consumer_1"
+
+## See https://github.com/nats-io/nats.rs/blob/main/async-nats/src/options.rs
+#no_echo = true
+#ping_interval = "60s"
+#connection_timeout = "10s"
+#tls_required = true
+#tls_first = true
+#root_certificates = ""
+#client_cert = ""
+#client_key = ""
+#sender_capacity = 256
+#auth.jwt = ""
+#auth.jwt_seed = ""
+#auth.nkey = ""
+#auth.username = ""
+#auth.password = ""
+#auth.token = ""
+
+[[bridges.entries]]
+
+remote.topic = "test1"
+#remote.group = "group1"
+
+local.topic = "local/topic1/ingress/${remote.topic}"
+
+## Choose 0, 1, 2, or not set (follow message QoS, i.e. user-defined properties "qos")
+##
+## Value: 0 | 1 | 2
+#local.qos = 1
+
+## Choose true or false, or not set (follow message Retain, i.e. user-defined properties "retain")
+##
+## Value: true | false
+## Default: false
+#local.retain = false
+
+## Allow forwarding of empty messages
+##
+## Value: true | false
+## Default: true
+#local.allow_empty_forward = false
+
+[[bridges.entries]]
+remote.topic = "test2"
+#remote.group = "group2"
+
+local.topic = "local/topic2/ingress"
+#local.qos = 0
+#local.retain = false
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-ingress-pulsar.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-ingress-pulsar.toml
@@ -1,0 +1,216 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-ingress-pulsar
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-ingress-pulsar.md
+
+[[bridges]]
+
+## Whether to enable
+##
+## Value: true | false
+## Default: false
+enable = true
+
+## Bridge name
+##
+## Value: String
+name = "bridge_pulsar_1"
+
+## The address of the Pulsar broker that the client will connect to using plain TCP.
+## In this case, it's connecting to the local broker at port 6650.
+##
+## The address of the Pulsar broker that the client would connect to using SSL/TLS.
+## Uncomment this line to enable a secure connection to the local broker at port 6651.
+##
+## Value: URL
+#servers = "pulsar+ssl://127.0.0.1:6651"
+servers = "pulsar://127.0.0.1:6650"
+
+## Consumer name prefix
+##
+## Value: String
+consumer_name_prefix = "consumer_1"
+
+## Add a custom certificate chain from a file to authenticate the server in TLS connections
+##
+## Value: String
+#cert_chain_file = "./rmqtt-bin/rmqtt.fullchain.pem"
+
+## Allow insecure TLS connection if set to true, defaults to false
+##
+## Value: true | false
+## Default: false
+#allow_insecure_connection = false
+
+## Whether hostname verification is enabled when insecure TLS connection is allowed, defaults to true
+##
+## Value: true | false
+## Default: true
+#tls_hostname_verification_enabled = true
+
+## Auth Configuration
+##
+## Value: token(JWT, Biscuit)/ or oauth2
+#auth.name = "token"
+#auth.data = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiZXhwIjoxNjI2NzY5MjAwLCJpYXQiOjE2MjY3NjU2MDB9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+#auth.name = "oauth2"
+#auth.data = "{\"issuer_url\":\"https://example.com/oauth2/issuer\", \"credentials_url\":\"file:///path/to/credentials/file.json\"}"
+
+## Message expiration time, 0 means no expiration
+##
+## Value: Duration
+## Default: "5m"
+expiry_interval = "5m"
+
+[[bridges.entries]]
+
+## Sets the consumer's topic or add one to the list of topics
+##
+## Value: String
+remote.topic = "non-persistent://public/default/test"
+
+## Adds a list of topics to the future consumer
+##
+## Value: String
+#remote.topics = ["non-persistent://public/default/test1", "non-persistent://public/default/test2"]
+
+## Sets up a consumer that will listen on all topics matching the regular expression
+##
+## Value: String
+#remote.topic_regex = "non-persistent://public/default/.*"
+
+## Sets the kind of subscription
+##
+## Value: "exclusive", "shared", "failover", "key_shared"
+#remote.subscription_type = "shared"
+
+## Sets the subscription's name
+##
+## Value: String
+#remote.subscription = ""
+
+## Tenant/Namespace to be used when matching against a regex. For other consumers, specify namespace using the
+## `<persistent|non-persistent://<tenant>/<namespace>/<topic>` topic format.
+##
+## Defaults to `public/default` if not specifid
+##
+## Value: String
+#lookup_namespace = ""
+
+## Interval for refreshing the topics when using a topic regex. Unused otherwise.
+##
+## Value: Duration
+#topic_refresh_interval = "10s"
+
+## Sets the consumer id for this consumer
+##
+## Value: u64
+#consumer_id = 1
+
+## Sets the batch size
+## batch messages containing more than the configured batch size will not be sent by Pulsar
+##
+## Value: u64
+## Default: 1000
+#batch_size = 1000
+
+## Sets the dead letter policy
+##
+## Value: Object
+#remote.dead_letter_policy = {max_redeliver_count = 10, dead_letter_topic = "test_topic"}
+
+## The time after which a message is dropped without being acknowledged or nacked
+## that the message is resent. If `None`, messages will only be resent when a
+## consumer disconnects with pending unacknowledged messages.
+##
+## Value: Duration
+#remote.unacked_message_resend_delay = "20s"
+
+
+### Configuration options for consumers
+
+## Sets the priority level
+##
+## Value: i32
+#remote.options.priority_level = 3
+
+## Signal whether the subscription should be backed by a durable cursor or not
+##
+## Value: true | false
+#remote.options.durable = false
+
+## Read compacted
+##
+## Value: true | false
+#remote.options.read_compacted = false
+
+## Signal whether the subscription will initialize on latest
+## or earliest message (default on latest)
+##
+## Value: earliest | latest
+## latest - start at the most recent message
+## earliest - start at the oldest message
+#remote.options.initial_position = "latest"
+
+## User defined properties added to all messages
+##
+## Value: Object
+#remote.options.metadata = {}
+
+## Payload data format
+##
+## Value: bytes | json
+## Default: bytes
+#remote.payload_format = "json"
+
+## Payload Path
+##
+## Extract the publish payload from the Pulsar message payload. This config item is only supported when
+## `remote.payload_format` is set to JSON. For example: `/msg` or `/data/msg`
+##
+## Value: String
+#remote.payload_path = "msg"
+
+## MQTT publish message topic,
+##
+## Value: String
+##
+## Placeholder:
+##  - ${remote.topic}: pulsar message topic.
+##  - ${remote.properties.xxxx}: user-defined properties "topic". ${remote.properties.topic}
+##  - ${remote.payload.xxxx}: Extract the topic from the Pulsar message payload. If the topic is an array, the message will be
+##                     forwarded to each target topic individually. This placeholder is only supported when
+##                     `remote.payload_format` is set to JSON. For example: `${remote.payload.topics}`
+##
+local.topic = "local/topic1/ingress/${remote.topic}"
+#local.topics = ["local/topic1/ingress/${remote.properties.topic1}", "${remote.properties.topic2}", "${remote.payload.topic}", "${remote.payload.topics}"]
+
+## Choose 0, 1, 2, or not set (follow message QoS, i.e. user-defined properties "qos")
+##
+## Value: 0 | 1 | 2
+#local.qos = 1
+
+## Choose true or false, or not set (follow message Retain, i.e. user-defined properties "retain")
+##
+## Value: true | false
+## Default: false
+#local.retain = false
+
+## Allow forwarding of empty messages
+##
+## Value: true | false
+## Default: true
+#local.allow_empty_forward = false
+
+[[bridges.entries]]
+
+remote.topic = "non-persistent://public/default/test9"
+
+local.topic = "local/topic2/ingress"
+#local.qos = 0
+#local.retain = false
+
+
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-origin.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-bridge-origin.toml
@@ -1,0 +1,28 @@
+##--------------------------------------------------------------------
+## rmqtt-bridge-origin
+##--------------------------------------------------------------------
+##
+## This plugin identifies whether an MQTT client originates from a
+## bridge-ingress-mqtt or bridge-egress-mqtt connection by checking
+## the client_id against configurable markers.
+##
+## The identified bridge origin is stored in session.extra_attrs
+## under the configurable attr_key, making it available to other
+## plugins (e.g., for anti-loop or routing decisions).
+##
+## See: https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/bridge-origin.md
+##--------------------------------------------------------------------
+
+# Marker string to identify ingress bridge clients.
+# If a client_id contains this substring, it is treated as an ingress bridge client.
+# Default: ":ingress:"
+#ingress_marker = ":ingress:"
+
+# Marker string to identify egress bridge clients.
+# If a client_id contains this substring, it is treated as an egress bridge client.
+# Default: ":egress:"
+#egress_marker = ":egress:"
+
+# Key used to store BridgeOrigin in session.extra_attrs.
+# Default: "bridge_origin"
+#attr_key = "bridge_origin"

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-cluster-broadcast.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-cluster-broadcast.toml
@@ -1,0 +1,24 @@
+##--------------------------------------------------------------------
+## rmqtt-cluster-broadcast
+##--------------------------------------------------------------------
+
+#grpc message type
+message_type = 98
+# The list of gRPC addresses for the nodes in the cluster.
+# Each entry contains the node ID (e.g., 1, 2, 3) followed by the corresponding IP address and port.
+# These addresses are used for inter-node communication within the cluster.
+node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+#Maximum number of messages sent in batch
+node_grpc_batch_size = 128
+##Client concurrent request limit
+node_grpc_client_concurrency_limit = 128
+##Connect and send to server timeout
+node_grpc_client_timeout = "15s"
+
+##Task execution queue workers
+task_exec_queue_workers = 500
+
+##Task execution queue max capacity
+task_exec_queue_max = 100_000
+
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-cluster-raft.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-cluster-raft.toml
@@ -1,0 +1,87 @@
+##--------------------------------------------------------------------
+## rmqtt-cluster-raft
+##--------------------------------------------------------------------
+
+#cluster raft worker threads
+worker_threads = 6
+
+#grpc message type
+message_type = 198
+# The list of gRPC addresses for the nodes in the cluster.
+# Each entry contains the node ID (e.g., 1, 2, 3) followed by the corresponding IP address and port.
+# These addresses are used for communication between the nodes using gRPC.
+node_grpc_addrs = ["1@127.0.0.1:5363", "2@127.0.0.1:5364", "3@127.0.0.1:5365"]
+#Maximum number of messages sent in batch
+node_grpc_batch_size = 128
+##Client concurrent request limit
+node_grpc_client_concurrency_limit = 128
+##Connect and send to server timeout
+node_grpc_client_timeout = "10s"
+
+# The list of Raft peer addresses for the nodes in the cluster.
+# Each entry contains the node ID and the corresponding IP address and port for Raft consensus communication.
+# These addresses are used by the Raft protocol to maintain consistency and coordination across the nodes.
+raft_peer_addrs = ["1@127.0.0.1:6003", "2@127.0.0.1:6004", "3@127.0.0.1:6005"]
+
+#Raft cluster listening address
+#If this listening address is not specified, the address of the node corresponding to `raft_peer_addrs` will be used.
+#laddr = "0.0.0.0:6003"
+
+# Specify the leader node ID.
+#
+# This option is primarily intended for single-host pseudo-cluster deployments,
+# where multiple cluster nodes run on the same machine for testing or development.
+#
+# In a real distributed cluster, leader election is performed automatically and
+# this option is typically unnecessary.
+#
+# When the value is 0 or not specified, the first node in the cluster
+# configuration will be designated as the Leader.
+#
+# It can also be overridden via the CLI flag `--raft-leader-id`.
+#
+# Default value: 0
+leader_id = 0
+
+#Handshake lock timeout
+try_lock_timeout = "10s"
+task_exec_queue_workers = 500
+task_exec_queue_max = 100_000
+
+#algorithm used to compress the snapshot, value: zstd,lz4,zlib,snappy
+compression = "zstd"
+
+#Check the health of the node, and automatically terminate the program if the node is abnormal.
+#Default value: false
+health.exit_on_node_unavailable = false
+#Exit code on program termination.
+#Default value: -1
+health.exit_code = -1
+#When exit_on_node_unavailable is enabled, the program will terminate after a specified number of consecutive node failures.
+#Default value: 2
+health.max_continuous_unavailable_count = 2
+#Cluster node unavailability check interval.
+#Default value: 2 seconds
+health.unavailable_check_interval = "2s"
+
+raft.grpc_timeout = "6s"
+raft.grpc_concurrency_limit = 200
+raft.grpc_breaker_threshold = 5
+raft.grpc_breaker_retry_interval = "2500ms"
+raft.proposal_batch_size = 60
+raft.proposal_batch_timeout = "200ms"
+raft.snapshot_interval = "300s"
+raft.heartbeat = "100ms"
+
+raft.election_tick = 10
+raft.heartbeat_tick = 5
+raft.max_size_per_msg = 0
+raft.max_inflight_msgs = 256
+raft.check_quorum = true
+raft.pre_vote = true
+raft.min_election_tick = 0
+raft.max_election_tick = 0
+raft.read_only_option = "Safe"
+raft.skip_bcast_commit = false
+raft.batch_append = false
+raft.priority = 0

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-http-api.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-http-api.toml
@@ -1,0 +1,102 @@
+##--------------------------------------------------------------------
+## rmqtt-http-api
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/http-api.md
+
+## Max Row Limit
+max_row_limit = 10_000
+## HTTP Listener address
+http_laddr = "0.0.0.0:6060"
+## HTTP bearer token for API authentication.
+## When set, all HTTP API requests must include an `Authorization: Bearer <token>` header.
+## When not set (default), no authentication is required.
+#http_bearer_token = "public"
+
+## Enable TCP SO_REUSEADDR on the HTTP listener.
+## Default: true
+# http_reuseaddr = true
+
+## Enable TCP SO_REUSEPORT on the HTTP listener.
+## Default: false
+# http_reuseport = false
+
+## Indicates whether to print HTTP request logs
+http_request_log = false
+
+## Metrics sample interval for collecting and caching internal metrics.
+## Default: "5s"
+# metrics_sample_interval = "5s"
+
+## gRPC message type identifier for HTTP API messages.
+## Default: 99
+# message_type = 99
+
+## Message expiry interval for messages published via the HTTP API.
+##
+## After this duration, the message expires and will NOT be delivered
+## to subscribers. This only applies to messages published through
+## the HTTP API endpoint (`/api/v1/message/publish`), not to regular
+## MQTT client publishes.
+##
+## Value: Duration (e.g. "5m", "1h", "30s")
+## Set to "0" (zero) for no expiry.
+## Default: "5m"
+message_expiry_interval = "5m"
+
+## Prometheus metrics data caching interval.
+##
+## Value: Duration
+## Default: "5s"
+prometheus_metrics_cache_interval = "5s"
+
+## Dashboard static directory (optional).
+##
+## By default (when unset), the Dashboard SPA is served from assets
+## embedded directly into the binary via rust-embed at compile time,
+## so no external files are needed.
+##
+## If set, the http-api plugin loads the Dashboard SPA from this
+## external directory at the `/dashboard/` path instead, which allows
+## swapping the frontend build without recompiling the binary.
+# dashboard_static_dir = "/path/to/dashboard/dist"
+
+##--------------------------------------------------------------------
+## Stats/Metrics History Persistence (optional)
+##
+## When `storage` is configured, the plugin periodically snapshots
+## Stats and Metrics, converts them to JSON, and writes them to the
+## backend with TTL-based expiration. History query APIs
+## (`/api/v1/stats/history`, `/api/v1/metrics/history`, etc.) then
+## become available.
+##
+## To disable, omit the entire `storage` section.
+##--------------------------------------------------------------------
+
+##─── Redb backend ──────────────────────────────────────────────────────
+storage.type = "redb"
+storage.redb.path = "/var/log/rmqtt/.cache/http-api-history/{node}.redb"
+
+##─── Sled backend (default) ─────────────────────────────────────────────
+#storage.type = "sled"
+#storage.sled.path = "/var/log/rmqtt/.cache/http-api-history/{node}.sled"
+#storage.sled.cache_capacity = "1G"
+
+##─── Redis backend ──────────────────────────────────────────────────────
+# storage.type = "redis"
+# storage.redis.url = "redis://127.0.0.1:6379/"
+# storage.redis.prefix = "http-api-history-{node}"
+
+##─── Redis Cluster backend ──────────────────────────────────────────────
+# storage.type = "redis-cluster"
+# storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/"]
+# storage.redis-cluster.prefix = "http-api-history-{node}"
+
+##─── Flush interval (how often to snapshot Stats/Metrics) ───────────────
+## Default: "5s"
+# flush_interval = "5s"
+
+##─── History retention (TTL for each data point) ────────────────────────
+## After this period, the storage backend automatically evicts old data.
+## Default: "7d"
+# history_retention = "7d"

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-message-storage.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-message-storage.toml
@@ -1,0 +1,37 @@
+##--------------------------------------------------------------------
+## rmqtt-message-storage
+##--------------------------------------------------------------------
+
+##ram, redis, redis-cluster
+storage.type = "ram"
+
+##ram
+storage.ram.cache_capacity = "3G"
+storage.ram.cache_max_count = 1_000_000
+storage.ram.encode = false
+
+##Maximum pending messages in the in-memory channel (back-pressure limit).
+##Beyond this, new store requests are rejected.
+##Default: 300000
+#storage.ram.queue_max = 300_000
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "message-{node}"
+
+##redis-cluster
+storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
+storage.redis-cluster.prefix = "message-{node}"
+
+##Quantity of expired messages cleared during each cleanup cycle.
+cleanup_count = 5000
+
+##Timeout for storage I/O operations, channel sends, and circuit breaker
+##per-operation timeout. 0 = no timeout. Examples: "5s", "500ms".
+##Default: "15s"
+#backend_timeout = "15s"
+
+##─── Circuit breaker ────────────────────────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##The per-operation timeout uses `backend_timeout` above.

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-p2p-messaging.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-p2p-messaging.toml
@@ -1,0 +1,8 @@
+##--------------------------------------------------------------------
+## rmqtt-p2p-messaging
+##--------------------------------------------------------------------
+
+#"prefix": `p2p/{clientid}/{topic}` — the `p2p` identifier is at the start.
+#"suffix": `{topic}/p2p/{clientid}` — the `p2p` identifier is at the end.
+#"both": supports both prefix and suffix formats.
+mode = "prefix"

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-retainer.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-retainer.toml
@@ -1,0 +1,44 @@
+##--------------------------------------------------------------------
+## rmqtt-retainer
+##--------------------------------------------------------------------
+#
+# Single node mode         - ram, sled, redis
+# Multi-node cluster mode  - ram, sled, redis
+#
+
+##ram, sled, redis
+storage.type = "ram"
+
+##sled
+storage.sled.path = "/var/log/rmqtt/.cache/retain/{node}"
+storage.sled.cache_capacity = "3G"
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "retain"
+
+# The maximum number of retained messages, where 0 indicates no limit. After the number of reserved messages exceeds
+# the maximum limit, existing reserved messages can be replaced, but reserved messages cannot be stored for new topics.
+max_retained_messages = 0
+
+# The maximum Payload value for retaining messages. After the Payload size exceeds the maximum value, the RMQTT
+# message server will process the received reserved message as a regular message.
+max_payload_size = "1MB"
+
+# TTL for retained messages. Set to 0 for no expiration.
+# If not specified, the message expiration time will be used by default.
+retained_message_ttl = "0m"
+
+# Maximum number of messages per batch (default: 500).
+batch_messages_limit = 500
+
+##─── Backend timeout (circuit breaker) ──────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##Only the backend operation timeout can be overridden here.
+##
+##Backend storage operation timeout. If a storage call (Sled/Redis)
+##exceeds this duration it is aborted and counted as a failure by the
+##circuit breaker. Set to "0s" to disable.
+##Default: "8s"
+#backend_timeout = "8s"

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-session-storage.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-session-storage.toml
@@ -1,0 +1,29 @@
+##--------------------------------------------------------------------
+## rmqtt-session-storage
+##--------------------------------------------------------------------
+
+##sled, redis, redis-cluster
+storage.type = "sled"
+
+##sled
+storage.sled.path = "/var/log/rmqtt/.cache/session/{node}"
+storage.sled.cache_capacity = "3G"
+
+##redis
+storage.redis.url = "redis://127.0.0.1:6379/"
+storage.redis.prefix = "session-{node}"
+
+##redis-cluster
+storage.redis-cluster.urls = ["redis://127.0.0.1:6380/", "redis://127.0.0.1:6381/", "redis://127.0.0.1:6382/"]
+storage.redis-cluster.prefix = "session-{node}"
+
+##─── Backend timeout (circuit breaker) ──────────────────────────────────────
+##All circuit-breaker parameters (failure rate, window, etc.) are inherited
+##from the global `[circuit_breaker]` section in `rmqtt.toml`.
+##Only the backend operation timeout can be overridden here.
+
+##Backend storage operation timeout. If a storage call (Sled/Redis)
+##exceeds this duration it is aborted and counted as a failure by the
+##circuit breaker. Set to "0s" to disable.
+##Default: "15s"
+#backend_timeout = "15s"

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-shared-subscription.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-shared-subscription.toml
@@ -1,0 +1,19 @@
+# rmqtt-shared-subscription Plugin Configuration
+#
+# Supported strategies:
+#   random              - Random subscriber selection (basic load balancing)
+#   round_robin         - Sequential round-robin (default)
+#   round_robin_per_group - Per-node independent round-robin (large cluster)
+#   sticky              - Fixed subscriber per publisher (stateful processing)
+#   local               - Prefer publisher's node (reduce cross-node traffic)
+#   hash_clientid       - Hash by publisher ClientId (per-device ordering)
+#   hash_topic          - Hash by topic (topic sharding)
+
+# Selection strategy
+# Default: round_robin
+strategy = "round_robin"
+
+# Maximum sticky bindings in the LRU cache (only applies to "sticky" strategy).
+# When the cache fills up, the least recently used binding is evicted.
+# Default: 100000
+sticky_cache_size = 100000

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-sys-topic.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-sys-topic.toml
@@ -1,0 +1,12 @@
+##--------------------------------------------------------------------
+## rmqtt-sys-topic
+##--------------------------------------------------------------------
+
+##$SYS system message publish QoS
+publish_qos = 1
+
+##$SYS system message publish period
+publish_interval = "1m"
+
+##Message expiration time, 0 means no expiration
+message_expiry_interval = "5m"

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-topic-rewrite.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-topic-rewrite.toml
@@ -1,0 +1,22 @@
+##--------------------------------------------------------------------
+## rmqtt-topic-rewrite
+##--------------------------------------------------------------------
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/topic-rewrite.md
+
+# action - Options are publish, subscribe, or all
+# source_topic_filter - Topic filter for subscribing, unsubscribing, or publishing messages
+# dest_topic - Destination topic
+# regex - Regular expression
+
+# Expressions can use ${clientid} to represent the client ID and ${username} to represent the client username.
+
+rules = [
+#    { action = "all", source_topic_filter = "x/+/#", dest_topic = "xx/$1/$2", regex = "^x/(.+)/(.+)$" },
+#    { action = "all", source_topic_filter = "x/y/1", dest_topic = "xx/y/1" },
+#    { action = "all", source_topic_filter = "x/y/#", dest_topic = "xx/y/$1", regex = "^x/y/(.+)$" },
+#    { action = "all", source_topic_filter = "iot/cid/#", dest_topic = "iot/${clientid}/$1", regex = "^iot/cid/(.+)$" },
+#    { action = "all", source_topic_filter = "iot/uname/#", dest_topic = "iot/${username}/$1", regex = "^iot/uname/(.+)$" },
+#    { action = "all", source_topic_filter = "a/+/+/+", dest_topic = "aa/$1/$2/$3", regex = "^a/(.+)/(.+)/(.+)$" }
+]
+

--- a/rmqtt-test/configs/retain-disabled/plugins/rmqtt-web-hook.toml
+++ b/rmqtt-test/configs/retain-disabled/plugins/rmqtt-web-hook.toml
@@ -1,0 +1,53 @@
+##--------------------------------------------------------------------
+## rmqtt-web-hook
+##--------------------------------------------------------------------
+## http
+#    Method: POST
+#    Body: <JSON>
+#    Payload: BASE64
+## file
+#    None
+#
+
+# See more keys and their definitions at https://github.com/rmqtt/rmqtt/blob/master/docs/en_US/web-hook.md
+
+##--------------------------------------------------------------------
+## Hook General Config
+##--------------------------------------------------------------------
+# Maximum number of tasks that can be queued before new tasks are rejected.
+# Changing this value requires restarting the service to take effect.
+queue_capacity = 300_000
+
+# Maximum number of tasks that can be executed concurrently.
+# Changing this value requires restarting the service to take effect.
+concurrency_limit = 128
+
+
+## Default urls, supports http and file protocols
+#urls = ["file:///var/log/rmqtt/hook.log", "http://127.0.0.1:5656/mqtt/webhook"]
+urls = ["file:///var/log/rmqtt/hook.log"]
+
+## Http config
+http_timeout = "8s"
+#If it fails, try again after approximately 2, 4, 7, 11, 18, or 42 seconds
+retry_max_elapsed_time = "60s"
+retry_multiplier = 2.5
+
+## Hook rules config
+rule.session_created = [{action = "session_created" } ]
+rule.session_terminated = [{action = "session_terminated" } ]
+rule.session_subscribed = [{action = "session_subscribed"  } ]
+rule.session_unsubscribed = [{action = "session_unsubscribed" } ]
+
+rule.client_connect = [{action = "client_connect"}]
+rule.client_connack = [{action = "client_connack"} ]
+rule.client_connected = [{action = "client_connected" } ]
+rule.client_disconnected = [{action = "client_disconnected" } ]
+rule.client_subscribe = [{action = "client_subscribe" } ]
+rule.client_unsubscribe = [{action = "client_unsubscribe" } ]
+
+rule.message_publish = [{action = "message_publish", topics=["#", "$SYS/#"] }]
+rule.message_delivered = [{action = "message_delivered", topics=["#", "$SYS/#"] } ]
+rule.message_acked = [{action = "message_acked", topics=["#", "$SYS/#"] } ]
+rule.message_dropped = [{action = "message_dropped" } ]
+rule.offline_message = [{action = "offline_message", topics=["#", "$SYS/#"] }]

--- a/rmqtt-test/configs/retain-disabled/rmqtt.toml
+++ b/rmqtt-test/configs/retain-disabled/rmqtt.toml
@@ -48,7 +48,8 @@ log.file = "rmqtt.log"
 ##--------------------------------------------------------------------
 ## Plugins
 ##--------------------------------------------------------------------
-plugins.dir = "rmqtt-plugins/"
+# Self-contained: plugin configs live in this directory's plugins/ sub-dir.
+plugins.dir = "rmqtt-test/configs/retain-disabled/plugins/"
 # NOTE: rmqtt-retainer is intentionally NOT loaded, so the broker advertises
 # `Retain Available = 0` (the CONNECT-side `retain_available` config item was
 # removed in 0.11.0; availability is driven solely by the retainer plugin).

--- a/rmqtt-test/src/broker/lifecycle.rs
+++ b/rmqtt-test/src/broker/lifecycle.rs
@@ -15,6 +15,9 @@ use super::healthcheck::health_check_sync;
 /// Default broker TCP address
 const DEFAULT_BROKER_ADDR: &str = "127.0.0.1:1883";
 
+/// Default (self-contained) broker config, relative to the workspace root
+const DEFAULT_CONFIG_REL: &str = "rmqtt-test/configs/default/rmqtt.toml";
+
 /// Broker process manager (synchronous)
 pub struct BrokerProcess {
     /// Path to the broker binary
@@ -30,10 +33,14 @@ pub struct BrokerProcess {
 impl BrokerProcess {
     /// Create a new broker process manager
     ///
-    /// Searches for the broker binary in target/release and target/debug
+    /// Searches for the broker binary in target/release and target/debug,
+    /// and uses the self-contained `rmqtt-test/configs/default/rmqtt.toml`
+    /// as the default config (never the repository-root rmqtt.toml).
     pub fn new(workspace_root: Option<PathBuf>) -> Self {
         let binary_path = Self::find_binary(workspace_root.as_deref());
-        Self { binary_path, addr: DEFAULT_BROKER_ADDR.to_string(), config_path: None, child: None }
+        let config_path =
+            workspace_root.as_ref().map(|root| root.join(DEFAULT_CONFIG_REL)).filter(|p| p.exists());
+        Self { binary_path, addr: DEFAULT_BROKER_ADDR.to_string(), config_path, child: None }
     }
 
     /// Create with a specific binary path and address
@@ -131,6 +138,25 @@ impl BrokerProcess {
     /// Restart the broker
     pub fn restart(&mut self) -> Result<(), anyhow::Error> {
         self.stop()?;
+        // Small delay to let ports free up
+        std::thread::sleep(Duration::from_millis(500));
+        self.start()
+    }
+
+    /// Update the config file path (without restarting)
+    pub fn set_config(&mut self, config: Option<PathBuf>) {
+        self.config_path = config;
+    }
+
+    /// Get the currently configured config file path
+    pub fn config_path(&self) -> Option<&PathBuf> {
+        self.config_path.as_ref()
+    }
+
+    /// Stop the broker, switch to the given config file and start again
+    pub fn restart_with_config(&mut self, config: Option<PathBuf>) -> Result<(), anyhow::Error> {
+        self.stop()?;
+        self.config_path = config;
         // Small delay to let ports free up
         std::thread::sleep(Duration::from_millis(500));
         self.start()

--- a/rmqtt-test/src/framework/context.rs
+++ b/rmqtt-test/src/framework/context.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 
 use bytestring::ByteString;
 use parking_lot::Mutex;
+use tracing::info;
 use uuid::Uuid;
 
 use crate::broker::BrokerProcess;
@@ -137,6 +138,30 @@ impl TestContext {
             b.restart()
         } else {
             Err(anyhow::anyhow!("no broker managed by this context"))
+        }
+    }
+
+    /// Ensure the broker runs with the given config file (synchronous,
+    /// idempotent).
+    ///
+    /// If the broker is already running with `target` (compared against
+    /// `BrokerProcess::config_path`), nothing happens. Otherwise the broker
+    /// is restarted with the new config. Returns `Ok(())` in `--no-broker`
+    /// mode (nothing to switch); the caller decides how to warn.
+    pub fn ensure_broker_config(&self, target: &std::path::Path) -> Result<(), anyhow::Error> {
+        if let Some(ref broker) = self.broker {
+            let mut b = broker.lock();
+            if b.config_path().map(|p| p.as_path()) == Some(target) {
+                return Ok(());
+            }
+            info!(
+                "switching broker config: {:?} -> {:?}",
+                b.config_path().map(|p| p.display().to_string()),
+                target.display()
+            );
+            b.restart_with_config(Some(target.to_path_buf()))
+        } else {
+            Ok(())
         }
     }
 

--- a/rmqtt-test/src/framework/scheduler.rs
+++ b/rmqtt-test/src/framework/scheduler.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use super::context::TestContext;
 use super::suite::TestSuite;
@@ -21,8 +21,39 @@ impl TestScheduler {
     }
 
     /// Run all test suites (synchronous - each test creates its own tokio runtime)
+    ///
+    /// Before each suite, the broker is switched to `suite.config` if it is
+    /// not already running with it (config changes happen only at suite
+    /// boundaries). In `--no-broker` mode the switch is skipped with a single
+    /// warning; a failed switch aborts that suite and records an Error.
     pub fn run(&mut self, suites: Vec<TestSuite>, ctx: &mut TestContext) {
+        let mut warned_no_broker = false;
         for suite in suites {
+            if let Some(ref target) = suite.config {
+                if !ctx.has_broker() {
+                    if !warned_no_broker {
+                        warn!(
+                            "--no-broker mode: ignoring per-suite broker config requirements \
+                             (external broker used as-is)"
+                        );
+                        warned_no_broker = true;
+                    }
+                } else if let Err(e) = ctx.ensure_broker_config(target) {
+                    error!(
+                        "failed to switch broker config for suite '{}' to {:?}: {}",
+                        suite.name,
+                        target.display(),
+                        e
+                    );
+                    self.results.push(TestResult::error(
+                        &suite.name,
+                        "harness",
+                        Duration::ZERO,
+                        format!("broker config switch to {:?} failed: {}", target.display(), e),
+                    ));
+                    continue;
+                }
+            }
             self.run_suite(suite, ctx);
         }
     }

--- a/rmqtt-test/src/framework/suite.rs
+++ b/rmqtt-test/src/framework/suite.rs
@@ -1,6 +1,9 @@
 //! Test Suite - grouping and ordering of test cases
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+use tracing::info;
 
 use super::testcase::TestCase;
 
@@ -9,17 +12,26 @@ pub struct TestSuite {
     pub name: String,
     pub tests: Vec<Arc<dyn TestCase>>,
     pub parallel: bool,
+    /// Broker config file used by the whole suite (set after splitting;
+    /// `None` only before `split_suites_by_config` runs, or when the suite
+    /// is explicitly created with the harness default config semantics).
+    pub config: Option<PathBuf>,
 }
 
 impl TestSuite {
     /// Create a new test suite
     pub fn new(name: &str) -> Self {
-        Self { name: name.to_string(), tests: Vec::new(), parallel: false }
+        Self { name: name.to_string(), tests: Vec::new(), parallel: false, config: None }
     }
 
     /// Create a parallel test suite
     pub fn parallel(name: &str) -> Self {
-        Self { name: name.to_string(), tests: Vec::new(), parallel: true }
+        Self { name: name.to_string(), tests: Vec::new(), parallel: true, config: None }
+    }
+
+    /// Create a test suite pinned to a specific broker config
+    pub fn with_config(name: &str, config: PathBuf) -> Self {
+        Self { name: name.to_string(), tests: Vec::new(), parallel: false, config: Some(config) }
     }
 
     /// Add a test case
@@ -41,4 +53,65 @@ impl TestSuite {
     pub fn is_empty(&self) -> bool {
         self.tests.is_empty()
     }
+}
+
+/// A group of test cases that share the same declared broker config
+/// (`None` = harness default config), preserving their original relative order.
+type ConfigGroup = (Option<PathBuf>, Vec<Arc<dyn TestCase>>);
+
+/// Split each suite into sub-suites grouped by the test cases' `broker_config()`.
+///
+/// - Suites with an explicit `config` are kept as-is (they are already pinned
+///   to a single config, e.g. cluster suites).
+/// - Otherwise test cases are grouped by their declared config, preserving the
+///   original relative order inside each group:
+///   - the default-config group keeps the original suite name;
+///   - every other group becomes a `{suite}@{config_name}` sub-suite.
+/// - Every produced suite gets a concrete `config` (`default_config` for the
+///   default group), so the scheduler can switch configs at suite boundaries.
+pub fn split_suites_by_config(suites: Vec<TestSuite>, default_config: &Path) -> Vec<TestSuite> {
+    let mut out = Vec::new();
+    for suite in suites {
+        if suite.config.is_some() {
+            out.push(suite);
+            continue;
+        }
+
+        // Group by declared config, preserving first-seen order.
+        let mut groups: Vec<ConfigGroup> = Vec::new();
+        for test in suite.tests {
+            let cfg = test.broker_config();
+            match groups.iter_mut().find(|(c, _)| *c == cfg) {
+                Some((_, tests)) => tests.push(test),
+                None => groups.push((cfg, vec![test])),
+            }
+        }
+
+        for (cfg, tests) in groups {
+            let name = match &cfg {
+                None => suite.name.clone(),
+                Some(p) => format!("{}@{}", suite.name, config_name(p)),
+            };
+            let config = cfg.or_else(|| Some(default_config.to_path_buf()));
+            let sub = TestSuite { name, tests, parallel: suite.parallel, config };
+            info!(
+                "split suite '{}' -> '{}' ({} tests, config: {:?})",
+                suite.name,
+                sub.name,
+                sub.tests.len(),
+                sub.config.as_ref().map(|p| p.display().to_string())
+            );
+            out.push(sub);
+        }
+    }
+    out
+}
+
+/// Derive a short human-readable name for a config file, e.g.
+/// `rmqtt-test/configs/retain-disabled/rmqtt.toml` -> `retain-disabled`.
+fn config_name(path: &Path) -> String {
+    path.parent()
+        .and_then(|d| d.file_name())
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.file_name().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default())
 }

--- a/rmqtt-test/src/framework/testcase.rs
+++ b/rmqtt-test/src/framework/testcase.rs
@@ -109,6 +109,18 @@ pub trait TestCase: Send + Sync {
     /// Execute the test case
     fn execute(&self, ctx: &mut TestContext) -> TestResult;
 
+    /// Broker config file required by this test case (absolute or
+    /// workspace-relative path), or `None` to use the harness default config
+    /// (`--config`, or `rmqtt-test/configs/default/rmqtt.toml`).
+    ///
+    /// This is a *grouping* hint only: at suite build time, test cases that
+    /// declare the same non-default config are split out into their own
+    /// `{suite}@{config}` sub-suite, so the scheduler only ever switches the
+    /// broker config at suite boundaries.
+    fn broker_config(&self) -> Option<PathBuf> {
+        None
+    }
+
     /// Test timeout (default: 60 seconds)
     fn timeout(&self) -> Duration {
         Duration::from_secs(60)
@@ -126,3 +138,4 @@ pub trait TestCase: Send + Sync {
 }
 
 use crate::framework::context::TestContext;
+use std::path::PathBuf;

--- a/rmqtt-test/src/main.rs
+++ b/rmqtt-test/src/main.rs
@@ -24,7 +24,7 @@ mod transport;
 use broker::BrokerProcess;
 use framework::context::{TestConfig, TestContext};
 use framework::scheduler::TestScheduler;
-use framework::suite::TestSuite;
+use framework::suite::{split_suites_by_config, TestSuite};
 use report::{write_detail_log, ConsoleReporter, HtmlReporter, JsonReporter};
 
 #[derive(Debug, Parser)]
@@ -94,6 +94,25 @@ fn main() {
     info!("Broker address: {}", opt.addr);
     info!("Detail log: {} | Packet trace: test-trace.log", opt.log_file);
 
+    // Resolve the repository root: explicit --workspace, else the current
+    // directory when it looks like the repo root, else CARGO_MANIFEST_DIR.
+    let workspace_root = resolve_workspace(opt.workspace.as_deref());
+    info!("Workspace root: {}", workspace_root.display());
+
+    // Resolve the harness default broker config: --config, or the
+    // self-contained `rmqtt-test/configs/default/rmqtt.toml` (never the
+    // repository-root rmqtt.toml).
+    let default_config = match opt.config {
+        Some(ref c) => PathBuf::from(c),
+        None => workspace_root.join("rmqtt-test/configs/default/rmqtt.toml"),
+    };
+    if !default_config.exists() {
+        error!("Broker config not found: {}", default_config.display());
+        error!("Hint: pass --config <path> or build from the repository root");
+        std::process::exit(1);
+    }
+    info!("Default broker config: {}", default_config.display());
+
     // Configure test context
     let test_config = TestConfig {
         broker_addr: opt.addr.clone(),
@@ -105,16 +124,12 @@ fn main() {
 
     // Start broker if needed (synchronous - BrokerProcess uses std::process)
     let broker = if !opt.no_broker {
-        let mut broker = if let Some(ref binary) = opt.binary {
-            BrokerProcess::with_config(
-                PathBuf::from(binary),
-                opt.addr.clone(),
-                opt.config.as_ref().map(PathBuf::from),
-            )
-        } else {
-            let workspace = opt.workspace.as_ref().map(PathBuf::from);
-            BrokerProcess::new(workspace)
-        };
+        let binary = opt
+            .binary
+            .as_ref()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| BrokerProcess::find_binary(Some(&workspace_root)));
+        let mut broker = BrokerProcess::with_config(binary, opt.addr.clone(), Some(default_config.clone()));
 
         match broker.start() {
             Ok(()) => {
@@ -139,8 +154,11 @@ fn main() {
         TestContext::new(test_config)
     };
 
-    // Build test suites
+    // Build suites, split them by per-test config declarations, then apply
+    // the --suites filter (empty selection keeps everything).
     let suites = build_suites(&opt);
+    let suites = split_suites_by_config(suites, &default_config);
+    let suites = filter_suites(suites, &opt.suites);
 
     // Run tests (synchronous - each test creates its own runtime internally)
     let mut scheduler = TestScheduler::new();
@@ -174,28 +192,28 @@ fn main() {
         Err(e) => error!("Failed to write detail log: {}", e),
     }
 
-    // Exit code
+    // Exit code. Drop the context first so the managed broker child process
+    // is killed: `std::process::exit` skips destructors and would leak the
+    // broker (ports stay bound until it is killed manually).
     if summary.failed > 0 || summary.errors > 0 {
+        drop(ctx);
         std::process::exit(1);
     }
 }
 
 /// Build test suites based on CLI options
 fn build_suites(opt: &Opt) -> Vec<TestSuite> {
-    let run_all = opt.suites.is_empty();
-    let should_run = |name: &str| run_all || opt.suites.iter().any(|s| s == name);
-
     let mut suites = Vec::new();
 
-    if should_run("functional_v3") {
+    if should_run("functional_v3", opt) {
         suites.push(build_functional_v3_suite());
     }
 
-    if should_run("functional_v311") {
+    if should_run("functional_v311", opt) {
         suites.push(build_functional_v311_suite());
     }
 
-    if should_run("functional_v5") {
+    if should_run("functional_v5", opt) {
         suites.push(build_functional_v5_suite());
     }
 
@@ -203,19 +221,70 @@ fn build_suites(opt: &Opt) -> Vec<TestSuite> {
     // (see rmqtt-test/configs/pubrel-collision-cluster/). It is only run when
     // explicitly requested — never as part of the default full run, so it
     // cannot break the single-node suites.
-    if opt.suites.iter().any(|s| s == "functional_v5_cluster") {
+    if should_run("functional_v5_cluster", opt) {
         suites.push(build_functional_v5_cluster_suite());
     }
 
-    if should_run("stress") {
+    if should_run("stress", opt) {
         suites.push(build_stress_suite(opt.stress_clients));
     }
 
-    if should_run("chaos") {
+    if should_run("chaos", opt) {
         suites.push(build_chaos_suite(opt.chaos_iterations));
     }
 
     suites
+}
+
+/// Decide whether the (original, pre-split) suite `name` is selected.
+///
+/// - Empty `--suites` = default full run, which excludes the two-node
+///   `functional_v5_cluster` suite.
+/// - Otherwise a suite is selected when a selector equals its name, is a
+///   prefix (`functional_v5` also selects `functional_v5@retain-disabled`),
+///   or is a sub-suite name of it (`functional_v5@retain-disabled` also
+///   selects `functional_v5`).
+fn should_run(name: &str, opt: &Opt) -> bool {
+    if opt.suites.is_empty() {
+        return name != "functional_v5_cluster";
+    }
+    opt.suites
+        .iter()
+        .any(|s| s == name || name.starts_with(&format!("{}@", s)) || s.starts_with(&format!("{}@", name)))
+}
+
+/// Filter the (split) suites by the `--suites` selection.
+///
+/// Runs after `split_suites_by_config`, so sub-suite names like
+/// `functional_v5@retain-disabled` can be selected directly, while
+/// `functional_v5` also matches every `functional_v5@*` sub-suite.
+/// An empty selection keeps everything (the cluster suite was already
+/// excluded by `build_suites` for the default full run).
+fn filter_suites(suites: Vec<TestSuite>, selected: &[String]) -> Vec<TestSuite> {
+    if selected.is_empty() {
+        return suites;
+    }
+    suites
+        .into_iter()
+        .filter(|s| selected.iter().any(|sel| s.name == *sel || s.name.starts_with(&format!("{}@", sel))))
+        .collect()
+}
+
+/// Resolve the repository (workspace) root used to locate the rmqttd binary
+/// and the test configs: explicit `--workspace`, else the current directory
+/// when it looks like the repo root, else derived from CARGO_MANIFEST_DIR.
+fn resolve_workspace(explicit: Option<&str>) -> PathBuf {
+    if let Some(w) = explicit {
+        return PathBuf::from(w);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd.join("rmqtt.toml").exists() && cwd.join("rmqtt-test/configs").exists() {
+            return cwd;
+        }
+    }
+    // CARGO_MANIFEST_DIR = <root>/rmqtt-test -> parent = <root>
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().map(|p| p.to_path_buf()).unwrap_or(manifest)
 }
 
 fn build_functional_v3_suite() -> TestSuite {

--- a/rmqtt-test/src/tests/functional/qos2_pubrel_resume_collision.rs
+++ b/rmqtt-test/src/tests/functional/qos2_pubrel_resume_collision.rs
@@ -56,6 +56,14 @@ impl TestCase for Qos2PubrelResumeCollisionTest {
         "qos2_pubrel_resume_collision"
     }
 
+    /// The reproduction needs the `rmqtt-message-storage` plugin (stored
+    /// message re-delivery on resume), which the default config does not
+    /// load; the harness splits this test into the
+    /// `functional_v5@pubrel-collision` sub-suite automatically.
+    fn broker_config(&self) -> Option<std::path::PathBuf> {
+        Some(crate::tests::config_path("pubrel-collision"))
+    }
+
     fn execute(&self, ctx: &mut TestContext) -> TestResult {
         let start = Instant::now();
         let rt = tokio::runtime::Runtime::new().unwrap();

--- a/rmqtt-test/src/tests/functional/retain_unavailable_v5.rs
+++ b/rmqtt-test/src/tests/functional/retain_unavailable_v5.rs
@@ -118,6 +118,13 @@ impl TestCase for WillRetainRejectedWhenRetainUnavailableV5Test {
         "v5_will_retain_rejected_when_retain_unavailable"
     }
 
+    /// This scenario requires a broker that does NOT load the retainer
+    /// plugin; the harness splits this test into the
+    /// `functional_v5@retain-disabled` sub-suite automatically.
+    fn broker_config(&self) -> Option<std::path::PathBuf> {
+        Some(crate::tests::config_path("retain-disabled"))
+    }
+
     fn timeout(&self) -> Duration {
         Duration::from_secs(20)
     }

--- a/rmqtt-test/src/tests/mod.rs
+++ b/rmqtt-test/src/tests/mod.rs
@@ -1,5 +1,18 @@
 //! Test suites
 
+use std::path::PathBuf;
+
 pub mod chaos;
 pub mod functional;
 pub mod stress;
+
+/// Resolve a test broker config path, e.g. `config_path("retain-disabled")`
+/// -> `<workspace>/rmqtt-test/configs/retain-disabled/rmqtt.toml`.
+///
+/// Built from `CARGO_MANIFEST_DIR` (the `rmqtt-test` crate dir), so the
+/// returned path is absolute and independent of the process working
+/// directory. Config files must live under `rmqtt-test/configs/<name>/` and
+/// be self-contained (their own `plugins/` sub-dir).
+pub fn config_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("configs").join(name).join("rmqtt.toml")
+}


### PR DESCRIPTION
Allow single-node tests to run against different broker configs in one run: test cases declare their required config via TestCase::broker_config() and are split at suite-build time into {suite}@{config} sub-suites (e.g. functional_v5@retain-disabled); the scheduler restarts the broker to switch configs only at suite boundaries.

- Make all test broker configs self-contained under rmqtt-test/configs/ (default/, retain-disabled/, pubrel-collision/, each with own plugins/) instead of relying on the repository-root rmqtt.toml / rmqtt-plugins/*.toml
- Always start rmqttd with an explicit -f: --config, or the new configs/default/rmqtt.toml (keeps all TCP/TLS/WS/WSS/QUIC listeners)
- Add BrokerProcess::set_config/restart_with_config/config_path and TestContext::ensure_broker_config (idempotent switch)
- --suites prefix matching: functional_v5 also selects functional_v5@*; functional_v5_cluster still runs only when explicitly requested
- Wire up will_retain_rejected_when_retain_unavailable_v5 (retain-disabled) and qos2_pubrel_resume_collision (pubrel-collision) so they execute for real instead of being skipped/not reproducible under the default config
- Fix broker child-process leak on failure exit: drop(ctx) before std::process::exit(1) so the managed broker is killed
- Fix clippy::type_complexity in split_suites_by_config
- Update README.md/README-CN.md and docs (testing, testing-report, getting-started, zh_CN + en_US); add docs/zh_CN/development/rmqtt-test-config-switching.md