### PR TITLE
docs: correct hook priority ordering description

### DIFF
--- a/docs/en_US/architecture/overview.md
+++ b/docs/en_US/architecture/overview.md
@@ -273,7 +273,7 @@ pub trait Handler: Send + Sync {
 
 ### Hook Registration Priority
 
-Handlers can register with a priority. Lower values execute first. The `counter` plugin registers at `Priority::MAX` to ensure it runs last.
+Handlers can register with a priority. Higher values execute first (numerically highest `Priority` first). The `counter` plugin registers at `Priority::MAX`, so it runs first in each hook chain.
 
 ---
 

--- a/docs/en_US/development/plugin-development.md
+++ b/docs/en_US/development/plugin-development.md
@@ -316,11 +316,11 @@ All available hook types:
 ### Handler Priority
 
 ```rust
-// Register with specific priority (lower = earlier execution)
+// Register with specific priority (higher = earlier execution)
 register.add_priority(Type::MessagePublish, handler, 100).await
 ```
 
-The `counter` plugin uses `Priority::MAX` to ensure it runs last.
+The `counter` plugin uses `Priority::MAX`, so it runs first in each hook chain.
 
 ---
 

--- a/docs/zh_CN/architecture/overview.md
+++ b/docs/zh_CN/architecture/overview.md
@@ -264,7 +264,7 @@ pub trait Handler: Send + Sync {
 
 ### 钩子注册优先级
 
-处理器可以注册时指定优先级。数值越小越先执行。`counter` 插件以 `Priority::MAX` 注册，确保它在最后执行。
+处理器可以注册时指定优先级。数值越大越先执行（数值最大的 `Priority` 最先派发）。`counter` 插件以 `Priority::MAX` 注册，因此它在每条 hook 链中最先执行。
 
 ---
 

--- a/rmqtt/src/hook.rs
+++ b/rmqtt/src/hook.rs
@@ -25,7 +25,7 @@
 //!
 //! ## Key Features
 //! - Protocol version specific handling (v3.1, v3.1.1, v5)
-//! - Priority-based handler ordering (0=highest)
+//! - Priority-based handler ordering (higher value = higher priority)
 //! - Atomic hook registration/enabling
 //! - Session-aware processing context
 //! - Comprehensive result type system
@@ -42,8 +42,10 @@
 //! 2. Register via `HookManager::register()`
 //! 3. Process hook results via `HookResult` enum
 //!
-//! Note: All hooks are executed in reverse priority order (high to low)
-//! until a handler returns `proceed=false`.
+//! Note: Handlers are dispatched in descending priority order (numerically
+//! highest `Priority` value first). Handlers sharing the same priority are
+//! dispatched in unspecified order. The chain runs until a handler returns
+//! `proceed=false`.
 
 use std::collections::BTreeMap;
 use std::num::NonZeroU32;
@@ -72,8 +74,10 @@ use crate::Result;
 
 /// Hook handler priority value.
 ///
-/// Lower numerical values indicate higher priority.
-/// Priority 0 is the highest (executed first).
+/// Higher numerical values indicate higher priority: a handler registered
+/// with a larger `Priority` is dispatched before handlers with smaller
+/// values. The default priority of `0` is the *lowest*. Handlers sharing
+/// the same priority are dispatched in unspecified order.
 pub type Priority = u32;
 
 /// Whether hook chain execution should continue.
@@ -99,7 +103,8 @@ pub type ReturnType = (Proceed, Option<HookResult>);
 ///
 /// 1. A session-level event occurs (e.g., connect, publish, subscribe).
 /// 2. [`HookManager`] dispatches to the appropriate hook [`Type`].
-/// 3. Registered handlers execute in reverse priority order (highest first).
+/// 3. Registered handlers execute in descending priority order (numerically
+///    highest `Priority` value first).
 /// 4. Each handler receives the accumulated result from previous handlers.
 /// 5. If any handler returns `proceed=false`, execution short-circuits.
 /// 6. The final result is returned to the caller.
@@ -194,14 +199,17 @@ pub trait HookManager: Sync + Send {
 /// Handlers are not active until `start()` is called.
 #[async_trait]
 pub trait Register: Sync + Send {
-    /// Register a handler with default priority (0, highest).
+    /// Register a handler with the default priority (0, the lowest).
+    ///
+    /// Handlers with higher priorities are dispatched first.
     async fn add(&self, typ: Type, handler: Box<dyn Handler>) {
         self.add_priority(typ, 0, handler).await;
     }
 
     /// Register a handler with a specific priority level.
     ///
-    /// Lower priority values execute first.
+    /// Higher priority values execute first. Handlers sharing the same
+    /// priority execute in unspecified order.
     async fn add_priority(&self, typ: Type, priority: Priority, handler: Box<dyn Handler>);
 
     /// Activate all registered handlers.
@@ -614,9 +622,10 @@ type HandlerId = String;
 ///
 /// # Handler Execution
 ///
-/// Handlers are executed in reverse BTreeMap order (highest priority first).
-/// Each handler receives the accumulated result from prior handlers.
-/// If any handler returns `proceed = false`, the chain short-circuits.
+/// Handlers are executed in reverse BTreeMap order, i.e. numerically
+/// highest `Priority` value first. Each handler receives the accumulated
+/// result from prior handlers. If any handler returns `proceed = false`,
+/// the chain short-circuits.
 #[derive(Clone)]
 pub struct DefaultHookManager {
     #[allow(clippy::type_complexity)]


### PR DESCRIPTION
- Update documentation to reflect that higher Priority values execute first
- Fix counter plugin description: it now runs first instead of last
- Sync Chinese and English documentation
- Update code comments in hook.rs to match new priority semantics
- Clarify that default priority 0 is the lowest, not the highest