### PR TITLE
docker: downgrade alpine base image to 3.18.12

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.24.1
+FROM arm64v8/alpine:3.18.12
 LABEL maintainer="rmqtt <rmqttd@126.com>"
 
 RUN mkdir -p /app/rmqtt/rmqtt-bin

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM alpine:3.24.1
+FROM alpine:3.18.12
 LABEL maintainer="rmqtt <rmqttd@126.com>"
 
 RUN mkdir -p /app/rmqtt/rmqtt-bin


### PR DESCRIPTION
Revert alpine from 3.24.1 to 3.18.12 for both amd64 and aarch64 architectures to ensure compatibility with existing dependencies or resolve runtime issues.