### PR TITLE
fix(codec): reject empty topic filters in SUBSCRIBE/UNSUBSCRIBE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "rmqtt-codec"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rust-version = "1.94.0"
 
 [workspace.dependencies]
 rmqtt = "0.24.0"
-rmqtt-codec = "0.3.0"
+rmqtt-codec = "0.3.1"
 rmqtt-net = "0.4.0"
 rmqtt-conf = "0.4.0"
 rmqtt-macros = "0.1.2"

--- a/rmqtt-codec/Cargo.toml
+++ b/rmqtt-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-codec"
-version = "0.3.0"
+version = "0.3.1"
 description = "MQTT protocol codec implementation with multi-version support and version negotiation"
 repository = "https://github.com/rmqtt/rmqtt/tree/master/rmqtt-codec"
 edition.workspace = true

--- a/rmqtt-codec/src/error.rs
+++ b/rmqtt-codec/src/error.rs
@@ -83,6 +83,8 @@ pub enum DecodeError {
     PacketIdRequired,
     #[error("Max size exceeded: size={size}, max={max}")]
     MaxSizeExceeded { size: u32, max: u32 },
+    #[error("Invalid topic filter")]
+    InvalidTopicFilter,
     #[error("utf8 error")]
     Utf8Error,
     #[error("io error, {:?}", _0)]
@@ -108,6 +110,7 @@ impl ToReasonCode for DecodeError {
             DecodeError::UnsupportedPacketType => DisconnectReasonCode::ImplementationSpecificError,
             DecodeError::PacketIdRequired => DisconnectReasonCode::ProtocolError,
             DecodeError::MaxSizeExceeded { .. } => DisconnectReasonCode::PacketTooLarge,
+            DecodeError::InvalidTopicFilter => DisconnectReasonCode::TopicFilterInvalid,
             DecodeError::Utf8Error => DisconnectReasonCode::PayloadFormatInvalid,
             DecodeError::Io(_) => DisconnectReasonCode::UnspecifiedError,
         }

--- a/rmqtt-codec/src/v3/decode.rs
+++ b/rmqtt-codec/src/v3/decode.rs
@@ -132,10 +132,15 @@ fn decode_subscribe_packet(src: &mut Bytes) -> Result<Packet, DecodeError> {
     let mut topic_filters = Vec::new();
     while src.has_remaining() {
         let topic = ByteString::decode(src)?;
+        // MQTT-4.7.3-1: topic filters MUST be at least one character long
+        ensure!(!topic.is_empty(), DecodeError::InvalidTopicFilter);
         ensure!(src.remaining() >= 1, DecodeError::InvalidLength);
         let qos = (src.get_u8() & 0b0000_0011).try_into()?;
         topic_filters.push((topic, qos));
     }
+    // MQTT-3.8.3-1: the payload of a SUBSCRIBE packet MUST contain at least
+    // one topic filter
+    ensure!(!topic_filters.is_empty(), DecodeError::InvalidTopicFilter);
 
     Ok(Packet::Subscribe { packet_id, topic_filters })
 }
@@ -157,8 +162,15 @@ fn decode_unsubscribe_packet(src: &mut Bytes) -> Result<Packet, DecodeError> {
     let packet_id = NonZeroU16::decode(src)?;
     let mut topic_filters = Vec::new();
     while src.remaining() > 0 {
-        topic_filters.push(ByteString::decode(src)?);
+        let topic = ByteString::decode(src)?;
+        // MQTT-4.7.3-1: topic filters MUST be at least one character long
+        ensure!(!topic.is_empty(), DecodeError::InvalidTopicFilter);
+        topic_filters.push(topic);
     }
+    // MQTT-3.10.3-1: the payload of an UNSUBSCRIBE packet MUST contain at
+    // least one topic filter
+    ensure!(!topic_filters.is_empty(), DecodeError::InvalidTopicFilter);
+
     Ok(Packet::Unsubscribe { packet_id, topic_filters })
 }
 


### PR DESCRIPTION
Close a conformance gap: SUBSCRIBE/UNSUBSCRIBE with no topic filters or an empty-string filter were decoded successfully and acknowledged by the broker instead of closing the connection.

- add DecodeError::InvalidTopicFilter, mapped to v5 DisconnectReasonCode::TopicFilterInvalid (143)
- decode_subscribe_packet: reject empty-string filter (MQTT-4.7.3-1) and zero-filter payload (MQTT-3.8.3-1)
- decode_unsubscribe_packet: same (MQTT-4.7.3-1 / MQTT-3.10.3-1)
- bump rmqtt-codec to 0.3.1