### PR TITLE
perf(http-api): use dedicated executor for history flusher tasks

### DIFF
--- a/rmqtt-plugins/rmqtt-http-api/src/flusher.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/flusher.rs
@@ -69,6 +69,7 @@ pub fn start_flusher(
     retention: Duration,
 ) -> tokio::task::JoinHandle<()> {
     let node_id = scx.node.id();
+    let exec = scx.get_exec(("HISTORY_FLUSHER_EXEC", 10, 10_000));
     tokio::spawn(async move {
         let mut timer = tokio::time::interval(interval);
         timer.tick().await; // baseline on start
@@ -87,7 +88,7 @@ pub fn start_flusher(
                 // Async flush to storage
                 let db = storage_db.clone();
                 let cache = stats_cache.clone();
-                tokio::spawn(async move {
+                exec.spawn(async move {
                     flush_one(&db, &cache, &storage_key, ts, retention).await;
                 });
             }
@@ -101,7 +102,7 @@ pub fn start_flusher(
                 metrics_cache.write().await.put(ts, entry);
                 let db = storage_db.clone();
                 let cache = metrics_cache.clone();
-                tokio::spawn(async move {
+                exec.spawn(async move {
                     flush_one(&db, &cache, &storage_key, ts, retention).await;
                 });
             }


### PR DESCRIPTION
**Problem**
History flusher spawned background flush tasks directly using `tokio::spawn`, which can cause unbounded task growth and interfere with other critical broker operations during high load or storage backpressure.

**Solution**
Use a dedicated `HISTORY_FLUSHER_EXEC` task execution queue for all history flush operations with bounded concurrency and queue capacity.

**Changes**
- Create `HISTORY_FLUSHER_EXEC` with 10 workers and 10,000 queue capacity
- Replace `tokio::spawn` with `exec.spawn` for both stats and metrics flush tasks
- Prevents unbounded task accumulation during storage slowdowns

**Benefits**
- Bounded task concurrency prevents resource exhaustion
- Isolates flush tasks from other critical broker operations
- Graceful backpressure when storage backend is slow
- Better observability through task execution queue metrics