### PR TITLE
fix(codec): enforce reserved bits check in v5 subscribe options

### DIFF
--- a/rmqtt-codec/src/v5/packet/subscribe.rs
+++ b/rmqtt-codec/src/v5/packet/subscribe.rs
@@ -283,6 +283,9 @@ impl Decode for SubscriptionOptions {
     fn decode(src: &mut Bytes) -> Result<Self, DecodeError> {
         ensure!(src.has_remaining(), DecodeError::InvalidLength);
         let val = src.get_u8();
+        // [MQTT-3.8.3-4] The reserved bits (6-7) in the Subscription Options
+        // byte MUST be set to 0; otherwise it is a Malformed Packet.
+        ensure!(val & 0b1100_0000 == 0, DecodeError::MalformedPacket);
         let qos = (val & 0b0000_0011).try_into()?;
         let retain_handling = ((val & 0b0011_0000) >> 4).try_into()?;
         Ok(SubscriptionOptions {


### PR DESCRIPTION
Add validation per [MQTT-3.8.3-4]: the reserved bits (6-7) in the Subscription Options byte MUST be set to 0; otherwise it is a Malformed Packet.