### PR TITLE
fix(logging): include remote address in connection error logs

### DIFF
--- a/rmqtt/src/node.rs
+++ b/rmqtt/src/node.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use systemstat::Platform;
 
+#[cfg(feature = "grpc")]
 use crate::context::CircuitBreakerConfig;
 use crate::context::ServerContext;
 #[cfg(feature = "grpc")]

--- a/rmqtt/src/server.rs
+++ b/rmqtt/src/server.rs
@@ -227,12 +227,14 @@ async fn listen_tcp(scx: ServerContext, l: &Listener, lid: ListenerId) {
             Ok(accept) => {
                 let scx = scx.clone();
                 tokio::spawn(async move {
-                    log::debug!("TCP connection from {}", accept.remote_addr);
+                    // Extract before `accept.tcp()` consumes the acceptor.
+                    let remote_addr = accept.remote_addr;
+                    log::debug!("TCP connection from {remote_addr}");
 
                     let stream = match accept.tcp() {
                         Ok(s) => s,
                         Err(e) => {
-                            log::warn!("TCP accept error: {e}");
+                            log::warn!("TCP accept error: {e}, from: {remote_addr}");
                             return;
                         }
                     };
@@ -240,16 +242,16 @@ async fn listen_tcp(scx: ServerContext, l: &Listener, lid: ListenerId) {
                     match stream.mqtt().await {
                         Ok(MqttStream::V3(s)) => {
                             if let Err(e) = v3::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv3 processing error: {e}");
+                                log::info!("MQTTv3 processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Ok(MqttStream::V5(s)) => {
                             if let Err(e) = v5::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv5 processing error: {e}");
+                                log::info!("MQTTv5 processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Err(e) => {
-                            log::info!("MQTT version detection failed: {e}");
+                            log::info!("MQTT version detection failed: {e}, from: {remote_addr}");
                         }
                     }
                 });
@@ -273,12 +275,14 @@ async fn listen_tls(scx: ServerContext, l: &Listener, lid: ListenerId) {
             Ok(accept) => {
                 let scx = scx.clone();
                 tokio::spawn(async move {
-                    log::debug!("TLS connection from {}", accept.remote_addr);
+                    // Extract before `accept.tls()` consumes the acceptor.
+                    let remote_addr = accept.remote_addr;
+                    log::debug!("TLS connection from {remote_addr}");
 
                     let stream = match accept.tls().await {
                         Ok(s) => s,
                         Err(e) => {
-                            log::warn!("TLS accept error: {e}");
+                            log::warn!("TLS accept error: {e}, from: {remote_addr}");
                             return;
                         }
                     };
@@ -286,16 +290,16 @@ async fn listen_tls(scx: ServerContext, l: &Listener, lid: ListenerId) {
                     match stream.mqtt().await {
                         Ok(MqttStream::V3(s)) => {
                             if let Err(e) = v3::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv3/TLS processing error: {e}");
+                                log::info!("MQTTv3/TLS processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Ok(MqttStream::V5(s)) => {
                             if let Err(e) = v5::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv5/TLS processing error: {e}");
+                                log::info!("MQTTv5/TLS processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Err(e) => {
-                            log::info!("MQTT/TLS version detection failed: {e}");
+                            log::info!("MQTT/TLS version detection failed: {e}, from: {remote_addr}");
                         }
                     }
                 });
@@ -319,12 +323,14 @@ async fn listen_ws(scx: ServerContext, l: &Listener, lid: ListenerId) {
             Ok(accept) => {
                 let scx = scx.clone();
                 tokio::spawn(async move {
-                    log::debug!("WebSocket connection from {}", accept.remote_addr);
+                    // Extract before `accept.ws()` consumes the acceptor.
+                    let remote_addr = accept.remote_addr;
+                    log::debug!("WebSocket connection from {remote_addr}");
 
                     let stream = match accept.ws().await {
                         Ok(s) => s,
                         Err(e) => {
-                            log::warn!("WebSocket accept error: {e}");
+                            log::warn!("WebSocket accept error: {e}, from: {remote_addr}");
                             return;
                         }
                     };
@@ -332,16 +338,16 @@ async fn listen_ws(scx: ServerContext, l: &Listener, lid: ListenerId) {
                     match stream.mqtt().await {
                         Ok(MqttStream::V3(s)) => {
                             if let Err(e) = v3::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv3/WS processing error: {e}");
+                                log::info!("MQTTv3/WS processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Ok(MqttStream::V5(s)) => {
                             if let Err(e) = v5::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv5/WS processing error: {e}");
+                                log::info!("MQTTv5/WS processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Err(e) => {
-                            log::info!("MQTT/WS version detection failed: {e}");
+                            log::info!("MQTT/WS version detection failed: {e}, from: {remote_addr}");
                         }
                     }
                 });
@@ -365,12 +371,14 @@ async fn listen_wss(scx: ServerContext, l: &Listener, lid: ListenerId) {
             Ok(accept) => {
                 let scx = scx.clone();
                 tokio::spawn(async move {
-                    log::debug!("WSS connection from {}", accept.remote_addr);
+                    // Extract before `accept.wss()` consumes the acceptor.
+                    let remote_addr = accept.remote_addr;
+                    log::debug!("WSS connection from {remote_addr}");
 
                     let stream = match accept.wss().await {
                         Ok(s) => s,
                         Err(e) => {
-                            log::warn!("WSS accept error: {e}");
+                            log::warn!("WSS accept error: {e}, from: {remote_addr}");
                             return;
                         }
                     };
@@ -378,16 +386,16 @@ async fn listen_wss(scx: ServerContext, l: &Listener, lid: ListenerId) {
                     match stream.mqtt().await {
                         Ok(MqttStream::V3(s)) => {
                             if let Err(e) = v3::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv3/WSS processing error: {e}");
+                                log::info!("MQTTv3/WSS processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Ok(MqttStream::V5(s)) => {
                             if let Err(e) = v5::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv5/WSS processing error: {e}");
+                                log::info!("MQTTv5/WSS processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Err(e) => {
-                            log::info!("MQTT/WSS version detection failed: {e}");
+                            log::info!("MQTT/WSS version detection failed: {e}, from: {remote_addr}");
                         }
                     }
                 });
@@ -411,12 +419,14 @@ async fn listen_quic(scx: ServerContext, l: &Listener, lid: ListenerId) {
             Ok(accept) => {
                 let scx = scx.clone();
                 tokio::spawn(async move {
-                    log::debug!("QUIC connection from {}", accept.remote_addr);
+                    // Extract before `accept.quic()` consumes the acceptor.
+                    let remote_addr = accept.remote_addr;
+                    log::debug!("QUIC connection from {remote_addr}");
 
                     let stream = match accept.quic().await {
                         Ok(s) => s,
                         Err(e) => {
-                            log::warn!("QUIC accept error: {e}");
+                            log::warn!("QUIC accept error: {e}, from: {remote_addr}");
                             return;
                         }
                     };
@@ -424,16 +434,16 @@ async fn listen_quic(scx: ServerContext, l: &Listener, lid: ListenerId) {
                     match stream.mqtt().await {
                         Ok(MqttStream::V3(s)) => {
                             if let Err(e) = v3::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv3/QUIC processing error: {e}");
+                                log::info!("MQTTv3/QUIC processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Ok(MqttStream::V5(s)) => {
                             if let Err(e) = v5::process(scx.clone(), s, lid).await {
-                                log::info!("MQTTv5/QUIC processing error: {e}");
+                                log::info!("MQTTv5/QUIC processing error: {e}, from: {remote_addr}");
                             }
                         }
                         Err(e) => {
-                            log::info!("MQTT/QUIC version detection failed: {e}");
+                            log::info!("MQTT/QUIC version detection failed: {e}, from: {remote_addr}");
                         }
                     }
                 });

--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -82,6 +82,7 @@ use tokio::sync::RwLock;
 use tokio::time::{Duration, Instant};
 
 use crate::acl::AuthInfo;
+#[cfg(feature = "retain")]
 use crate::codec::v5::RetainHandling;
 use crate::codec::{
     v3,


### PR DESCRIPTION
**Problem**
Error logs for connection accept failures and MQTT processing errors did not include the remote client address, making it difficult to trace which clients were affected or to correlate errors with specific sources.

**Solution**
Extract `remote_addr` from the accept object before consuming it, and include it in all related log messages:

- Connection accept errors (TCP, TLS, WebSocket, WSS, QUIC)
- MQTT version detection failures
- MQTTv3/MQTTv5 processing errors

**Affected Listeners**
- TCP (`listen_tcp`)
- TLS (`listen_tls`)
- WebSocket (`listen_ws`)
- WSS (`listen_wss`)
- QUIC (`listen_quic`)

**Additional Fixes**
- `rmqtt/src/node.rs`: Add `#[cfg(feature = "grpc")]` to CircuitBreakerConfig import
- `rmqtt/src/session.rs`: Add `#[cfg(feature = "retain")]` to RetainHandling import

**Benefits**
- Better debugging and troubleshooting capability
- Clearer log correlation with client IP addresses
- More context for diagnosing connection issues