### PR TITLE
ci: bump MSRV to 1.94.0 and update http-api config reading

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -76,7 +76,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - "1.89.0"  # minimum supported rust version
+          - "1.94.0"  # minimum supported rust version
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/rmqtt-plugins/rmqtt-http-api/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-http-api/src/lib.rs
@@ -56,7 +56,7 @@ impl HttpApiPlugin {
     #[inline]
     async fn new<S: Into<String>>(scx: ServerContext, name: S) -> Result<Self> {
         let name = name.into();
-        let mut cfg = scx.plugins.read_config::<PluginConfig>(&name)?;
+        let mut cfg = scx.plugins.read_config_default::<PluginConfig>(&name)?;
         log::info!("{name} HttpApiPlugin cfg: {cfg:?}");
 
         // Replace {node} placeholder in storage config paths (before init_db)


### PR DESCRIPTION
- Upgrade minimum supported Rust version from 1.89.0 to 1.94.0 in CI
- Replace `read_config` with `read_config_default` in rmqtt-http-api to align with latest API changes