### PR TITLE
fix(codec): reject empty topic names and filters in v3 decode paths

### DIFF
--- a/rmqtt-codec/src/error.rs
+++ b/rmqtt-codec/src/error.rs
@@ -85,6 +85,8 @@ pub enum DecodeError {
     MaxSizeExceeded { size: u32, max: u32 },
     #[error("Invalid topic filter")]
     InvalidTopicFilter,
+    #[error("Invalid topic name")]
+    InvalidTopicName,
     #[error("utf8 error")]
     Utf8Error,
     #[error("io error, {:?}", _0)]
@@ -111,6 +113,7 @@ impl ToReasonCode for DecodeError {
             DecodeError::PacketIdRequired => DisconnectReasonCode::ProtocolError,
             DecodeError::MaxSizeExceeded { .. } => DisconnectReasonCode::PacketTooLarge,
             DecodeError::InvalidTopicFilter => DisconnectReasonCode::TopicFilterInvalid,
+            DecodeError::InvalidTopicName => DisconnectReasonCode::TopicNameInvalid,
             DecodeError::Utf8Error => DisconnectReasonCode::PayloadFormatInvalid,
             DecodeError::Io(_) => DisconnectReasonCode::UnspecifiedError,
         }

--- a/rmqtt-codec/src/v3/decode.rs
+++ b/rmqtt-codec/src/v3/decode.rs
@@ -109,6 +109,8 @@ fn decode_connect_ack_packet(src: &mut Bytes) -> Result<Packet, DecodeError> {
 
 fn decode_publish_packet(src: &mut Bytes, packet_flags: u8) -> Result<Packet, DecodeError> {
     let topic = ByteString::decode(src)?;
+    // MQTT-4.7.3-1: Topic Names MUST be at least one character long
+    ensure!(!topic.is_empty(), DecodeError::InvalidTopicName);
     let qos = QoS::try_from((packet_flags & 0b0110) >> 1)?;
     let packet_id = if qos == QoS::AtMostOnce {
         None


### PR DESCRIPTION
Close a conformance gap where PUBLISH with an empty Topic Name and SUBSCRIBE/UNSUBSCRIBE with no topic filters or an empty-string filter were decoded successfully and acknowledged by the broker instead of closing the connection.

- add DecodeError::InvalidTopicFilter (MQTT-3.8.3-1 / 3.10.3-1 / 4.7.3-1) and DecodeError::InvalidTopicName (MQTT-4.7.3-1), mapped to v5 DisconnectReasonCode::TopicFilterInvalid (143) / TopicNameInvalid (144)
- decode_publish_packet: reject empty Topic Name
- decode_subscribe_packet: reject empty-string filter and zero-filter payload
- decode_unsubscribe_packet: same