### PR TITLE
test: fix packet wire order, self-managed broker startup, and port-race robustness

### DIFF
--- a/rmqtt-test/README-CN.md
+++ b/rmqtt-test/README-CN.md
@@ -118,7 +118,7 @@ configs/
 
 ## 📋 测试套件
 
-### functional_v3（47 个用例）— MQTT 3.1
+### functional_v3（51 个用例）— MQTT 3.1
 
 针对 MQTT v3.1（IBM MQIsdp）的规范符合性套件，覆盖正向、反向与边界场景：
 
@@ -133,44 +133,55 @@ configs/
 | 会话 | `session_v3_persistent` / `clean` / `offline_queue` |
 | 通配符 | `wildcard_v3_plus` / `hash` / `overlap` / `dollar_topics` / `case_sensitive` / `leading_slash` |
 | 边界 | `boundary_v3_empty_payload` / `large_payload` / `long_topic` / `special_chars_topic` / `max_keepalive` / `rapid_subscribe` |
-| 协议错误 | `protocol_error_v3_subscribe_qos3` / `publish_packet_id_zero` / `bad_remaining_length` / `empty_topic_filter` / `reserved_packet_type` / `subscribe_qos0_fixed_header` |
+| 协议错误 | `protocol_error_v3_subscribe_qos3` / `publish_packet_id_zero` / `publish_empty_topic` / `bad_remaining_length` / `empty_topic_filter`（订阅/取消订阅）/ `reserved_packet_type` / `subscribe_qos0_fixed_header` |
 
 > v3.1 客户端通过 `build_connect_bytes` 手工构造 MQIsdp CONNECT 报文（codec 将协议级别硬编码为 4，对 3.1.1/5.0 正确）。
 
-### functional_v311（64 个用例）— MQTT 3.1.1
+### functional_v311（108 个用例）— MQTT 3.1.1
 
 | 类别 | 用例 |
 |------|------|
-| 连接 | `connect_v311` / `empty_client_id` / `multiple_connections` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` [MQTT-3.1.0-2] / `long_client_id` |
-| 发布/订阅 | `pubsub_v311_qos0/1/2` / `retain_v311_message` / `unsubscribe_v311` |
-| QoS 2 一致性 | `qos2_replayed_publish_dedup_v311` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume_v311` [MQTT-4.4.0-1] / `qos2_duplicate_detection` |
-| 保留消息 | `retain_v311_store_and_deliver` / `empty_payload_deletes` [MQTT-3.3.1-9] / `overwrite` / `live_message_not_retained` / `will` |
-| 遗嘱消息 | `last_will_v311` / `clean` / `unclean` / `qos2` / `keepalive_timeout` |
-| Keep Alive | `keepalive_v311_ping_keeps_alive` / `timeout` / `zero` / `max_value` |
-| 会话 | `clean_session_false` / `offline_queue_v311` / `present_on_resume` [MQTT-3.2.2.1] / `clean_discard` [MQTT-3.1.2-6] |
-| 通配符 | `wildcard_plus` / `hash` / `case_sensitive` / `leading_slash` / `hash_not_last` |
+| 连接 | `connect_v311` / `empty_client_id` / `multiple_connections` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` [MQTT-3.1.0-2] / `long_client_id` / `client_id_65535` / `assigned_client_id` / `invalid_utf8_client_id` / `invalid_utf8_username` / `invalid_utf8_will_topic` / `username_flag_mismatch` / `password_flag_mismatch` / `will_flag_zero_but_qos_set` / `will_qos3` / `will_not_fire_on_rejected_connect` |
+| 发布/订阅 | `pubsub_v311_qos0/1/2` / `publish_wildcard_reject` / `qos_downgrade_v311` / `ordering_qos2_v311` |
+| QoS 2 / 恢复 | `qos2_replayed_publish_dedup_v311` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume_v311` [MQTT-4.4.0-1] / `qos2_duplicate_detection` / `qos1_publish_resend_on_resume_v311` / `qos2_broker_to_client_no_pubrec_v311` |
+| 保留消息 | `retain_v311_store_and_deliver` / `empty_payload_deletes` [MQTT-3.3.1-9] / `overwrite` / `live_message_not_retained` / `live_publish_keeps_retained` / `will` / `restart_recovery` |
+| 遗嘱消息 | `last_will_v311` / `qos0` / `qos1` / `qos2` / `clean` / `unclean` / `invalid_utf8_payload` / `keepalive_timeout` |
+| Keep Alive | `keepalive_v311_ping_keeps_alive` / `timeout` / `zero` / `max_value` / `pingresp_explicit` / `window_boundary` |
+| 会话 | `clean_session_false` / `offline_queue_v311` / `present_on_resume` [MQTT-3.2.2.1] / `clean_discard` [MQTT-3.1.2-6] / `takeover` / `tcp_fin_rst` |
+| 通配符 | `wildcard_plus` / `hash` / `case_sensitive` / `leading_slash` / `hash_not_last` / `overlap` / `empty_levels` |
 | 认证 / $SYS / 共享订阅 | `auth_empty_client_id_fail` / `auth_connect_disconnect_sequence` / `dollar_topics` / `shared_sub_v311` |
-| 边界 | `max_client_id` / `long_topic` / `empty_payload` / `large_payload` / `special_chars_topic` / `rapid_subscribe` |
+| 边界 | `max_client_id` / `long_topic` / `empty_payload` / `large_payload` / `special_chars_topic` / `rapid_subscribe` / `remaining_length_max` |
 | 多主题 | `multi_topic_subscribe_v311` / `overlapping_subscriptions` / `message_ordering` |
-| 协议错误 | `invalid_protocol_version` / `empty_topic_filter` / `protocol_error_v311_*`（订阅 QoS3、固定头 QoS、发布 QoS3/pid0、剩余长度、保留类型） |
+| 协议错误 | `invalid_protocol_version` / `protocol_error_v311_*`（订阅/取消订阅：QoS3、QoS0 固定头、空 payload/filter、packet id 0；发布：QoS3、pid0、空主题、QoS0 携带 packet id；剩余长度非法、声明长度不匹配、报文截断、保留 packet type、packet type 15、PUBREL/PUBREC/PUBCOMP 错误 flags、未请求的 PUBREL、CONNECT payload 顺序、非法 UTF-8 主题）/ `remaining_length_transition_v311` |
+| CONNACK 返回码（自管 broker） | `connack_return_codes_auth_http_v311`（auth-http + 用例内 mock，端口 1892）/ `connack_not_authorized_v311`（auth-jwt，端口 1893）——这两个用例自行拉起 broker，不使用 harness broker |
 
-### functional_v5（63 个用例）— MQTT 5.0
+### functional_v5（99 个用例）— MQTT 5.0
 
 | 类别 | 用例 |
 |------|------|
-| 连接 / CONNACK | `connect_v5` / `reason_codes` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` / `client_id_too_long` / `auth_method_rejected` (0x8C) / `connack_capabilities_v5` / `connack_receive_max_echo_v5` / `connack_assigned_client_id_v5` / `empty_clientid_cleanstart0_rejected` |
-| 发布/订阅 | `pubsub_v5_qos0/1/2` |
-| 会话 | `session_expiry_v5` / `takeover_v5` / `clean_start_v5` / `disconnect_expiry_zero` [MQTT-3.14.2-2] / `expiry_cleanup` |
-| V5 特性 | `flow_control_v5` / `no_local_v5` / `will_delay_v5` / `shared_sub_v5` / `topic_alias_v5`（服务端/客户端/未知别名→0x94）/ `retain_handling_*_v5` / `retain_as_published_v5` / `server_keepalive_v5` / `max_packet_size_v5`（+ 强制）/ `subscribe_identifiers_v5` / `payload_format_v5` / `publication_expiry_v5` / `request_response_v5` / `user_properties_v5` / `wildcard_available_v5` |
+| 连接 / CONNACK | `connect_v5` / `reason_codes` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` / `client_id_too_long` / `auth_method_rejected` (0x8C) / `connack_capabilities_v5` / `connack_receive_max_echo_v5` / `connack_assigned_client_id_v5` / `assigned_clientid_v5` / `empty_clientid_cleanstart0_rejected` |
+| 连接反向（🐞 expected-fail） | `connect_v5_will_flag_zero_but_qos_set` / `connect_v5_will_flag_zero_but_retain_set` [MQTT-3.1.2-11/12] — 已登记 broker 缺陷 |
+| 发布/订阅 | `pubsub_v5_qos0/1/2` / `qos1_ordering` / `qos_downgrade_v5_matrix` / `publish_properties_passthrough_v5` |
+| 会话 | `session_expiry_v5` / `takeover_v5` / `clean_start_v5` / `disconnect_expiry_zero` [MQTT-3.14.2-2] / `expiry_cleanup` / `expiry_update_on_reconnect` |
+| V5 特性 | `flow_control_v5` / `flow_control_v5_inflight_cap_strict` / `no_local_v5` / `will_delay_v5` / `will_properties_v5_delivery` / `shared_sub_v5` / `shared_sub_v5_malformed_filter` / `topic_alias_v5`（服务端/客户端/未知别名→0x94、零→0x94、超上限→0x94）/ `retain_handling_*_v5` / `retain_as_published_v5` / `server_keepalive_v5` / `max_packet_size_v5`（+ 强制）/ `subscribe_identifiers_v5`（+ 更新）/ `subscribe_multi_filter_mixed_v5` / `payload_format_v5` / `publication_expiry_v5` / `message_expiry_v5_forwarded` / `message_expiry_v5_queued_drop` / `request_response_v5` / `request_problem_info_v5` / `user_properties_v5` / `wildcard_available_v5` |
+| 流控反向（🐞 expected-fail） | `flow_control_v5_receive_max_violation` [MQTT-4.9.0-1/2] — 已登记 broker 缺陷（无 DISCONNECT 0x93） |
 | 保留消息 | `retain_v5_store_and_deliver` / `empty_payload_deletes` / `overwrite` / `live_message_not_retained` / `will` |
 | QoS 2 | `qos2_replayed_publish_dedup` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume` [MQTT-4.4.0-1] / `qos2_pubrel_resume_collision` |
 | 通配符 | `wildcard_v5_case_sensitive` / `leading_slash` |
-| 协议错误 | `protocol_error_v5_*`（订阅 QoS3、固定头 QoS、发布 QoS3/pid0/空主题、剩余长度、保留类型） |
+| 原因码（MAY 级） | `reason_code_v5_puback_no_matching_subscribers` / `reason_code_v5_unsuback_no_subscription` —— 断言合法原因码（0x00 或 0x10 / 0x11） |
+| 响应/问题信息（info） | `connack_response_info_v5` / `publish_v5_response_topic_wildcard` —— 记录型观察，不计成败 |
+| 协议错误 | `protocol_error_v5_*`（订阅/取消订阅：QoS3、QoS0 固定头、空 payload、packet id 0、sub-id 0、保留位、retain handling 3、取消订阅携带 sub-id；发布：QoS3、pid0、空主题、QoS0 携带 DUP；剩余长度非法、保留类型、DISCONNECT 错误 flags、非法 UTF-8 主题、未请求的 AUTH、User Property 非法 UTF-8） |
 | 断开原因码 | `disconnect_reason_v5` |
-| Will Retain vs Retain Available | `will_retain_rejected_when_retain_unavailable_v5`（在 `functional_v5@retain-disabled` 子套件中真正执行） |
+| Keep Alive / TCP | `ping_v5` / `mqtt_keepalive_timeout_reclaims_tcp` / `tcp_keepalive_socket_option`（仅 Linux，其他平台跳过） |
+| Will Retain vs Retain Available | `v5_will_retain_rejected_when_retain_unavailable`（在 `functional_v5@retain-disabled` 子套件中真正执行） |
 
-> functional_v5 共 63 个用例：默认配置组运行其中 61 个；
-> `will_retain_rejected_when_retain_unavailable_v5` 与 `qos2_pubrel_resume_collision`
+> **expected-fail 用例（🐞）**：完整执行，但断言 broker 尚未实现的行为（已登记的
+> 合规缺口）。失败记为 `EXPECTED-FAIL`，不计入套件失败；broker 合规后会浮出为
+> `UNEXPECTED-PASS`，届时应转正为普通断言。详见
+> `designs/mqtt-5.0-standalone-test-gap-analysis.md`。
+
+> functional_v5 共 99 个用例：默认配置组运行其中 97 个；
+> `v5_will_retain_rejected_when_retain_unavailable` 与 `qos2_pubrel_resume_collision`
 > 因需要不同的 broker 配置，构建时自动拆分为 `functional_v5@retain-disabled` 与
 > `functional_v5@pubrel-collision` 两个子套件执行（见上方「Broker 配置」章节）。
 
@@ -194,15 +205,18 @@ configs/
 > 该测试修复前 3/3 轮复现 BUG（重复 PUBREL）；修复后 3/3 轮 PASS。修复方案详见
 > [`designs/pubrel-resume-inflight-id-collision.md`](../designs/pubrel-resume-inflight-id-collision.md)。
 
-### stress（3 个用例）
+### stress（6 个用例）
 
 | 用例 | 说明 |
 |------|------|
 | `connection_load` | N 客户端并发连接/断开（默认 100） |
 | `publish_load` | 持续发布 1000 条 QoS 1 消息，统计 QPS |
 | `fan_out` | 1 发布者 → N 订阅者扇出测试 |
+| `stress_mixed_qos_v311` | QoS 0/1/2 混合流量（v3.1.1 客户端） |
+| `stress_subscription_mass` | 大量订阅建立与投递验证 |
+| `stress_retain_flood` | 发布大量保留消息冲击 broker 内存 |
 
-### chaos（16 个用例）
+### chaos（18 个用例）
 
 | 用例 | 说明 |
 |------|------|
@@ -212,6 +226,7 @@ configs/
 | `chaos_reconnect_storm` | 50 客户端同时连接风暴 |
 | `chaos_qos1_reliability` | QoS 1 可靠性验证 |
 | `chaos_slow_consumer` | 慢消费者场景 |
+| `session_storage_expired_cleanup` / `_edge` | 会话存储启动加载优化：过期离线会话在加载时被跳过（并删除），存活会话不受影响（含边界变体） |
 | `chaos_broker_restart_session_routing` | issue #475 单机复现：持久会话从 sled 恢复后跨重启仍可路由（子套件 `chaos@session-sled`） |
 | `cluster_restart_session_routing_broadcast` / `_raft` | 同缺陷经集群复现（broadcast 双节点 / raft 三节点），仅重启 node1 |
 | `cluster_whole_restart_session_routing_broadcast` / `_raft` | 同缺陷经集群复现，全集群重启 |

--- a/rmqtt-test/README.md
+++ b/rmqtt-test/README.md
@@ -125,7 +125,7 @@ harness `--addr` (default `127.0.0.1:1883`), otherwise the health check fails.
 
 ## 📋 Test Suites
 
-### `functional_v3` (47 cases) — MQTT 3.1
+### `functional_v3` (51 cases) — MQTT 3.1
 
 Spec-conformance suite for MQTT v3.1 (IBM MQIsdp), covering positive, negative
 and boundary scenarios:
@@ -141,45 +141,58 @@ and boundary scenarios:
 | Session | `session_v3_persistent` / `clean` / `offline_queue` |
 | Wildcard | `wildcard_v3_plus` / `hash` / `overlap` / `dollar_topics` / `case_sensitive` / `leading_slash` |
 | Boundary | `boundary_v3_empty_payload` / `large_payload` / `long_topic` / `special_chars_topic` / `max_keepalive` / `rapid_subscribe` |
-| Protocol errors | `protocol_error_v3_subscribe_qos3` / `publish_packet_id_zero` / `bad_remaining_length` / `empty_topic_filter` / `reserved_packet_type` / `subscribe_qos0_fixed_header` |
+| Protocol errors | `protocol_error_v3_subscribe_qos3` / `publish_packet_id_zero` / `publish_empty_topic` / `bad_remaining_length` / `empty_topic_filter` (subscribe/unsubscribe) / `reserved_packet_type` / `subscribe_qos0_fixed_header` |
 
 > The v3.1 client hand-builds the MQIsdp CONNECT bytes (`build_connect_bytes`)
 > because the codec hard-codes protocol level 4 (correct for 3.1.1/5.0).
 
-### `functional_v311` (64 cases) — MQTT 3.1.1
+### `functional_v311` (108 cases) — MQTT 3.1.1
 
 | Category | Cases |
 |----------|-------|
-| Connect | `connect_v311` / `empty_client_id` / `multiple_connections` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` [MQTT-3.1.0-2] / `long_client_id` |
-| Pub/Sub | `pubsub_v311_qos0/1/2` / `retain_v311_message` / `unsubscribe_v311` |
-| QoS 2 conformance | `qos2_replayed_publish_dedup_v311` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume_v311` [MQTT-4.4.0-1] / `qos2_duplicate_detection` |
-| Retained | `retain_v311_store_and_deliver` / `empty_payload_deletes` [MQTT-3.3.1-9] / `overwrite` / `live_message_not_retained` / `will` |
-| Last Will | `last_will_v311` / `clean` / `unclean` / `qos2` / `keepalive_timeout` |
-| Keep alive | `keepalive_v311_ping_keeps_alive` / `timeout` / `zero` / `max_value` |
-| Session | `clean_session_false` / `offline_queue_v311` / `present_on_resume` [MQTT-3.2.2.1] / `clean_discard` [MQTT-3.1.2-6] |
-| Wildcard | `wildcard_plus` / `hash` / `case_sensitive` / `leading_slash` / `hash_not_last` |
+| Connect | `connect_v311` / `empty_client_id` / `multiple_connections` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` [MQTT-3.1.0-2] / `long_client_id` / `client_id_65535` / `assigned_client_id` / `invalid_utf8_client_id` / `invalid_utf8_username` / `invalid_utf8_will_topic` / `username_flag_mismatch` / `password_flag_mismatch` / `will_flag_zero_but_qos_set` / `will_qos3` / `will_not_fire_on_rejected_connect` |
+| Pub/Sub | `pubsub_v311_qos0/1/2` / `publish_wildcard_reject` / `qos_downgrade_v311` / `ordering_qos2_v311` |
+| QoS 2 / resume | `qos2_replayed_publish_dedup_v311` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume_v311` [MQTT-4.4.0-1] / `qos2_duplicate_detection` / `qos1_publish_resend_on_resume_v311` / `qos2_broker_to_client_no_pubrec_v311` |
+| Retained | `retain_v311_store_and_deliver` / `empty_payload_deletes` [MQTT-3.3.1-9] / `overwrite` / `live_message_not_retained` / `live_publish_keeps_retained` / `will` / `restart_recovery` |
+| Last Will | `last_will_v311` / `qos0` / `qos1` / `qos2` / `clean` / `unclean` / `invalid_utf8_payload` / `keepalive_timeout` |
+| Keep alive | `keepalive_v311_ping_keeps_alive` / `timeout` / `zero` / `max_value` / `pingresp_explicit` / `window_boundary` |
+| Session | `clean_session_false` / `offline_queue_v311` / `present_on_resume` [MQTT-3.2.2.1] / `clean_discard` [MQTT-3.1.2-6] / `takeover` / `tcp_fin_rst` |
+| Wildcard | `wildcard_plus` / `hash` / `case_sensitive` / `leading_slash` / `hash_not_last` / `overlap` / `empty_levels` |
 | Auth / dollar / shared | `auth_empty_client_id_fail` / `auth_connect_disconnect_sequence` / `dollar_topics` / `shared_sub_v311` |
-| Boundary | `max_client_id` / `long_topic` / `empty_payload` / `large_payload` / `special_chars_topic` / `rapid_subscribe` |
+| Boundary | `max_client_id` / `long_topic` / `empty_payload` / `large_payload` / `special_chars_topic` / `rapid_subscribe` / `remaining_length_max` |
 | Multi-topic | `multi_topic_subscribe_v311` / `overlapping_subscriptions` / `message_ordering` |
-| Protocol errors | `invalid_protocol_version` / `empty_topic_filter` / `protocol_error_v311_*` (subscribe qos3, fixed-header QoS, publish qos3/pid0, bad remaining length, reserved type) |
+| Protocol errors | `invalid_protocol_version` / `protocol_error_v311_*` (subscribe/unsubscribe: qos3, qos0 fixed header, empty payload/filter, packet id 0; publish: qos3, pid0, empty topic, packet id on QoS0; bad remaining length, declared length mismatch, truncated packet, reserved packet type, packet type 15, pubrel/pubrec/pubcomp wrong flags, unsolicited pubrel, connect payload order, invalid UTF-8 topic) / `remaining_length_transition_v311` |
+| CONNACK return codes (self-managed brokers) | `connack_return_codes_auth_http_v311` (auth-http + in-test mock, port 1892) / `connack_not_authorized_v311` (auth-jwt, port 1893) — these cases spawn their own brokers and don't use the harness broker |
 
-### `functional_v5` (63 cases) — MQTT 5.0
+### `functional_v5` (99 cases) — MQTT 5.0
 
 | Category | Cases |
 |----------|-------|
-| Connect / CONNACK | `connect_v5` / `reason_codes` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` / `client_id_too_long` / `auth_method_rejected` (0x8C) / `connack_capabilities_v5` / `connack_receive_max_echo_v5` / `connack_assigned_client_id_v5` / `empty_clientid_cleanstart0_rejected` |
-| Pub/Sub | `pubsub_v5_qos0/1/2` |
-| Session | `session_expiry_v5` / `takeover_v5` / `clean_start_v5` / `disconnect_expiry_zero` [MQTT-3.14.2-2] / `expiry_cleanup` |
-| V5 features | `flow_control_v5` / `no_local_v5` / `will_delay_v5` / `shared_sub_v5` / `topic_alias_v5` (server/client/unknown-alias → 0x94) / `retain_handling_*_v5` / `retain_as_published_v5` / `server_keepalive_v5` / `max_packet_size_v5` (+ enforcement) / `subscribe_identifiers_v5` / `payload_format_v5` / `publication_expiry_v5` / `request_response_v5` / `user_properties_v5` / `wildcard_available_v5` |
+| Connect / CONNACK | `connect_v5` / `reason_codes` / `session_present_fresh` / `wrong_protocol_name` / `unsupported_level` / `reserved_flag` / `second_connect` / `client_id_too_long` / `auth_method_rejected` (0x8C) / `connack_capabilities_v5` / `connack_receive_max_echo_v5` / `connack_assigned_client_id_v5` / `assigned_clientid_v5` / `empty_clientid_cleanstart0_rejected` |
+| Connect negative (🐞 expected-fail) | `connect_v5_will_flag_zero_but_qos_set` / `connect_v5_will_flag_zero_but_retain_set` [MQTT-3.1.2-11/12] — registered broker defects |
+| Pub/Sub | `pubsub_v5_qos0/1/2` / `qos1_ordering` / `qos_downgrade_v5_matrix` / `publish_properties_passthrough_v5` |
+| Session | `session_expiry_v5` / `takeover_v5` / `clean_start_v5` / `disconnect_expiry_zero` [MQTT-3.14.2-2] / `expiry_cleanup` / `expiry_update_on_reconnect` |
+| V5 features | `flow_control_v5` / `flow_control_v5_inflight_cap_strict` / `no_local_v5` / `will_delay_v5` / `will_properties_v5_delivery` / `shared_sub_v5` / `shared_sub_v5_malformed_filter` / `topic_alias_v5` (server/client/unknown-alias → 0x94, zero → 0x94, over-max → 0x94) / `retain_handling_*_v5` / `retain_as_published_v5` / `server_keepalive_v5` / `max_packet_size_v5` (+ enforcement) / `subscribe_identifiers_v5` (+ update) / `subscribe_multi_filter_mixed_v5` / `payload_format_v5` / `publication_expiry_v5` / `message_expiry_v5_forwarded` / `message_expiry_v5_queued_drop` / `request_response_v5` / `request_problem_info_v5` / `user_properties_v5` / `wildcard_available_v5` |
+| Flow-control negative (🐞 expected-fail) | `flow_control_v5_receive_max_violation` [MQTT-4.9.0-1/2] — registered broker defect (no DISCONNECT 0x93) |
 | Retained | `retain_v5_store_and_deliver` / `empty_payload_deletes` / `overwrite` / `live_message_not_retained` / `will` |
 | QoS 2 | `qos2_replayed_publish_dedup` [MQTT-4.3.3-10] / `qos2_pubrel_resend_on_resume` [MQTT-4.4.0-1] / `qos2_pubrel_resume_collision` |
 | Wildcard | `wildcard_v5_case_sensitive` / `leading_slash` |
-| Protocol errors | `protocol_error_v5_*` (subscribe qos3, fixed-header QoS, publish qos3/pid0/empty-topic, bad remaining length, reserved type) |
+| Reason codes (MAY-level) | `reason_code_v5_puback_no_matching_subscribers` / `reason_code_v5_unsuback_no_subscription` — assert a legal reason code (0x00 or 0x10 / 0x11) |
+| Response/Problem Information (info) | `connack_response_info_v5` / `publish_v5_response_topic_wildcard` — record-type observations, never failures |
+| Protocol errors | `protocol_error_v5_*` (subscribe/unsubscribe: qos3, qos0 fixed header, empty payload, packet id 0, sub-id 0, reserved bits, retain handling 3, with sub-id on unsubscribe; publish: qos3, pid0, empty topic, dup on QoS 0; bad remaining length, reserved type, disconnect bad flags, invalid UTF-8 topic, unsolicited AUTH, user property bad UTF-8) |
 | Disconnect | `disconnect_reason_v5` |
-| Will Retain vs Retain Available | `will_retain_rejected_when_retain_unavailable_v5` (executed in the `functional_v5@retain-disabled` sub-suite) |
+| Keep alive / TCP | `ping_v5` / `mqtt_keepalive_timeout_reclaims_tcp` / `tcp_keepalive_socket_option` (Linux-gated, skipped elsewhere) |
+| Will Retain vs Retain Available | `v5_will_retain_rejected_when_retain_unavailable` (executed in the `functional_v5@retain-disabled` sub-suite) |
 
-> `functional_v5` totals 63 cases: the default-config group runs 61 of them;
-> `will_retain_rejected_when_retain_unavailable_v5` and
+> **Expected-fail cases (🐞)**: they execute fully but assert behaviors the
+> broker does not implement yet (registered conformance gaps). A failure is
+> recorded as `EXPECTED-FAIL` and does not count against the suite; when the
+> broker becomes compliant the case surfaces as `UNEXPECTED-PASS` and should
+> be promoted to a normal assertion. See
+> `designs/mqtt-5.0-standalone-test-gap-analysis.md`.
+
+> `functional_v5` totals 99 cases: the default-config group runs 97 of them;
+> `v5_will_retain_rejected_when_retain_unavailable` and
 > `qos2_pubrel_resume_collision` require different broker configs and are
 > automatically split into the `functional_v5@retain-disabled` and
 > `functional_v5@pubrel-collision` sub-suites at build time (see the
@@ -206,15 +219,18 @@ This suite **requires two manually started nodes** and is never included in the 
 > after the fix it PASSES in 3/3 rounds. Fix design: see
 > [`designs/pubrel-resume-inflight-id-collision.md`](../designs/pubrel-resume-inflight-id-collision.md).
 
-### `stress` (3 cases)
+### `stress` (6 cases)
 
 | Case | Description |
 |------|-------------|
 | `connection_load` | N concurrent client connect/disconnect (default 100) |
 | `publish_load` | Continuous publish 1000 QoS 1 messages, QPS statistics |
 | `fan_out` | 1 publisher → N subscribers fan-out test |
+| `stress_mixed_qos_v311` | Mixed QoS 0/1/2 traffic (v3.1.1 client) |
+| `stress_subscription_mass` | Mass subscription setup and delivery verification |
+| `stress_retain_flood` | Publish many retained messages to flood broker memory |
 
-### `chaos` (16 cases)
+### `chaos` (18 cases)
 
 | Case | Description |
 |------|-------------|
@@ -224,6 +240,7 @@ This suite **requires two manually started nodes** and is never included in the 
 | `chaos_reconnect_storm` | 50 concurrent connection storms |
 | `chaos_qos1_reliability` | QoS 1 reliability verification |
 | `chaos_slow_consumer` | Slow consumer scenario |
+| `session_storage_expired_cleanup` / `_edge` | Session-storage startup-load optimization: expired offline sessions are skipped (and removed) during load, live sessions survive (edge variant included) |
 | `chaos_broker_restart_session_routing` | Issue #475 single-node reproduction: a persistent session restored from sled must stay routable across a broker restart (sub-suite `chaos@session-sled`) |
 | `cluster_restart_session_routing_broadcast` / `_raft` | Same defect through a cluster (broadcast 2 nodes / raft 3 nodes), node 1 restarted only |
 | `cluster_whole_restart_session_routing_broadcast` / `_raft` | Same defect through a cluster, whole-cluster restart |

--- a/rmqtt-test/src/broker/healthcheck.rs
+++ b/rmqtt-test/src/broker/healthcheck.rs
@@ -13,3 +13,28 @@ pub fn health_check_sync(addr: &str, timeout: Duration) -> bool {
     TcpStream::connect_timeout(&addr.parse().unwrap_or_else(|_| "127.0.0.1:1883".parse().unwrap()), timeout)
         .is_ok()
 }
+
+/// Check whether a TCP address is free to bind (bind probe, not connect probe).
+///
+/// Briefly binds a listener and drops it. If any socket already listens on
+/// the same address (including 0.0.0.0 wildcards), the bind fails. Used as a
+/// pre-flight check so the harness can fail fast with a clear message instead
+/// of waiting a full start timeout for a broker that can never bind.
+pub fn port_free_sync(addr: &str) -> bool {
+    std::net::TcpListener::bind(addr).is_ok()
+}
+
+/// Wait until the TCP address stops accepting connections, i.e. the previous
+/// owner has released it (connection refused). Returns `false` on timeout.
+pub fn wait_port_free_sync(addr: &str, timeout: Duration) -> bool {
+    let peer = addr.parse().unwrap_or_else(|_| "127.0.0.1:1883".parse().unwrap());
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        // Connection refused -> nothing is listening on the port anymore.
+        if TcpStream::connect_timeout(&peer, Duration::from_millis(200)).is_err() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}

--- a/rmqtt-test/src/broker/lifecycle.rs
+++ b/rmqtt-test/src/broker/lifecycle.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use tracing::{info, warn};
 
-use super::healthcheck::health_check_sync;
+use super::healthcheck::{health_check_sync, port_free_sync, wait_port_free_sync};
 
 /// Default broker TCP address
 const DEFAULT_BROKER_ADDR: &str = "127.0.0.1:1883";
@@ -83,6 +83,18 @@ impl BrokerProcess {
 
         info!("Starting broker: {:?}", self.binary_path);
 
+        // Pre-flight check: fail fast when the port is already occupied by a
+        // residual broker or any other process, instead of waiting the full
+        // health-check timeout for a broker that can never bind.
+        if !port_free_sync(&self.addr) {
+            return Err(anyhow::anyhow!(
+                "port {} is already in use by another process; a residual broker may \
+                 still be running (check: netstat -ano | findstr {})",
+                self.addr,
+                self.addr.rsplit(':').next().unwrap_or("?")
+            ));
+        }
+
         let mut cmd = std::process::Command::new(&self.binary_path);
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::piped());
 
@@ -132,6 +144,13 @@ impl BrokerProcess {
             info!("Stopping broker (PID: {:?})", child.id());
             let _ = child.kill();
             let _ = child.wait();
+            // The process is reaped, but on some platforms the listening
+            // socket can linger briefly; wait until the port is actually
+            // released before returning (a follow-up restart would otherwise
+            // race into WSAEADDRINUSE / EADDRINUSE).
+            if !wait_port_free_sync(&self.addr, Duration::from_secs(5)) {
+                warn!("port {} still in use 5s after broker stop", self.addr);
+            }
             info!("Broker stopped");
         }
         Ok(())
@@ -140,8 +159,6 @@ impl BrokerProcess {
     /// Restart the broker
     pub fn restart(&mut self) -> Result<(), anyhow::Error> {
         self.stop()?;
-        // Small delay to let ports free up
-        std::thread::sleep(Duration::from_millis(500));
         self.start()
     }
 
@@ -159,8 +176,6 @@ impl BrokerProcess {
     pub fn restart_with_config(&mut self, config: Option<PathBuf>) -> Result<(), anyhow::Error> {
         self.stop()?;
         self.config_path = config;
-        // Small delay to let ports free up
-        std::thread::sleep(Duration::from_millis(500));
         self.start()
     }
 
@@ -170,6 +185,11 @@ impl BrokerProcess {
             info!("Killing broker (PID: {:?})", child.id());
             let _ = child.kill();
             let _ = child.wait();
+            // Same rationale as `stop`: wait for the port to be released so a
+            // subsequent start (e.g. chaos restart) cannot race the teardown.
+            if !wait_port_free_sync(&self.addr, Duration::from_secs(5)) {
+                warn!("port {} still in use 5s after broker kill", self.addr);
+            }
         }
         Ok(())
     }

--- a/rmqtt-test/src/tests/functional/cluster_session_restart.rs
+++ b/rmqtt-test/src/tests/functional/cluster_session_restart.rs
@@ -134,15 +134,48 @@ impl ClusterNode {
     }
 
     /// Block until the MQTT port accepts TCP connections.
-    pub(crate) fn wait_healthy(&self, timeout: Duration) -> bool {
+    ///
+    /// Fails FAST when the broker process exits before the port opens:
+    /// waiting the full timeout against a dead process only masks the real
+    /// cause (config/plugin errors), so the log tail is dumped immediately
+    /// instead. The same diagnostics are dumped when the timeout expires.
+    pub(crate) fn wait_healthy(&mut self, timeout: Duration) -> bool {
         let start = Instant::now();
         while start.elapsed() < timeout {
+            // Detect an early broker exit before probing the port.
+            if let Some(child) = self.child.as_mut() {
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        eprintln!(
+                            "[cluster-node] broker on {} exited early (status: {status}); log tail:\n{}",
+                            self.addr,
+                            self.log_tail(30).unwrap_or_else(|| "<log file unreadable>".into())
+                        );
+                        return false;
+                    }
+                    Ok(None) => {} // still running
+                    Err(e) => eprintln!("[cluster-node] try_wait failed: {e}"),
+                }
+            }
             if health_check_sync(&self.addr, Duration::from_secs(2)) {
                 return true;
             }
             std::thread::sleep(Duration::from_millis(200));
         }
+        eprintln!(
+            "[cluster-node] broker on {} not healthy after {timeout:?}; log tail:\n{}",
+            self.addr,
+            self.log_tail(30).unwrap_or_else(|| "<log file unreadable>".into())
+        );
         false
+    }
+
+    /// Read the last `lines` lines of the node's log file (for diagnostics).
+    pub(crate) fn log_tail(&self, lines: usize) -> Option<String> {
+        let content = std::fs::read_to_string(&self.log_file).ok()?;
+        let collected: Vec<&str> = content.lines().collect();
+        let start = collected.len().saturating_sub(lines);
+        Some(collected[start..].join("\n"))
     }
 
     pub(crate) fn kill(&mut self) {

--- a/rmqtt-test/src/tests/functional/connack_return_codes_v311.rs
+++ b/rmqtt-test/src/tests/functional/connack_return_codes_v311.rs
@@ -18,6 +18,7 @@ use std::net::TcpStream;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
+use crate::broker::healthcheck::port_free_sync;
 use crate::framework::context::TestContext;
 use crate::framework::testcase::{TestCase, TestResult};
 use crate::tests::functional::cluster_session_restart::{rmqttd_binary, ClusterNode};
@@ -28,14 +29,15 @@ const AUTH_HTTP_ADDR: &str = "127.0.0.1:1892";
 const AUTH_JWT_ADDR: &str = "127.0.0.1:1893";
 const AUTH_NODE_START_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Spawn a self-managed broker for a named auth config (`auth-denied` /
-/// `auth-jwt-denied`). Returns the node handle; dropping it kills the
-/// broker. The default harness broker stays untouched on 1883.
-fn spawn_auth_broker(config_name: &str, addr: &str) -> Result<(ClusterNode, PathBuf), anyhow::Error> {
-    spawn_auth_broker_with_config(crate::tests::config_path(config_name), config_name, addr)
-}
-
-/// Spawn a self-managed broker from an explicit config directory.
+/// Spawn a self-managed broker from an explicit config FILE (the `rmqtt.toml`
+/// inside the prepared config directory).
+///
+/// NOTE: `-f` must point at the FILE, not the directory. rmqtt-conf loads the
+/// `-f` path with `File::with_name(..).required(false)`, so a directory (or
+/// any unreadable path) is SILENTLY skipped and the broker falls back to
+/// built-in defaults — http-api on 6060, gRPC on 5363, MQTT on 1883 — which
+/// then collides with the harness broker (WSAEADDRINUSE 10048) and the
+/// intended auth config never takes effect.
 fn spawn_auth_broker_with_config(
     config: PathBuf,
     label: &str,
@@ -48,12 +50,31 @@ fn spawn_auth_broker_with_config(
             binary
         ));
     }
+    if !config.is_file() {
+        return Err(anyhow::anyhow!(
+            "{label}: config path {:?} is not a file; `-f` must point at rmqtt.toml \
+             (a directory is silently ignored by the broker and defaults get used)",
+            config
+        ));
+    }
+    // Pre-flight check: fail fast when the MQTT port is already occupied by a
+    // residual broker / unrelated process, instead of burning the full start
+    // timeout on a broker that can never bind.
+    if !port_free_sync(addr) {
+        return Err(anyhow::anyhow!(
+            "{label}: MQTT address {addr} is already in use by another process; \
+             a residual broker may still be running"
+        ));
+    }
     let log_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join("target");
     let log_file = log_dir.join(format!("{label}-node.log"));
     let mut node = ClusterNode::new(config, addr, log_file);
     node.spawn(&binary)?;
     if !node.wait_healthy(AUTH_NODE_START_TIMEOUT) {
-        return Err(anyhow::anyhow!("{label} broker did not become healthy"));
+        return Err(anyhow::anyhow!(
+            "{label} broker did not become healthy; log tail:\n{}",
+            node.log_tail(30).unwrap_or_else(|| "<log file unreadable>".into())
+        ));
     }
     Ok((node, binary))
 }
@@ -92,17 +113,39 @@ fn prepare_auth_config(mock_port: u16) -> anyhow::Result<PathBuf> {
     let content = std::fs::read_to_string(&plugin_cfg)?;
     let updated = content.replace("9099", &mock_port.to_string());
     std::fs::write(&plugin_cfg, updated)?;
-    // The main config's plugins.dir still points at the ORIGINAL config
-    // directory — rewrite it to the copy, otherwise the broker would load
-    // the untouched 9099 plugin config from the source tree.
+    // The main config's plugins.dir is a RELATIVE path (resolved against the
+    // broker process CWD). Rewrite it to the ABSOLUTE copy path so the broker
+    // always loads the rewritten plugin config regardless of where the
+    // harness was launched from.
     let main_cfg = dst.join("rmqtt.toml");
     let content = std::fs::read_to_string(&main_cfg)?;
-    let updated = content.replace(
-        "rmqtt-test/configs/auth-denied/plugins/",
-        &format!("target/auth-denied-{mock_port}/plugins/"),
-    );
+    let abs_plugins_dir = std::fs::canonicalize(dst.join("plugins"))?.to_string_lossy().replace('\\', "/"); // TOML-friendly separators on Windows too
+    let updated = content.replace("rmqtt-test/configs/auth-denied/plugins/", &format!("{abs_plugins_dir}/"));
     std::fs::write(&main_cfg, updated)?;
-    Ok(dst)
+    // Return the FILE, not the directory: `-f <dir>` is silently ignored by
+    // rmqtt-conf (required(false)) and the broker would run on defaults.
+    Ok(main_cfg)
+}
+
+/// Copy `configs/auth-jwt-denied/` into `target/auth-jwt-denied-<uid>/` with
+/// its `plugins.dir` rewritten to an absolute path (removes the broker-CWD
+/// dependence; no mock port to rewrite here).
+fn prepare_jwt_config() -> anyhow::Result<PathBuf> {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("configs").join("auth-jwt-denied");
+    let uid = uuid::Uuid::new_v4().simple();
+    let dst = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("target")
+        .join(format!("auth-jwt-denied-{uid}"));
+    copy_dir_recursive(&src, &dst)?;
+    let main_cfg = dst.join("rmqtt.toml");
+    let content = std::fs::read_to_string(&main_cfg)?;
+    let abs_plugins_dir = std::fs::canonicalize(dst.join("plugins"))?.to_string_lossy().replace('\\', "/");
+    let updated =
+        content.replace("rmqtt-test/configs/auth-jwt-denied/plugins/", &format!("{abs_plugins_dir}/"));
+    std::fs::write(&main_cfg, updated)?;
+    // Return the FILE, not the directory (same reason as prepare_auth_config).
+    Ok(main_cfg)
 }
 
 /// Build a raw v3.1.1 CONNECT with optional username / password.
@@ -245,11 +288,18 @@ async fn spawn_mock_auth_server() -> anyhow::Result<(tokio::task::JoinHandle<()>
                             Err(_) => break,
                         }
                     }
-                    let full = String::from_utf8_lossy(&buf).into_owned();
                     let first_line = head.lines().next().unwrap_or("").to_string();
+                    // Parse form fields from the request BODY only. The
+                    // plugin serializes its params HashMap, so the field
+                    // order varies per broker process; when `username`
+                    // happens to be the first field it would otherwise be
+                    // glued to the HTTP head ("...\r\n\r\nusername") and
+                    // never match, turning the accepted user into a
+                    // spurious deny -> CONNACK 0x04.
+                    let body_only = String::from_utf8_lossy(&buf[head_end..]).into_owned();
                     // deny only auth requests whose username != "good"; ACL
                     // requests and accepted users are allowed
-                    let uname = form_param(&full, "username");
+                    let uname = form_param(&body_only, "username");
                     let response =
                         if !first_line.contains("/mqtt/acl") && uname != "good" { "deny" } else { "allow" };
                     // Diagnostic: surface what the mock actually saw, so a
@@ -366,7 +416,9 @@ impl TestCase for ConnackReturnCodesAuthHttpV311Test {
     }
 
     fn timeout(&self) -> Duration {
-        Duration::from_secs(20)
+        // Must exceed AUTH_NODE_START_TIMEOUT (20s) + mock probe + cleanup,
+        // otherwise the harness masks the real failure as "(timeout)".
+        Duration::from_secs(45)
     }
 }
 
@@ -388,7 +440,8 @@ impl TestCase for ConnackNotAuthorizedV311Test {
         let start = Instant::now();
 
         let verdict = (|| -> anyhow::Result<Option<u8>> {
-            let (_node, _binary) = spawn_auth_broker("auth-jwt-denied", AUTH_JWT_ADDR)?;
+            let config = prepare_jwt_config()?;
+            let (_node, _binary) = spawn_auth_broker_with_config(config, "auth-jwt-denied", AUTH_JWT_ADDR)?;
             // flags = clean (0x02) | user name (0x80) | password (0x40)
             let pkt = build_connect(0xC2, "rc-jwt", Some("anyone"), Some("not-a-valid-jwt"));
             connect_return_code(AUTH_JWT_ADDR, &pkt)
@@ -413,6 +466,8 @@ impl TestCase for ConnackNotAuthorizedV311Test {
     }
 
     fn timeout(&self) -> Duration {
-        Duration::from_secs(15)
+        // Must exceed AUTH_NODE_START_TIMEOUT (20s) + cleanup, otherwise the
+        // harness masks the real failure as "(timeout)".
+        Duration::from_secs(45)
     }
 }

--- a/rmqtt-test/src/tests/functional/flow_control_v5.rs
+++ b/rmqtt-test/src/tests/functional/flow_control_v5.rs
@@ -276,6 +276,11 @@ fn connack_receive_max(connack: &[u8]) -> Option<u16> {
 /// Negative: a client that exceeds the broker's advertised Receive Maximum
 /// (more in-flight QoS 1 PUBLISHes than the broker allows without waiting for
 /// PUBACK) must be disconnected with reason 0x93. [MQTT-4.9.0-1 / MQTT-4.9.0-2]
+///
+/// Known broker defect (registered, see conformance-gap log): the broker
+/// accepts unbounded in-flight QoS 1 PUBLISHes without sending DISCONNECT
+/// 0x93 or closing the connection. Expected-fail until enforced; a pass
+/// surfaces as UNEXPECTED-PASS and should then be promoted.
 pub struct FlowControlV5ReceiveMaxViolationTest;
 
 impl TestCase for FlowControlV5ReceiveMaxViolationTest {
@@ -299,8 +304,12 @@ impl TestCase for FlowControlV5ReceiveMaxViolationTest {
                 let mut body: Vec<u8> = Vec::new();
                 body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
                 body.extend_from_slice(topic);
-                body.push(0x00); // property length 0
+                // Wire order for QoS > 0: topic, THEN packet id, THEN
+                // properties. (A property byte before the packet id makes the
+                // packet malformed -> Malformed Packet close, which would let
+                // this test pass vacuously without exercising Receive Maximum.)
                 body.extend_from_slice(&pid.to_be_bytes()); // packet id
+                body.push(0x00); // property length 0
                 body.extend_from_slice(b"v"); // payload
 
                 let mut pkt = vec![0x32]; // PUBLISH QoS 1
@@ -370,6 +379,10 @@ impl TestCase for FlowControlV5ReceiveMaxViolationTest {
 
     fn timeout(&self) -> Duration {
         Duration::from_secs(20)
+    }
+
+    fn expectation(&self) -> crate::framework::testcase::Expectation {
+        crate::framework::testcase::Expectation::ExpectedFail
     }
 }
 

--- a/rmqtt-test/src/tests/functional/protocol_error_v5.rs
+++ b/rmqtt-test/src/tests/functional/protocol_error_v5.rs
@@ -395,8 +395,10 @@ impl TestCase for ProtocolErrorV5PublishPacketIdZeroTest {
             let mut body: Vec<u8> = Vec::new();
             body.extend_from_slice(&(topic.len() as u16).to_be_bytes());
             body.extend_from_slice(topic);
-            body.push(0x00); // property length
+            // Wire order for QoS > 0: topic, THEN packet id, THEN properties,
+            // so the rejection really is the zero packet id [MQTT-2.2.1-2].
             body.extend_from_slice(&[0x00, 0x00]); // packet id 0 — illegal
+            body.push(0x00); // property length
             body.extend_from_slice(b"payload");
 
             let mut pkt = vec![0x32]; // PUBLISH QoS 1

--- a/rmqtt-test/src/tests/functional/request_problem_info_v5.rs
+++ b/rmqtt-test/src/tests/functional/request_problem_info_v5.rs
@@ -272,10 +272,15 @@ impl TestCase for RequestProblemInfoV5Test {
             }
 
             // 2) PUBLISH QoS 1 with no matching subscriber -> PUBACK (0x40)
+            // Wire order per MQTT 5.0 §3.3.2.1: Topic Name FIRST, then
+            // Packet Identifier (QoS > 0), then Properties, then Payload.
+            // (The previous version had these two swapped, which made the
+            // broker read the packet id as a topic length -> Malformed
+            // Packet -> the connection was closed without a PUBACK.)
             let mut pub_body: Vec<u8> = Vec::new();
-            pub_body.extend_from_slice(&[0x00, 0x02]); // packet id 2
             pub_body.extend_from_slice(&[0x00, 0x08]); // topic length
             pub_body.extend_from_slice(b"nosubs/t"); // 8 bytes, no subscriber
+            pub_body.extend_from_slice(&[0x00, 0x02]); // packet id 2
             pub_body.push(0x00); // property length 0
             pub_body.extend_from_slice(b"x"); // payload
             let mut pub_pkt = vec![0x32]; // PUBLISH QoS 1


### PR DESCRIPTION
Harness/broker lifecycle hardening:
- Add port_free_sync() pre-flight check so BrokerProcess::start fails fast with a clear message when the MQTT port is already occupied, instead of burning the full health-check timeout on a broker that can never bind.
- Replace the fixed 500ms restart sleep with wait_port_free_sync(): after stop/kill, block (up to 5s) until the port is actually released, closing the WSAEADDRINUSE / EADDRINUSE restart race.
- ClusterNode::wait_healthy now detects early broker exit via try_wait() and dumps the log tail immediately, both on early exit and on timeout, so config/plugin failures surface with diagnostics instead of masking.

Self-managed auth broker tests (connack_return_codes_v311):
- Fix `-f` invocation: it must point at the rmqtt.toml FILE, not the directory. rmqtt-conf loads `-f` with required(false), so a directory was silently ignored and the broker fell back to built-in defaults (1883/6060/5363), colliding with the harness broker. Add an is_file() guard and return the file path from prepare_*_config().
- Rewrite plugins.dir to an ABSOLUTE path: the relative path resolved against the broker CWD, so the rewritten plugin config was only picked up depending on where the harness was launched from.
- Mock auth server: parse form fields from the request BODY only; the params HashMap order varies per process, so a leading "username" field glued to the HTTP head and was never matched, spuriously denying the accepted user (CONNACK 0x04).
- Raise case timeouts to 45s so they exceed AUTH_NODE_START_TIMEOUT (20s) and surface real failures instead of "(timeout)".
- auth-jwt case now uses prepare_jwt_config() with absolute plugins.dir.

Test packet correctness (PUBLISH QoS > 0 wire order is topic, packet id, then properties — the previous order was malformed and let cases pass or fail vacuously):
- flow_control_v5: fix Receive Maximum violation packet; mark the case ExpectedFail (broker does not yet enforce DISCONNECT 0x93).
- protocol_error_v5: fix packet-id-zero packet so rejection is really the zero packet id [MQTT-2.2.1-2].
- request_problem_info_v5: fix no-subscriber PUBLISH so the broker returns PUBACK instead of closing with Malformed Packet.

Docs:
- Update README.md / README-CN.md: refresh suite case counts (functional_v3 51 / v311 108 / v5 99, stress 6, chaos 18), document expected-fail semantics and newly added cases.