### PR TITLE
fix(plugin/session-storage): bound in-flight offline-message persistence

### DIFF
--- a/rmqtt-plugins/rmqtt-session-storage/src/lib.rs
+++ b/rmqtt-plugins/rmqtt-session-storage/src/lib.rs
@@ -17,6 +17,7 @@
 
 use anyhow::anyhow;
 use std::convert::From as _;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -414,13 +415,21 @@ impl Plugin for StoragePlugin {
         self.register
             .add(
                 Type::OfflineMessage,
-                Box::new(OfflineMessageHandler::new(self.cfg.clone(), self.storage_db.clone())),
+                Box::new(OfflineMessageHandler::new(
+                    self.scx.clone(),
+                    self.cfg.clone(),
+                    self.storage_db.clone(),
+                )),
             )
             .await;
         self.register
             .add(
                 Type::OfflineInflightMessages,
-                Box::new(OfflineMessageHandler::new(self.cfg.clone(), self.storage_db.clone())),
+                Box::new(OfflineMessageHandler::new(
+                    self.scx.clone(),
+                    self.cfg.clone(),
+                    self.storage_db.clone(),
+                )),
             )
             .await;
 
@@ -548,14 +557,55 @@ impl Plugin for StoragePlugin {
     }
 }
 
+/// Bounded executor used for offline-message persistence.
+///
+/// These writes were previously dispatched with a raw `tokio::spawn`: one
+/// detached task per routed message per offline session, each owning a cloned
+/// payload. Under sustained load they accumulate faster than the storage
+/// backend drains them and the process is OOM-killed, even though
+/// `push_limit` bounds what is actually stored. A bounded queue caps the
+/// backlog instead.
+const OFFLINE_STORAGE_EXEC: (&str, usize, usize) = ("SESSION_STORAGE_OFFLINE_EXEC", 8, 10_000);
+
+/// Number of offline-message persistence tasks discarded because the bounded
+/// queue was full.
+static OFFLINE_SAVE_DROPPED: AtomicU64 = AtomicU64::new(0);
+
 struct OfflineMessageHandler {
+    scx: ServerContext,
     cfg: Arc<PluginConfig>,
     storage_db: StorageDb,
 }
 
 impl OfflineMessageHandler {
-    fn new(cfg: Arc<PluginConfig>, storage_db: StorageDb) -> Self {
-        Self { cfg, storage_db }
+    fn new(scx: ServerContext, cfg: Arc<PluginConfig>, storage_db: StorageDb) -> Self {
+        Self { scx, cfg, storage_db }
+    }
+
+    /// Dispatches a persistence task onto the bounded queue.
+    ///
+    /// When the queue is full the task is discarded and counted rather than
+    /// spawned, which keeps the backlog bounded. Discarding is consistent with
+    /// the existing `push_limit` behaviour, which already drops once a
+    /// session's offline queue reaches `max_mqueue_len`; the alternative --
+    /// awaiting the write inline -- would stall the routing path for every
+    /// client, including connected ones.
+    async fn dispatch<F>(&self, fut: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let exec = self.scx.get_exec(OFFLINE_STORAGE_EXEC);
+        if exec.try_spawn(fut).await.is_err() {
+            let dropped = OFFLINE_SAVE_DROPPED.fetch_add(1, Ordering::Relaxed) + 1;
+            if dropped % 1000 == 1 {
+                log::warn!(
+                    "offline message persistence queue is full, dropped {} save(s) in total, waiting_count: {}, active_count: {}",
+                    dropped,
+                    exec.waiting_count(),
+                    exec.active_count()
+                );
+            }
+        }
     }
 }
 
@@ -576,7 +626,7 @@ impl Handler for OfflineMessageHandler {
                 let max_mqueue_len = s.listen_cfg().max_mqueue_len;
                 let p = (*p).clone();
                 let f = f.clone();
-                tokio::spawn(async move {
+                self.dispatch(async move {
                     let offlines_list = storage_db.list(list_stored_key.as_ref(), None).await;
                     let res = offlines_list
                         .push_limit::<OfflineMessageOptionType>(
@@ -588,7 +638,8 @@ impl Handler for OfflineMessageHandler {
                     if let Err(e) = res {
                         log::warn!("{id:?} save offline messages error, {e}")
                     }
-                });
+                })
+                .await;
             }
 
             Parameter::OfflineInflightMessages(s, inflight_messages) => {
@@ -603,12 +654,13 @@ impl Handler for OfflineMessageHandler {
                 let storage_db = self.storage_db.clone();
                 let inflight_messages = inflight_messages.clone();
                 let id = s.id.clone();
-                tokio::spawn(async move {
+                self.dispatch(async move {
                     let m = storage_db.map(map_stored_key.as_ref(), None).await;
                     if let Err(e) = m.insert(INFLIGHT_MESSAGES, &inflight_messages).await {
                         log::warn!("{id:?} save offline inflight messages error, {e}")
                     }
-                });
+                })
+                .await;
             }
 
             _ => {


### PR DESCRIPTION
Fixes the unbounded memory growth reported in #495.

## The problem

Offline-message persistence in `rmqtt-session-storage` is dispatched with a raw `tokio::spawn` — one detached task per routed message per offline session, each owning a cloned payload:

```rust
let p = (*p).clone();
tokio::spawn(async move {
    let offlines_list = storage_db.list(list_stored_key.as_ref(), None).await;
    let res = offlines_list.push_limit::<OfflineMessageOptionType>(
        &Some((id.client_id.clone(), f, p)), max_mqueue_len, true,
    ).await;
    ...
});
```

There is no bound on those spawns, so when they are created faster than the storage backend drains them the pending futures accumulate on the heap and the process is OOM-killed.

`max_mqueue_len` does not help. `push_limit` bounds what is *stored*, but only once the task runs — it does not bound the backlog of tasks waiting to store it. That is why the visible queue metric looks healthy right up to the kill, and why no exposed counter moves.

Measurements are in #495; briefly, on a ~400 msg/s workload with session churn, live tokio tasks went from 93 to 231 372 in 21 s and the broker died at a 1 GiB limit after 48 s, with anonymous memory accounting for 99.9 % of the growth. Independent of backend (sled and redis identical) and of every expiry setting.

## The change

Route these writes through a bounded `TaskExecQueue` from the server context, as the plugin already does for `SESSION_REBUILD_EXEC`. `OfflineMessageHandler` gains a `ServerContext` and a `dispatch()` helper; both `tokio::spawn` sites in the handler (`OfflineMessage` and `OfflineInflightMessages`) go through it.

When the queue is full the task is discarded and counted, with a rate-limited warning carrying `waiting_count` / `active_count` so the condition is observable.

One file, +60/−8, no new dependencies.

**Note — this differs from what I offered in #495.** There I suggested awaiting the write inline when the queue is full. On reflection that is wrong: the hook runs on the routing path, so awaiting there would stall delivery for *every* client including connected ones — trading a memory bug for a broker-wide latency bug. Discarding also matches what `push_limit(..., max_mqueue_len, true)` already does once a session's offline queue is full, so it introduces no new semantics. Happy to switch to strict backpressure, or to make the bound configurable, if you would rather.

The queue bound is currently a hardcoded `10_000` (≈29 MB at the measured ~2.9 KiB per pending task) with 8 workers. Glad to move it into `PluginConfig` if you prefer it tunable.

## Validation

Same workload, same config, `0.24.0` built from `master` with this patch:

| | before | after |
| --- | --- | --- |
| live tokio tasks | 93 → **231 372** in 21 s | **83–84**, flat |
| anonymous memory | 125 → **4 084 MiB** | 105 → **236 MiB**, plateaus at t≈48 s |
| outcome at 1 GiB | **OOM-killed, 48 s** | **survives**, exit 0 |

After the change, growth in `memory.current` is reclaimable page cache tracking the sled data file (file 0 → 653 MiB against 654 MiB on disk, anon flat at ~230 MiB) — which is why it can touch the cgroup ceiling without being killed.

Offline persistence is unaffected at sustainable load — 50 `clean_session=false` sessions, 100 queued messages each, verified on reconnect:

```
"clients_complete": 50, "clients_empty": 0,
"expected_total": 5000, "missing_total": 0,
"duplicates_total": 0, "delivery_ratio": 1
```

`cargo fmt --all -- --check` clean; `cargo clippy -p rmqtt-session-storage --features sled --all-targets` reports no warnings.

## A separate observation

Under the heavy arm the queue saturates and the counter reached 1 811 001 discarded saves, with `waiting_count` pinned at 10 000 and sled absorbing roughly 5 MB/s. That workload asks for ~19 600 individual list-pushes per second, which is not reachable — the plugin performs one write per message per offline session with no batching. This patch converts that from an unrecoverable OOM into a survivable, counted, observable degradation, but batching offline writes per session would raise the ceiling a lot. Happy to look at that separately if it is of interest.

Unrelated: `CONTRIBUTING.md` lists `protoc` as the only native prerequisite, but `cargo build -p rmqttd` also needs `cmake` (for `rdkafka-sys`).
