### PR TITLE
fix(codec): reject empty topic filters in v5 SUBSCRIBE/UNSUBSCRIBE

### DIFF
--- a/rmqtt-codec/src/v5/packet/subscribe.rs
+++ b/rmqtt-codec/src/v5/packet/subscribe.rs
@@ -187,6 +187,9 @@ impl Subscribe {
             let opts = SubscriptionOptions::decode(src)?;
             topic_filters.push((topic, opts));
         }
+        // [MQTT-3.8.3-3] The SUBSCRIBE payload MUST contain at least one
+        // Topic Filter; an empty payload is a Protocol Error (parity with v3).
+        ensure!(!topic_filters.is_empty(), DecodeError::InvalidTopicFilter);
 
         Ok(Self { packet_id, id: sub_id, user_properties, topic_filters })
     }
@@ -222,6 +225,9 @@ impl Unsubscribe {
         while src.remaining() > 0 {
             topic_filters.push(ByteString::decode(src)?);
         }
+        // [MQTT-3.10.3-2] The UNSUBSCRIBE payload MUST contain at least one
+        // Topic Filter; an empty payload is a Protocol Error (parity with v3).
+        ensure!(!topic_filters.is_empty(), DecodeError::InvalidTopicFilter);
 
         Ok(Self { packet_id, user_properties, topic_filters })
     }


### PR DESCRIPTION
The v5 codec silently accepted SUBSCRIBE/UNSUBSCRIBE packets with an empty payload (zero topic filters) and the broker replied with a SUBACK carrying zero return codes — a double violation:

- MQTT-3.8.3-3 / MQTT-3.10.3-2: an empty payload is a Protocol Error
- MQTT-3.8.4: SUBACK payload MUST contain at least one return code

Root cause: `Subscribe::decode` / `Unsubscribe::decode` in rmqtt-codec/src/v5/packet/subscribe.rs skipped the topic-filter parse loop for empty payloads without any is_empty() validation. The v3 codec already guards this (rmqtt-codec/src/v3/decode.rs:153,182); this restores v3/v5 parity.

Fix: add `ensure!(!topic_filters.is_empty(), DecodeError::InvalidTopicFilter)` to both v5 decode paths. Rejection maps to DISCONNECT 0x8F (Topic Filter invalid) via the existing ToReasonCode chain.

Regression tests: protocol_error_v5_subscribe_empty_payload / protocol_error_v5_unsubscribe_empty_payload (rmqtt-test).