### PR TITLE
fix(session): reject MQTT v5 AUTH packets as unsupported

### DIFF
--- a/rmqtt-test/src/framework/scheduler.rs
+++ b/rmqtt-test/src/framework/scheduler.rs
@@ -8,7 +8,7 @@ use tracing::{error, info, warn};
 
 use super::context::TestContext;
 use super::suite::TestSuite;
-use super::testcase::{TestCase, TestResult, TestVerdict};
+use super::testcase::{Expectation, TestCase, TestResult, TestVerdict};
 
 /// Schedule and execute test suites
 pub struct TestScheduler {
@@ -76,7 +76,7 @@ impl TestScheduler {
         for idx in order {
             let test = &suite.tests[idx];
             let result = self.execute_test_with_retry(test, ctx, &suite.name);
-            let passed = result.verdict.is_passed();
+            let passed = result.verdict.counts_as_success();
             self.results.push(result);
 
             if !passed && is_critical_failure(&self.results) {
@@ -94,7 +94,8 @@ impl TestScheduler {
         }
     }
 
-    /// Execute a test with retry
+    /// Execute a test with retry, then map the raw outcome through the
+    /// test's declared [`Expectation`] (expected-fail / record-type).
     fn execute_test_with_retry(
         &self,
         test: &Arc<dyn TestCase>,
@@ -108,7 +109,7 @@ impl TestScheduler {
         let mut result = Self::execute_once(test.as_ref(), ctx, suite_name, start, timeout);
 
         for retry in 0..max_retries {
-            if result.verdict.is_passed() {
+            if result.verdict.counts_as_success() {
                 break;
             }
             info!("Retrying test '{}' (attempt {}/{})", test.name(), retry + 1, max_retries);
@@ -117,7 +118,7 @@ impl TestScheduler {
             result.retries = retry + 1;
         }
 
-        result
+        apply_expectation(result, test.expectation())
     }
 
     /// Execute a test once with timeout
@@ -152,6 +153,8 @@ impl TestScheduler {
         let mut skipped = 0;
         let mut errors = 0;
         let mut timeouts = 0;
+        let mut expected_fail = 0;
+        let mut info = 0;
         let mut total_duration = Duration::ZERO;
 
         for r in &self.results {
@@ -162,10 +165,22 @@ impl TestScheduler {
                 TestVerdict::Skipped(_) => skipped += 1,
                 TestVerdict::Error(_) => errors += 1,
                 TestVerdict::Timeout => timeouts += 1,
+                TestVerdict::ExpectedFail(_) => expected_fail += 1,
+                TestVerdict::Info(_) => info += 1,
             }
         }
 
-        TestSummary { total: self.results.len(), passed, failed, skipped, errors, timeouts, total_duration }
+        TestSummary {
+            total: self.results.len(),
+            passed,
+            failed,
+            skipped,
+            errors,
+            timeouts,
+            expected_fail,
+            info,
+            total_duration,
+        }
     }
 }
 
@@ -178,7 +193,59 @@ pub struct TestSummary {
     pub skipped: usize,
     pub errors: usize,
     pub timeouts: usize,
+    /// Broker violations recorded as expected failures (issue-backed)
+    pub expected_fail: usize,
+    /// Record-type observations (MAY-level spec behaviors)
+    pub info: usize,
     pub total_duration: Duration,
+}
+
+/// Map a raw test outcome through the test's declared [`Expectation`].
+fn apply_expectation(mut result: TestResult, expectation: Expectation) -> TestResult {
+    match expectation {
+        Expectation::Normal => result,
+        Expectation::ExpectedFail => match &result.verdict {
+            TestVerdict::Failed(_) | TestVerdict::Error(_) | TestVerdict::Timeout => {
+                let reason = verdict_observation(&result.verdict);
+                warn!("EXPECTED-FAIL: '{}' - broker violates the spec as expected: {}", result.name, reason);
+                result.verdict = TestVerdict::ExpectedFail(reason);
+                result
+            }
+            TestVerdict::Passed => {
+                result.note = Some(
+                    "UNEXPECTED-PASS: broker is now compliant; promote this test to a \
+                     normal assertion and close the linked issue"
+                        .to_string(),
+                );
+                result
+            }
+            _ => result,
+        },
+        Expectation::Info => match &result.verdict {
+            TestVerdict::Passed => {
+                let observation = result.note.clone().unwrap_or_else(|| "no observation".to_string());
+                result.verdict = TestVerdict::Info(observation);
+                result.note = None;
+                result
+            }
+            TestVerdict::Failed(_) | TestVerdict::Error(_) | TestVerdict::Timeout => {
+                let observation = verdict_observation(&result.verdict);
+                result.verdict = TestVerdict::Info(observation);
+                result
+            }
+            _ => result,
+        },
+    }
+}
+
+/// Extract a human-readable observation from a verdict.
+fn verdict_observation(verdict: &TestVerdict) -> String {
+    match verdict {
+        TestVerdict::Failed(r) | TestVerdict::Error(r) | TestVerdict::Skipped(r) => r.clone(),
+        TestVerdict::Timeout => "test timed out".to_string(),
+        TestVerdict::ExpectedFail(r) | TestVerdict::Info(r) => r.clone(),
+        TestVerdict::Passed => "passed".to_string(),
+    }
 }
 
 /// Resolve DAG dependencies to produce execution order (topological sort)

--- a/rmqtt-test/src/framework/testcase.rs
+++ b/rmqtt-test/src/framework/testcase.rs
@@ -10,12 +10,43 @@ pub enum TestVerdict {
     Skipped(String),
     Error(String),
     Timeout,
+    /// The broker violated the spec as expected by this test case. Recorded
+    /// as evidence (see the linked GitHub issue) and NOT counted as a suite
+    /// failure. When the broker becomes compliant, the test surfaces as an
+    /// unexpected pass and should be promoted to a normal assertion.
+    ExpectedFail(String),
+    /// Record-type verdict for MAY-level spec behaviors: the test observed
+    /// and reported the broker's actual behavior without asserting a
+    /// pass/fail outcome. Never counts as a failure.
+    Info(String),
 }
 
 impl TestVerdict {
     pub fn is_passed(&self) -> bool {
         matches!(self, TestVerdict::Passed)
     }
+
+    /// Verdicts that count as "no failure" for scheduling purposes:
+    /// retrying is stopped and the suite is not halted.
+    pub fn counts_as_success(&self) -> bool {
+        matches!(self, TestVerdict::Passed | TestVerdict::ExpectedFail(_) | TestVerdict::Info(_))
+    }
+}
+
+/// Declared expectation of a test case, applied by the scheduler after
+/// execution to map the raw outcome onto the reported verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Expectation {
+    /// Ordinary assertive test (default).
+    #[default]
+    Normal,
+    /// The broker is known to violate the spec here (a GitHub issue must be
+    /// registered). A failure is recorded as `ExpectedFail`; a pass is
+    /// annotated `UNEXPECTED-PASS` so the test can be promoted.
+    ExpectedFail,
+    /// Record-type test for MAY-level spec behavior: outcomes are reported
+    /// as `Info` observations, never as failures.
+    Info,
 }
 
 /// Test result with timing and metadata
@@ -134,6 +165,12 @@ pub trait TestCase: Send + Sync {
     /// Test dependencies (names of tests that must complete first)
     fn depends_on(&self) -> Vec<String> {
         Vec::new()
+    }
+
+    /// Declared expectation of this test case (default: normal assertion).
+    /// See [`Expectation`] for the expected-fail / record-type mechanisms.
+    fn expectation(&self) -> Expectation {
+        Expectation::Normal
     }
 }
 

--- a/rmqtt-test/src/main.rs
+++ b/rmqtt-test/src/main.rs
@@ -686,6 +686,36 @@ fn build_functional_v5_suite() -> TestSuite {
     suite.add(ProtocolErrorV5PublishEmptyTopicTest);
     suite.add(ProtocolErrorV5BadRemainingLengthTest);
     suite.add(ProtocolErrorV5ReservedPacketTypeTest);
+    // --- P0 gap-analysis additions (designs/mqtt-5.0-standalone-test-gap-analysis.md) ---
+    // G1/G2: SUBSCRIBE / UNSUBSCRIBE empty payload [MQTT-3.8.3-3 / MQTT-3.10.3-2]
+    suite.add(ProtocolErrorV5SubscribeEmptyPayloadTest);
+    suite.add(ProtocolErrorV5UnsubscribeEmptyPayloadTest);
+    // G3: subscription options — Retain Handling 3 / reserved bits
+    suite.add(ProtocolErrorV5RetainHandling3Test);
+    suite.add(ProtocolErrorV5SubOptionsReservedBitsTest);
+    // G4: Subscription Identifier = 0 / on UNSUBSCRIBE
+    suite.add(ProtocolErrorV5SubIdZeroTest);
+    suite.add(ProtocolErrorV5UnsubscribeWithSubIdTest);
+    // G6: DUP=1 with QoS=0 [MQTT-3.3.1-2]
+    suite.add(ProtocolErrorV5PublishDupOnQos0Test);
+    // G9: DISCONNECT with non-zero reserved fixed-header flags
+    suite.add(ProtocolErrorV5DisconnectBadFlagsTest);
+    // G10: SUBSCRIBE / UNSUBSCRIBE packet id 0 [MQTT-2.2.1-2]
+    suite.add(ProtocolErrorV5SubscribePacketIdZeroTest);
+    suite.add(ProtocolErrorV5UnsubscribePacketIdZeroTest);
+    // G11: invalid UTF-8 topic / user property
+    suite.add(ProtocolErrorV5InvalidUtf8TopicTest);
+    suite.add(ProtocolErrorV5UserPropertyBadUtf8Test);
+    // G12: unsolicited AUTH packet
+    suite.add(ProtocolErrorV5UnsolicitedAuthTest);
+    // G5: CONNECT Will Flag = 0 with Will QoS / Will Retain set
+    suite.add(ConnectV5WillFlagZeroButQosSetTest);
+    suite.add(ConnectV5WillFlagZeroButRetainSetTest);
+    // G7: Topic Alias 0 / exceeding advertised maximum
+    suite.add(TopicAliasV5ZeroTest);
+    suite.add(TopicAliasV5OverMaxTest);
+    // G8: client exceeding the broker's Receive Maximum → 0x93
+    suite.add(FlowControlV5ReceiveMaxViolationTest);
     // Retained message edge cases
     suite.add(RetainV5StoreAndDeliverTest);
     suite.add(RetainV5EmptyDeleteTest);

--- a/rmqtt-test/src/report/console.rs
+++ b/rmqtt-test/src/report/console.rs
@@ -17,6 +17,8 @@ impl ConsoleReporter {
                 TestVerdict::Passed => "\u{2714}",
                 TestVerdict::Failed(_) | TestVerdict::Error(_) | TestVerdict::Timeout => "\u{2718}",
                 TestVerdict::Skipped(_) => "\u{25CB}",
+                TestVerdict::ExpectedFail(_) => "\u{26A0}", // warning sign
+                TestVerdict::Info(_) => "\u{2139}",         // info sign
             };
 
             let reason = match &result.verdict {
@@ -24,6 +26,8 @@ impl ConsoleReporter {
                     format!(" ({})", r)
                 }
                 TestVerdict::Timeout => " (timeout)".to_string(),
+                TestVerdict::ExpectedFail(r) => format!(" (EXPECTED-FAIL: {})", r),
+                TestVerdict::Info(r) => format!(" (INFO: {})", r),
                 TestVerdict::Passed => result.note.as_ref().map(|n| format!(" ({})", n)).unwrap_or_default(),
             };
 
@@ -38,8 +42,9 @@ impl ConsoleReporter {
 
         println!("\n{}", "-".repeat(60));
         println!(
-            "  Total: {} | Passed: {} | Failed: {} | Errors: {} | Timeouts: {} | Skipped: {}",
+            "  Total: {} | Passed: {} | Failed: {} | Errors: {} | Timeouts: {} | Skipped: {} | ExpectedFail: {} | Info: {}",
             summary.total, summary.passed, summary.failed, summary.errors, summary.timeouts, summary.skipped,
+            summary.expected_fail, summary.info,
         );
         println!("  Duration: {:.2}s", summary.total_duration.as_secs_f64());
         println!("{}\n", "=".repeat(60));

--- a/rmqtt-test/src/report/detail_log.rs
+++ b/rmqtt-test/src/report/detail_log.rs
@@ -54,6 +54,8 @@ fn write_summary_section(file: &mut std::fs::File, summary: &TestSummary) -> Res
     writeln!(file, "  Errors:  {}", summary.errors)?;
     writeln!(file, "  Timeout: {}", summary.timeouts)?;
     writeln!(file, "  Skipped: {}", summary.skipped)?;
+    writeln!(file, "  ExpectedFail: {}", summary.expected_fail)?;
+    writeln!(file, "  Info:    {}", summary.info)?;
     writeln!(file, "  Duration: {:.1}s", summary.total_duration.as_secs_f64())?;
     Ok(())
 }
@@ -65,6 +67,8 @@ fn write_test_detail(file: &mut std::fs::File, result: &TestResult) -> Result<()
         TestVerdict::Skipped(_) => "SKIPPED",
         TestVerdict::Error(_) => "ERROR",
         TestVerdict::Timeout => "TIMEOUT",
+        TestVerdict::ExpectedFail(_) => "EXPECTED-FAIL",
+        TestVerdict::Info(_) => "INFO",
     };
 
     writeln!(file, "───────────────────────────────────────────────────────────────")?;
@@ -94,6 +98,22 @@ fn write_test_detail(file: &mut std::fs::File, result: &TestResult) -> Result<()
             writeln!(file, "  HINT: The test may be waiting for a response that never comes.")?;
             writeln!(file, "  This often indicates a protocol-level issue (e.g., broker rejected")?;
             writeln!(file, "  a packet, or the client sent a malformed packet).")?;
+        }
+        TestVerdict::ExpectedFail(reason) => {
+            writeln!(file)?;
+            writeln!(file, "  EXPECTED-FAIL OBSERVATION (broker violates the spec; see linked issue):")?;
+            for line in reason.lines() {
+                writeln!(file, "    {}", line)?;
+            }
+            writeln!(file)?;
+        }
+        TestVerdict::Info(observation) => {
+            writeln!(file)?;
+            writeln!(file, "  OBSERVATION (record-type test, no pass/fail assertion):")?;
+            for line in observation.lines() {
+                writeln!(file, "    {}", line)?;
+            }
+            writeln!(file)?;
         }
         TestVerdict::Passed => {
             if let Some(note) = &result.note {
@@ -137,6 +157,8 @@ fn verdict_reason(verdict: &TestVerdict) -> String {
     match verdict {
         TestVerdict::Failed(r) | TestVerdict::Error(r) | TestVerdict::Skipped(r) => r.clone(),
         TestVerdict::Timeout => "timeout".to_string(),
+        TestVerdict::ExpectedFail(r) => format!("expected-fail: {}", r),
+        TestVerdict::Info(r) => format!("info: {}", r),
         TestVerdict::Passed => "passed".to_string(),
     }
 }

--- a/rmqtt-test/src/report/html.rs
+++ b/rmqtt-test/src/report/html.rs
@@ -23,6 +23,8 @@ impl HtmlReporter {
         html.push_str(".error { color: #ff4757; }\n");
         html.push_str(".timeout { color: #ffa502; }\n");
         html.push_str(".skipped { color: #747d8c; }\n");
+        html.push_str(".expected-fail { color: #f9ca24; }\n");
+        html.push_str(".info { color: #54a0ff; }\n");
         html.push_str("table { border-collapse: collapse; width: 100%; }\n");
         html.push_str("th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #333; }\n");
         html.push_str("th { background: #16213e; }\n");
@@ -41,8 +43,17 @@ impl HtmlReporter {
              <span class='failed'>Failed: {}</span> | \
              <span class='error'>Errors: {}</span> | \
              <span class='timeout'>Timeouts: {}</span> | \
-             <span class='skipped'>Skipped: {}</span></p>\n",
-            summary.total, summary.passed, summary.failed, summary.errors, summary.timeouts, summary.skipped
+             <span class='skipped'>Skipped: {}</span> | \
+             <span class='expected-fail'>ExpectedFail: {}</span> | \
+             <span class='info'>Info: {}</span></p>\n",
+            summary.total,
+            summary.passed,
+            summary.failed,
+            summary.errors,
+            summary.timeouts,
+            summary.skipped,
+            summary.expected_fail,
+            summary.info
         ));
         html.push_str(&format!("<p>Duration: {:.2}s</p>\n", summary.total_duration.as_secs_f64()));
         html.push_str("</div>\n");
@@ -57,10 +68,14 @@ impl HtmlReporter {
                 TestVerdict::Error(_) => ("error", "ERROR"),
                 TestVerdict::Timeout => ("timeout", "TIMEOUT"),
                 TestVerdict::Skipped(_) => ("skipped", "SKIP"),
+                TestVerdict::ExpectedFail(_) => ("expected-fail", "XFAIL"),
+                TestVerdict::Info(_) => ("info", "INFO"),
             };
             let reason = match &r.verdict {
                 TestVerdict::Failed(r) | TestVerdict::Error(r) | TestVerdict::Skipped(r) => r.clone(),
                 TestVerdict::Timeout => "timed out".to_string(),
+                TestVerdict::ExpectedFail(rv) => format!("EXPECTED-FAIL: {}", rv),
+                TestVerdict::Info(rv) => format!("INFO: {}", rv),
                 TestVerdict::Passed => r.note.clone().unwrap_or_default(),
             };
             let duration = if r.duration.as_millis() < 1000 {

--- a/rmqtt-test/src/report/json.rs
+++ b/rmqtt-test/src/report/json.rs
@@ -22,6 +22,8 @@ pub struct JsonSummary {
     pub skipped: usize,
     pub errors: usize,
     pub timeouts: usize,
+    pub expected_fail: usize,
+    pub info: usize,
     pub duration_ms: u64,
 }
 
@@ -61,6 +63,8 @@ impl JsonReporter {
                 skipped: summary.skipped,
                 errors: summary.errors,
                 timeouts: summary.timeouts,
+                expected_fail: summary.expected_fail,
+                info: summary.info,
                 duration_ms: summary.total_duration.as_millis() as u64,
             },
             cases,
@@ -82,6 +86,8 @@ fn verdict_to_status(v: &TestVerdict) -> String {
         TestVerdict::Skipped(_) => "skipped".to_string(),
         TestVerdict::Error(_) => "error".to_string(),
         TestVerdict::Timeout => "timeout".to_string(),
+        TestVerdict::ExpectedFail(_) => "expected-fail".to_string(),
+        TestVerdict::Info(_) => "info".to_string(),
     }
 }
 
@@ -89,6 +95,8 @@ fn verdict_to_reason(v: &TestVerdict) -> Option<String> {
     match v {
         TestVerdict::Failed(r) | TestVerdict::Skipped(r) | TestVerdict::Error(r) => Some(r.clone()),
         TestVerdict::Timeout => Some("test timed out".to_string()),
+        TestVerdict::ExpectedFail(r) => Some(format!("expected-fail: {}", r)),
+        TestVerdict::Info(r) => Some(format!("info: {}", r)),
         TestVerdict::Passed => None,
     }
 }

--- a/rmqtt-test/src/tests/functional/connect_v5.rs
+++ b/rmqtt-test/src/tests/functional/connect_v5.rs
@@ -495,3 +495,80 @@ impl TestCase for ConnectV5AuthMethodRejectedTest {
         Duration::from_secs(10)
     }
 }
+
+// ---------------------------------------------------------------------------
+// P0 gap-analysis additions (designs/mqtt-5.0-standalone-test-gap-analysis.md)
+// ---------------------------------------------------------------------------
+
+/// Expect a CONNECT to be rejected: either the connection is closed without a
+/// successful CONNACK, or a CONNACK with a non-zero reason code is returned.
+fn expect_connect_rejected(ctx: &TestContext, packet: &[u8]) -> anyhow::Result<()> {
+    match raw_connect_v5_exchange(&ctx.config.broker_addr, packet) {
+        Ok(None) => Ok(()),
+        Ok(Some((_, code))) if code != 0 => Ok(()),
+        Ok(Some((_, code))) => {
+            Err(anyhow::anyhow!("broker accepted the illegal CONNECT (CONNACK reason 0x{code:02X})"))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Negative: CONNECT with Will Flag = 0 but Will QoS = 1 is a Malformed
+/// Packet. [MQTT-3.1.2-11 / MQTT-3.1.2-13]
+///
+/// Known broker defect (registered as a GitHub issue): expected-fail.
+pub struct ConnectV5WillFlagZeroButQosSetTest;
+
+impl TestCase for ConnectV5WillFlagZeroButQosSetTest {
+    fn name(&self) -> &str {
+        "connect_v5_will_flag_zero_but_qos_set"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        // flags = 0x0A: clean start (0x02) + Will QoS = 1 (0x08), Will Flag = 0
+        let packet = raw_connect_v5_bytes(b"MQTT", 5, 0x0A, 60, b"willflag-qos", None);
+        match expect_connect_rejected(ctx, &packet) {
+            Ok(()) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Err(e) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+
+    fn expectation(&self) -> crate::framework::testcase::Expectation {
+        crate::framework::testcase::Expectation::ExpectedFail
+    }
+}
+
+/// Negative: CONNECT with Will Flag = 0 but Will Retain = 1 is a Malformed
+/// Packet. [MQTT-3.1.2-11 / MQTT-3.1.2-12]
+///
+/// Known broker defect (registered as a GitHub issue): expected-fail.
+pub struct ConnectV5WillFlagZeroButRetainSetTest;
+
+impl TestCase for ConnectV5WillFlagZeroButRetainSetTest {
+    fn name(&self) -> &str {
+        "connect_v5_will_flag_zero_but_retain_set"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        // flags = 0x22: clean start (0x02) + Will Retain (0x20), Will Flag = 0
+        let packet = raw_connect_v5_bytes(b"MQTT", 5, 0x22, 60, b"willflag-retain", None);
+        match expect_connect_rejected(ctx, &packet) {
+            Ok(()) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Err(e) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+
+    fn expectation(&self) -> crate::framework::testcase::Expectation {
+        crate::framework::testcase::Expectation::ExpectedFail
+    }
+}

--- a/rmqtt-test/src/tests/functional/flow_control_v5.rs
+++ b/rmqtt-test/src/tests/functional/flow_control_v5.rs
@@ -88,3 +88,271 @@ impl TestCase for FlowControlV5Test {
         Duration::from_secs(20)
     }
 }
+
+// ---------------------------------------------------------------------------
+// P0 gap-analysis additions (designs/mqtt-5.0-standalone-test-gap-analysis.md)
+// ---------------------------------------------------------------------------
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+/// Open a raw TCP connection with a successful v5 CONNECT handshake and
+/// return (stream, connack bytes).
+fn raw_connect_with_connack(broker_addr: &str, client_id: &str) -> anyhow::Result<(TcpStream, Vec<u8>)> {
+    let mut stream = TcpStream::connect(broker_addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+
+    let mut body: Vec<u8> = Vec::new();
+    body.extend_from_slice(&[0x00, 0x04]);
+    body.extend_from_slice(b"MQTT");
+    body.push(5);
+    body.push(0x02); // clean start
+    body.extend_from_slice(&[0x00, 0x3C]); // keep alive 60
+    body.push(0x00); // property length 0
+    let cid = client_id.as_bytes();
+    body.extend_from_slice(&(cid.len() as u16).to_be_bytes());
+    body.extend_from_slice(cid);
+
+    let mut pkt = vec![0x10];
+    let mut len = body.len();
+    loop {
+        let mut b = (len % 128) as u8;
+        len /= 128;
+        if len > 0 {
+            b |= 0x80;
+        }
+        pkt.push(b);
+        if len == 0 {
+            break;
+        }
+    }
+    pkt.extend_from_slice(&body);
+
+    stream.write_all(&pkt)?;
+    stream.flush()?;
+    let connack = match read_full_packet_fc(&mut stream)? {
+        ReadOutcome::Packet(p) => p,
+        ReadOutcome::Eof | ReadOutcome::Timeout => {
+            return Err(anyhow::anyhow!("no CONNACK: connection closed or timed out"))
+        }
+    };
+    if connack.len() < 4 || connack[0] != 0x20 || connack[3] != 0 {
+        return Err(anyhow::anyhow!("no CONNACK: {:02x?}", &connack[..connack.len().min(8)]));
+    }
+    Ok((stream, connack))
+}
+
+/// Outcome of a raw packet read attempt.
+enum ReadOutcome {
+    Packet(Vec<u8>),
+    Eof,
+    Timeout,
+}
+
+/// Read one full MQTT packet (fixed header + remaining length) from a raw
+/// stream, distinguishing EOF from a read timeout.
+fn read_full_packet_fc(stream: &mut TcpStream) -> anyhow::Result<ReadOutcome> {
+    fn is_timeout(e: &std::io::Error) -> bool {
+        matches!(e.kind(), std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut)
+    }
+
+    let mut buf = Vec::new();
+    let mut b = [0u8; 1];
+    match stream.read(&mut b) {
+        Ok(0) => return Ok(ReadOutcome::Eof),
+        Err(e) if is_timeout(&e) => return Ok(ReadOutcome::Timeout),
+        Err(e) => return Err(e.into()),
+        Ok(_) => {}
+    }
+    buf.push(b[0]);
+
+    let mut remaining: u32 = 0;
+    let mut shift = 0u32;
+    loop {
+        match stream.read(&mut b) {
+            Ok(0) => return Ok(ReadOutcome::Eof),
+            Err(e) if is_timeout(&e) => return Ok(ReadOutcome::Timeout),
+            Err(e) => return Err(e.into()),
+            Ok(_) => {}
+        }
+        buf.push(b[0]);
+        remaining |= ((b[0] & 0x7F) as u32) << shift;
+        if b[0] & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+        if shift > 21 {
+            return Err(anyhow::anyhow!("malformed remaining length"));
+        }
+    }
+
+    let mut rest = vec![0u8; remaining as usize];
+    match stream.read_exact(&mut rest) {
+        Ok(()) => {}
+        Err(e) if is_timeout(&e) => return Ok(ReadOutcome::Timeout),
+        Err(e) => return Err(e.into()),
+    }
+    buf.extend_from_slice(&rest);
+    Ok(ReadOutcome::Packet(buf))
+}
+
+/// Parse the Receive Maximum (property 0x21) advertised in the CONNACK bytes.
+/// Returns `None` when the property is absent or the CONNACK cannot be
+/// scanned; the caller then derives a burst size from the spec default
+/// (65535, effectively unlimited).
+fn connack_receive_max(connack: &[u8]) -> Option<u16> {
+    if connack.len() < 4 || connack[0] != 0x20 {
+        return None;
+    }
+    let mut i = 1usize;
+    while i < connack.len() && connack[i] & 0x80 != 0 {
+        i += 1;
+    }
+    i += 1; // consume terminating varint byte
+    i += 2; // ack flags + reason code
+    if i >= connack.len() {
+        return None;
+    }
+    let mut plen: usize = 0;
+    let mut shift = 0u32;
+    loop {
+        if i >= connack.len() {
+            return None;
+        }
+        let v = connack[i];
+        i += 1;
+        plen |= ((v & 0x7F) as usize) << shift;
+        if v & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+    let props_end = (i + plen).min(connack.len());
+
+    while i < props_end {
+        let id = connack[i];
+        i += 1;
+        match id {
+            0x21 => {
+                if i + 2 > props_end {
+                    return None;
+                }
+                return Some(u16::from_be_bytes([connack[i], connack[i + 1]]));
+            }
+            0x24 | 0x25 => i += 1,
+            0x22 => i += 2,
+            0x11 | 0x27 => i += 4,
+            0x12 | 0x1F | 0x31 => {
+                if i + 2 > props_end {
+                    return None;
+                }
+                let slen = u16::from_be_bytes([connack[i], connack[i + 1]]) as usize;
+                i += 2 + slen;
+            }
+            0x26 => {
+                for _ in 0..2 {
+                    if i + 2 > props_end {
+                        return None;
+                    }
+                    let slen = u16::from_be_bytes([connack[i], connack[i + 1]]) as usize;
+                    i += 2 + slen;
+                }
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// Negative: a client that exceeds the broker's advertised Receive Maximum
+/// (more in-flight QoS 1 PUBLISHes than the broker allows without waiting for
+/// PUBACK) must be disconnected with reason 0x93. [MQTT-4.9.0-1 / MQTT-4.9.0-2]
+pub struct FlowControlV5ReceiveMaxViolationTest;
+
+impl TestCase for FlowControlV5ReceiveMaxViolationTest {
+    fn name(&self) -> &str {
+        "flow_control_v5_receive_max_violation"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+
+        let result = std::panic::catch_unwind(|| -> anyhow::Result<()> {
+            let (mut stream, connack) = raw_connect_with_connack(&ctx.config.broker_addr, "fc-violation")?;
+            let recv_max = connack_receive_max(&connack)
+                .ok_or_else(|| anyhow::anyhow!("could not parse Receive Maximum from CONNACK"))?;
+
+            // Burst of QoS 1 PUBLISHes far beyond the advertised Receive
+            // Maximum, with unique packet ids, sent without reading PUBACKs.
+            let burst: u16 = recv_max.saturating_mul(4).saturating_add(20);
+            let topic = b"test/fc/violation";
+            for pid in 1..=burst {
+                let mut body: Vec<u8> = Vec::new();
+                body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+                body.extend_from_slice(topic);
+                body.push(0x00); // property length 0
+                body.extend_from_slice(&pid.to_be_bytes()); // packet id
+                body.extend_from_slice(b"v"); // payload
+
+                let mut pkt = vec![0x32]; // PUBLISH QoS 1
+                let mut len = body.len();
+                loop {
+                    let mut b = (len % 128) as u8;
+                    len /= 128;
+                    if len > 0 {
+                        b |= 0x80;
+                    }
+                    pkt.push(b);
+                    if len == 0 {
+                        break;
+                    }
+                }
+                pkt.extend_from_slice(&body);
+                stream.write_all(&pkt)?;
+            }
+            stream.flush()?;
+
+            // Read responses until DISCONNECT / EOF / deadline.
+            let deadline = Instant::now() + Duration::from_secs(5);
+            stream.set_read_timeout(Some(Duration::from_millis(500)))?;
+            loop {
+                if Instant::now() > deadline {
+                    return Err(anyhow::anyhow!(
+                        "broker did not disconnect after {} in-flight QoS1 PUBLISHes \
+                         (Receive Maximum advertised: {})",
+                        burst,
+                        recv_max
+                    ));
+                }
+                match read_full_packet_fc(&mut stream)? {
+                    ReadOutcome::Eof => return Ok(()), // closed without DISCONNECT
+                    ReadOutcome::Timeout => continue,  // keep waiting until deadline
+                    ReadOutcome::Packet(pkt) => {
+                        let ptype = pkt[0] & 0xF0;
+                        if ptype == 0xE0 {
+                            // DISCONNECT: reason code is the first remaining byte
+                            if pkt.len() >= 3 && pkt[2] != 0x93 {
+                                return Err(anyhow::anyhow!(
+                                    "DISCONNECT with unexpected reason 0x{:02X}, expected 0x93",
+                                    pkt[2]
+                                ));
+                            }
+                            return Ok(());
+                        }
+                        // PUBACK (0x40) etc. — keep reading
+                    }
+                }
+            }
+        });
+
+        match result {
+            Ok(Ok(())) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Ok(Err(e)) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+            Err(_) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), "panic".into()),
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(20)
+    }
+}

--- a/rmqtt-test/src/tests/functional/protocol_error_v5.rs
+++ b/rmqtt-test/src/tests/functional/protocol_error_v5.rs
@@ -135,6 +135,57 @@ fn run_protocol_error(
     }
 }
 
+/// Append a Remaining Length varint for `len` and then `body` to `pkt`.
+fn finish_packet(pkt: &mut Vec<u8>, body: &[u8]) {
+    let mut len = body.len();
+    loop {
+        let mut b = (len % 128) as u8;
+        len /= 128;
+        if len > 0 {
+            b |= 0x80;
+        }
+        pkt.push(b);
+        if len == 0 {
+            break;
+        }
+    }
+    pkt.extend_from_slice(body);
+}
+
+/// Expect the broker to reject a raw packet: connection closed (EOF /
+/// timeout), or a DISCONNECT packet carrying a specific reason code.
+/// When `expect_reason` is `Some(code)`, the DISCONNECT reason code must
+/// match; otherwise any rejection signal is accepted.
+fn expect_rejection_with_reason(
+    stream: &mut TcpStream,
+    data: &[u8],
+    expect_reason: Option<u8>,
+) -> anyhow::Result<()> {
+    let _ = stream.write_all(data);
+    let _ = stream.flush();
+    let mut buf = [0u8; 16];
+    match stream.read(&mut buf) {
+        Ok(0) | Err(_) => Ok(()), // EOF / timeout → closed
+        Ok(n) if n >= 1 && buf[0] == 0xE0 => {
+            // DISCONNECT: [0xE0][rlen][reason][props...]
+            if let Some(expected) = expect_reason {
+                let rlen = buf[1] as usize;
+                if n >= 3 && rlen >= 1 && buf[2] != expected {
+                    return Err(anyhow::anyhow!(
+                        "broker sent DISCONNECT with reason 0x{:02X}, expected 0x{:02X}",
+                        buf[2],
+                        expected
+                    ));
+                }
+            }
+            Ok(())
+        }
+        Ok(n) => {
+            Err(anyhow::anyhow!("broker did not reject the packet (responded {:02x?})", &buf[..n.min(4)]))
+        }
+    }
+}
+
 /// Negative: SUBSCRIBE with requested QoS 3 is a protocol error.
 pub struct ProtocolErrorV5SubscribeQos3Test;
 
@@ -463,6 +514,388 @@ impl TestCase for ProtocolErrorV5ReservedPacketTypeTest {
             } else {
                 Err(anyhow::anyhow!("broker did not close for reserved packet type 0x00"))
             }
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// P0 gap-analysis additions (designs/mqtt-5.0-standalone-test-gap-analysis.md)
+// ---------------------------------------------------------------------------
+
+/// Negative: SUBSCRIBE with an empty payload (zero topic filters) is a
+/// Protocol Error. [MQTT-3.8.3-3]
+pub struct ProtocolErrorV5SubscribeEmptyPayloadTest;
+
+impl TestCase for ProtocolErrorV5SubscribeEmptyPayloadTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_subscribe_empty_payload"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let body: [u8; 3] = [0x00, 0x01, 0x00]; // packet id 1, property length 0
+            let mut pkt = vec![0x82]; // SUBSCRIBE, QoS 1 fixed header
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: UNSUBSCRIBE with an empty payload (zero topic filters) is a
+/// Protocol Error. [MQTT-3.10.3-2]
+///
+/// Broker fixed in the v5 codec (`Subscribe::decode` / `Unsubscribe::decode`
+/// now reject empty topic_filters, parity with v3); this test is the
+/// regression guard for that fix.
+pub struct ProtocolErrorV5UnsubscribeEmptyPayloadTest;
+
+impl TestCase for ProtocolErrorV5UnsubscribeEmptyPayloadTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_unsubscribe_empty_payload"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let body: [u8; 3] = [0x00, 0x01, 0x00]; // packet id 1, property length 0
+            let mut pkt = vec![0xA2]; // UNSUBSCRIBE, QoS 1 fixed header
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: SUBSCRIBE with Retain Handling value 3 in the subscription
+/// options is a Malformed Packet. [MQTT-3.8.3-4]
+pub struct ProtocolErrorV5RetainHandling3Test;
+
+impl TestCase for ProtocolErrorV5RetainHandling3Test {
+    fn name(&self) -> &str {
+        "protocol_error_v5_retain_handling_3"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let topic = b"test/rh3";
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&[0x00, 0x01]); // packet id 1
+            body.push(0x00); // property length 0
+            body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            body.extend_from_slice(topic);
+            body.push(0x30); // options: QoS 0, Retain Handling = 3 — illegal
+
+            let mut pkt = vec![0x82];
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: SUBSCRIBE with reserved bits (6-7) set in the subscription
+/// options is a Malformed Packet. [MQTT-3.8.3-5]
+pub struct ProtocolErrorV5SubOptionsReservedBitsTest;
+
+impl TestCase for ProtocolErrorV5SubOptionsReservedBitsTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_sub_options_reserved_bits"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let topic = b"test/subres";
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&[0x00, 0x01]); // packet id 1
+            body.push(0x00); // property length 0
+            body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            body.extend_from_slice(topic);
+            body.push(0xC0); // options: reserved bits 6-7 set — illegal
+
+            let mut pkt = vec![0x82];
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: SUBSCRIBE with Subscription Identifier 0 is a Protocol Error.
+/// [MQTT-3.8.2.1.2]
+pub struct ProtocolErrorV5SubIdZeroTest;
+
+impl TestCase for ProtocolErrorV5SubIdZeroTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_sub_id_zero"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let topic = b"test/subid0";
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&[0x00, 0x01]); // packet id 1
+            body.push(0x02); // property length
+            body.push(0x0B); // Subscription Identifier property
+            body.push(0x00); // value 0 — illegal
+            body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            body.extend_from_slice(topic);
+            body.push(0x00); // subscription options: QoS 0
+
+            let mut pkt = vec![0x82];
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: UNSUBSCRIBE carrying a Subscription Identifier property is a
+/// Protocol Error. [MQTT-3.10.2.1]
+pub struct ProtocolErrorV5UnsubscribeWithSubIdTest;
+
+impl TestCase for ProtocolErrorV5UnsubscribeWithSubIdTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_unsubscribe_with_sub_id"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let topic = b"test/unsubid";
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&[0x00, 0x01]); // packet id 1
+            body.push(0x02); // property length
+            body.push(0x0B); // Subscription Identifier property — illegal here
+            body.push(0x01); // value 1
+            body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            body.extend_from_slice(topic);
+
+            let mut pkt = vec![0xA2];
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: PUBLISH with DUP=1 and QoS=0 is a Malformed Packet.
+/// [MQTT-3.3.1-2]
+pub struct ProtocolErrorV5PublishDupOnQos0Test;
+
+impl TestCase for ProtocolErrorV5PublishDupOnQos0Test {
+    fn name(&self) -> &str {
+        "protocol_error_v5_publish_dup_on_qos0"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let topic = b"test/dup0";
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            body.extend_from_slice(topic);
+            body.push(0x00); // property length 0
+            body.extend_from_slice(b"payload");
+
+            let mut pkt = vec![0x38]; // PUBLISH with DUP=1, QoS=0 — illegal
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: DISCONNECT with non-zero reserved fixed-header flags is a
+/// Malformed Packet. [MQTT-3.14.1-1 / MQTT-3.14.1-2]
+pub struct ProtocolErrorV5DisconnectBadFlagsTest;
+
+impl TestCase for ProtocolErrorV5DisconnectBadFlagsTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_disconnect_bad_flags"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let pkt = [0xE1u8, 0x00]; // DISCONNECT with fixed-header flags != 0
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: SUBSCRIBE with packet identifier 0 is a Protocol Error.
+/// [MQTT-2.2.1-2]
+pub struct ProtocolErrorV5SubscribePacketIdZeroTest;
+
+impl TestCase for ProtocolErrorV5SubscribePacketIdZeroTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_subscribe_packet_id_zero"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let topic = b"test/subpid0";
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&[0x00, 0x00]); // packet id 0 — illegal
+            body.push(0x00); // property length 0
+            body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            body.extend_from_slice(topic);
+            body.push(0x00); // subscription options: QoS 0
+
+            let mut pkt = vec![0x82];
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: UNSUBSCRIBE with packet identifier 0 is a Protocol Error.
+/// [MQTT-2.2.1-2]
+pub struct ProtocolErrorV5UnsubscribePacketIdZeroTest;
+
+impl TestCase for ProtocolErrorV5UnsubscribePacketIdZeroTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_unsubscribe_packet_id_zero"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let topic = b"test/unsubpid0";
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&[0x00, 0x00]); // packet id 0 — illegal
+            body.push(0x00); // property length 0
+            body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            body.extend_from_slice(topic);
+
+            let mut pkt = vec![0xA2];
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: PUBLISH with a topic name that is not valid UTF-8 is a Malformed
+/// Packet. [MQTT-1.5.3 / MQTT-3.3.2-1]
+pub struct ProtocolErrorV5InvalidUtf8TopicTest;
+
+impl TestCase for ProtocolErrorV5InvalidUtf8TopicTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_invalid_utf8_topic"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&[0x00, 0x02]); // topic length 2
+            body.extend_from_slice(&[0xC3, 0x28]); // invalid UTF-8 sequence
+            body.push(0x00); // property length 0
+            body.extend_from_slice(b"payload");
+
+            let mut pkt = vec![0x30]; // PUBLISH QoS 0
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: PUBLISH with a User Property value that is not valid UTF-8 is a
+/// Malformed Packet. [MQTT-1.5.3 / MQTT-3.3.2.3.8]
+pub struct ProtocolErrorV5UserPropertyBadUtf8Test;
+
+impl TestCase for ProtocolErrorV5UserPropertyBadUtf8Test {
+    fn name(&self) -> &str {
+        "protocol_error_v5_user_property_bad_utf8"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let topic = b"test/uprop";
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            body.extend_from_slice(topic);
+            body.push(0x09); // property length: 1 + (2+2) + (2+2)
+            body.push(0x26); // User Property
+            body.extend_from_slice(&[0x00, 0x02]); // key length 2
+            body.extend_from_slice(b"k1");
+            body.extend_from_slice(&[0x00, 0x02]); // value length 2
+            body.extend_from_slice(&[0xC3, 0x28]); // invalid UTF-8 value
+            body.extend_from_slice(b"payload");
+
+            let mut pkt = vec![0x30]; // PUBLISH QoS 0
+            finish_packet(&mut pkt, &body);
+            expect_rejection_with_reason(stream, &pkt, None)
+        })
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}
+
+/// Negative: an AUTH packet when no authentication method was negotiated in
+/// CONNECT must be rejected. [MQTT-4.12.0-1 / MQTT-3.15.1]
+pub struct ProtocolErrorV5UnsolicitedAuthTest;
+
+impl TestCase for ProtocolErrorV5UnsolicitedAuthTest {
+    fn name(&self) -> &str {
+        "protocol_error_v5_unsolicited_auth"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+        run_protocol_error(self.name(), ctx, start, |stream| {
+            let pkt = [0xF0u8, 0x00]; // AUTH with no properties
+            expect_rejection_with_reason(stream, &pkt, None)
         })
     }
 

--- a/rmqtt-test/src/tests/functional/topic_alias_v5.rs
+++ b/rmqtt-test/src/tests/functional/topic_alias_v5.rs
@@ -267,3 +267,304 @@ impl TestCase for TopicAliasV5UnknownAliasTest {
         Duration::from_secs(15)
     }
 }
+
+// ---------------------------------------------------------------------------
+// P0 gap-analysis additions (designs/mqtt-5.0-standalone-test-gap-analysis.md)
+// ---------------------------------------------------------------------------
+
+/// Open a raw TCP connection with a successful v5 CONNECT handshake.
+fn raw_connect_stream(broker_addr: &str, client_id: &str) -> anyhow::Result<TcpStream> {
+    let mut stream = TcpStream::connect(broker_addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+
+    let mut body: Vec<u8> = Vec::new();
+    body.extend_from_slice(&[0x00, 0x04]);
+    body.extend_from_slice(b"MQTT");
+    body.push(5);
+    body.push(0x02); // clean start
+    body.extend_from_slice(&[0x00, 0x3C]); // keep alive 60
+    body.push(0x00); // property length 0
+    let cid = client_id.as_bytes();
+    body.extend_from_slice(&(cid.len() as u16).to_be_bytes());
+    body.extend_from_slice(cid);
+
+    let mut pkt = vec![0x10];
+    let mut len = body.len();
+    loop {
+        let mut b = (len % 128) as u8;
+        len /= 128;
+        if len > 0 {
+            b |= 0x80;
+        }
+        pkt.push(b);
+        if len == 0 {
+            break;
+        }
+    }
+    pkt.extend_from_slice(&body);
+
+    stream.write_all(&pkt)?;
+    stream.flush()?;
+    let connack = read_full_packet(&mut stream)?;
+    if connack.len() < 4 || connack[0] != 0x20 || connack[3] != 0 {
+        return Err(anyhow::anyhow!("no CONNACK: {:02x?}", &connack[..connack.len().min(8)]));
+    }
+    Ok(stream)
+}
+
+/// Extract the Topic Alias Maximum (property 0x22) advertised in the CONNACK
+/// bytes. Returns 0 when the property is absent (spec: absent means 0).
+fn connack_topic_alias_max(connack: &[u8]) -> Option<u16> {
+    // CONNACK: [0x20][rlen varint][ack flags][reason][props varint][props...]
+    if connack.len() < 4 || connack[0] != 0x20 {
+        return None;
+    }
+    let mut i = 1usize;
+    // skip remaining length varint
+    while i < connack.len() && connack[i] & 0x80 != 0 {
+        i += 1;
+    }
+    i += 1; // consume the terminating varint byte
+            // skip ack flags + reason code
+    i += 2;
+    if i >= connack.len() {
+        return None;
+    }
+    // property length varint
+    let mut plen: usize = 0;
+    let mut shift = 0u32;
+    loop {
+        if i >= connack.len() {
+            return None;
+        }
+        let b = connack[i];
+        i += 1;
+        plen |= ((b & 0x7F) as usize) << shift;
+        if b & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+    let props_end = (i + plen).min(connack.len());
+
+    while i < props_end {
+        let id = connack[i];
+        i += 1;
+        match id {
+            0x22 => {
+                if i + 2 > props_end {
+                    return None;
+                }
+                return Some(u16::from_be_bytes([connack[i], connack[i + 1]]));
+            }
+            // 1-byte properties
+            0x24 | 0x25 => i += 1,
+            // 2-byte properties
+            0x21 => i += 2,
+            // 4-byte properties
+            0x11 | 0x27 => i += 4,
+            // UTF-8 string properties
+            0x12 | 0x1F | 0x31 => {
+                if i + 2 > props_end {
+                    return None;
+                }
+                let slen = u16::from_be_bytes([connack[i], connack[i + 1]]) as usize;
+                i += 2 + slen;
+            }
+            // User Property (string + string)
+            0x26 => {
+                for _ in 0..2 {
+                    if i + 2 > props_end {
+                        return None;
+                    }
+                    let slen = u16::from_be_bytes([connack[i], connack[i + 1]]) as usize;
+                    i += 2 + slen;
+                }
+            }
+            _ => return None, // unknown property id — give up scanning
+        }
+    }
+    None
+}
+
+/// Negative: a PUBLISH carrying Topic Alias 0 is a Protocol Error.
+/// [MQTT-3.3.2-8]
+pub struct TopicAliasV5ZeroTest;
+
+impl TestCase for TopicAliasV5ZeroTest {
+    fn name(&self) -> &str {
+        "topic_alias_v5_zero"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+
+        let result = std::panic::catch_unwind(|| -> anyhow::Result<()> {
+            let mut stream = raw_connect_stream(&ctx.config.broker_addr, "v5-alias-zero")?;
+
+            // PUBLISH with topic + Topic Alias property = 0 (illegal)
+            let topic = b"test/v5/alias/zero";
+            let mut pb: Vec<u8> = Vec::new();
+            pb.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            pb.extend_from_slice(topic);
+            pb.push(0x03); // prop len: 0x23 + 2 bytes
+            pb.push(0x23); // Topic Alias
+            pb.extend_from_slice(&[0x00, 0x00]); // alias 0 — illegal
+            pb.extend_from_slice(b"hi");
+
+            let mut ppkt = vec![0x30];
+            let mut plen = pb.len();
+            loop {
+                let mut b = (plen % 128) as u8;
+                plen /= 128;
+                if plen > 0 {
+                    b |= 0x80;
+                }
+                ppkt.push(b);
+                if plen == 0 {
+                    break;
+                }
+            }
+            ppkt.extend_from_slice(&pb);
+            stream.write_all(&ppkt)?;
+            stream.flush()?;
+
+            let mut rbuf = [0u8; 16];
+            match stream.read(&mut rbuf) {
+                Ok(0) | Err(_) => Ok(()),                     // closed — acceptable
+                Ok(n) if n >= 2 && rbuf[0] == 0xE0 => Ok(()), // DISCONNECT — acceptable
+                Ok(n) => Err(anyhow::anyhow!(
+                    "broker did not reject Topic Alias 0 (responded {:02x?})",
+                    &rbuf[..n]
+                )),
+            }
+        });
+
+        match result {
+            Ok(Ok(())) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Ok(Err(e)) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+            Err(_) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), "panic".into()),
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(15)
+    }
+}
+
+/// Negative: a PUBLISH carrying a Topic Alias greater than the server's
+/// advertised Topic Alias Maximum must trigger a DISCONNECT with reason 0x94.
+/// [MQTT-3.3.2-9]
+pub struct TopicAliasV5OverMaxTest;
+
+impl TestCase for TopicAliasV5OverMaxTest {
+    fn name(&self) -> &str {
+        "topic_alias_v5_over_max"
+    }
+
+    fn execute(&self, ctx: &mut TestContext) -> TestResult {
+        let start = Instant::now();
+
+        let result = std::panic::catch_unwind(|| -> anyhow::Result<()> {
+            // Probe connection: read the CONNACK bytes and parse the
+            // advertised Topic Alias Maximum.
+            let mut probe = TcpStream::connect(&ctx.config.broker_addr)?;
+            probe.set_read_timeout(Some(Duration::from_secs(5)))?;
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&[0x00, 0x04]);
+            body.extend_from_slice(b"MQTT");
+            body.push(5);
+            body.push(0x02);
+            body.extend_from_slice(&[0x00, 0x3C]);
+            body.push(0x00);
+            let cid = b"v5-alias-max-probe";
+            body.extend_from_slice(&(cid.len() as u16).to_be_bytes());
+            body.extend_from_slice(cid);
+            let mut pkt = vec![0x10];
+            let mut len = body.len();
+            loop {
+                let mut b = (len % 128) as u8;
+                len /= 128;
+                if len > 0 {
+                    b |= 0x80;
+                }
+                pkt.push(b);
+                if len == 0 {
+                    break;
+                }
+            }
+            pkt.extend_from_slice(&body);
+            probe.write_all(&pkt)?;
+            probe.flush()?;
+            let connack = read_full_packet(&mut probe)?;
+            drop(probe);
+
+            let alias_max = connack_topic_alias_max(&connack)
+                .ok_or_else(|| anyhow::anyhow!("could not parse Topic Alias Maximum from CONNACK"))?;
+            let over_max = alias_max.saturating_add(1);
+            if over_max == 0 {
+                return Err(anyhow::anyhow!("Topic Alias Maximum already at u16::MAX"));
+            }
+
+            let mut stream = raw_connect_stream(&ctx.config.broker_addr, "v5-alias-overmax")?;
+
+            // PUBLISH with topic + Topic Alias = max + 1 (exceeds advertised max)
+            let topic = b"test/v5/alias/overmax";
+            let mut pb: Vec<u8> = Vec::new();
+            pb.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+            pb.extend_from_slice(topic);
+            pb.push(0x03); // prop len
+            pb.push(0x23); // Topic Alias
+            pb.extend_from_slice(&over_max.to_be_bytes());
+            pb.extend_from_slice(b"hi");
+
+            let mut ppkt = vec![0x30];
+            let mut plen = pb.len();
+            loop {
+                let mut b = (plen % 128) as u8;
+                plen /= 128;
+                if plen > 0 {
+                    b |= 0x80;
+                }
+                ppkt.push(b);
+                if plen == 0 {
+                    break;
+                }
+            }
+            ppkt.extend_from_slice(&pb);
+            stream.write_all(&ppkt)?;
+            stream.flush()?;
+
+            // Broker must close (EOF) or send DISCONNECT with reason 0x94
+            let mut rbuf = [0u8; 16];
+            match stream.read(&mut rbuf) {
+                Ok(0) | Err(_) => Ok(()), // closed — acceptable
+                Ok(n) if n >= 2 && rbuf[0] == 0xE0 => {
+                    if n >= 3 && rbuf[2] != 0x94 {
+                        return Err(anyhow::anyhow!(
+                            "DISCONNECT with unexpected reason 0x{:02X}, expected 0x94",
+                            rbuf[2]
+                        ));
+                    }
+                    Ok(())
+                }
+                Ok(n) => Err(anyhow::anyhow!(
+                    "broker accepted Topic Alias {} > max {} (responded {:02x?})",
+                    over_max,
+                    alias_max,
+                    &rbuf[..n]
+                )),
+            }
+        });
+
+        match result {
+            Ok(Ok(())) => TestResult::passed(self.name(), "functional_v5", start.elapsed()),
+            Ok(Err(e)) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), e.to_string()),
+            Err(_) => TestResult::failed(self.name(), "functional_v5", start.elapsed(), "panic".into()),
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(15)
+    }
+}

--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -87,7 +87,7 @@ use crate::codec::v5::RetainHandling;
 use crate::codec::{
     v3,
     v5::{
-        self, Auth, PublishAck2, PublishAck2Reason, PublishAckReason, SubscribeAckReason, ToReasonCode,
+        self, PublishAck2, PublishAck2Reason, PublishAckReason, SubscribeAckReason, ToReasonCode,
         UserProperties,
     },
 };
@@ -845,8 +845,13 @@ impl SessionState {
                 return Ok(());
             }
             Packet::V5(v5::Packet::Auth(_)) => {
-                sink.v5_mut().send_auth(Auth::default()).await?;
-                //@TODO Consider implementing Auth through hooks
+                // rmqtt does not support MQTT 5.0 enhanced authentication, so no
+                // authentication method can ever have been negotiated in the
+                // CONNACK. [MQTT-4.12.0] Receiving an AUTH packet in that state
+                // is a Protocol Error -> DISCONNECT 0x82 and close.
+                return Err(Reason::ProtocolError(ByteString::from_static(
+                    "received an AUTH packet but enhanced authentication is not supported",
+                )));
             }
             _ => {
                 return Err(format!("Received an unimplemented message, {pkt:?}").into());


### PR DESCRIPTION
RMQTT does not support MQTT 5.0 enhanced authentication. Since no authentication method can ever have been negotiated in the CONNACK, receiving an AUTH packet is a Protocol Error per [MQTT-4.12.0].

- Remove unused Auth import
- Return ProtocolError with DISCONNECT 0x82 instead of sending default Auth