### PR TITLE
docs(auth): clarify deny_if_error semantics and rmqtt-acl CONNECT fallthrough (#501)

### DIFF
--- a/docs/en_US/auth-http.md
+++ b/docs/en_US/auth-http.md
@@ -43,7 +43,10 @@ disconnect_if_pub_rejected = true
 ## Default: false
 disconnect_if_expiry = false
 
-##Return 'Deny' if http request error otherwise 'Ignore'
+## Return 'Deny' if the HTTP request itself fails (transport-layer errors:
+## connection refused, timeout, DNS or TLS failure), otherwise 'Ignore'.
+## Non-2xx status responses (404/500/502, ...) are not request errors; they
+## always yield 'Ignore' and the auth chain continues.
 ##
 ## Value: true | false
 ## Default: true
@@ -299,7 +302,9 @@ http_headers.Connection = "keep-alive"
 # If publishing a message is rejected, the connection will be disconnected.
 disconnect_if_pub_rejected = true
 
-# If the HTTP request encounters an error, return "deny"; otherwise, return "ignore".
+# If the HTTP request itself fails (connection refused, timeout, DNS/TLS error),
+# return "deny"; otherwise, return "ignore". Non-2xx status responses
+# (404/500/502, ...) are not request errors; they always yield "ignore".
 deny_if_error = true
 
 ```

--- a/docs/zh_CN/auth-http.md
+++ b/docs/zh_CN/auth-http.md
@@ -44,7 +44,9 @@ disconnect_if_pub_rejected = true
 ## Default: false
 disconnect_if_expiry = false
 
-##Return 'Deny' if http request error otherwise 'Ignore'
+## 仅当 HTTP 请求本身失败（传输层错误：连接拒绝、超时、DNS/TLS 失败）时返回 'Deny'，
+## 否则返回 'Ignore'。非 2xx 状态码响应（404/500/502 等）不属于请求错误，
+## 始终判定为 'Ignore' 并继续执行认证链。
 ##
 ## Value: true | false
 ## Default: true
@@ -111,6 +113,13 @@ http_acl_req.params = { access = "%A", username = "%u", clientid = "%c", ipaddr 
   - API HTTP 请求失败，且deny_if_error配置等于:false, 判定结果为:ignore, 继续执行认证链。
 - 超级用户：
   - 认证成功 且 响应头返回“X-Superuser: true”, 超级用户将跳过ACL授权。
+
+> **警告**<br>
+> 判定为 'ignore' 时，最终结果由认证链中其余插件决定。内置 rmqtt-acl 插件默认规则以
+> ["allow", "all"] 结尾，其省略的动作列表示**包含 CONNECT 在内的所有操作**，因此被判定为
+> 'ignore' 的连接会被该规则显式放行（即使 `allow_anonymous = false`）。启用自定义认证插件
+> （rmqtt-auth-http、rmqtt-auth-jwt 等）时，请将 rmqtt-acl.toml 中的 ["allow", "all"]
+> 注释掉并启用 ["deny", "all"]，以获得 fail-closed（失败即拒绝）行为。详见 docs/zh_CN/acl.md。
   
 响应示例：
 ```

--- a/rmqtt-plugins/rmqtt-acl.toml
+++ b/rmqtt-plugins/rmqtt-acl.toml
@@ -12,6 +12,21 @@ rules = [
     ["allow", { user = "dashboard" }, "subscribe", ["$SYS/#"]],
     ["allow", { ipaddr = "127.0.0.1" }, "pubsub", ["$SYS/#", "#"]],
     ["deny", "all", "subscribe", ["$SYS/#", { eq = "#" }]],
+    ## The rule below OMITS the action column, which resolves to ALL operations,
+    ## INCLUDING CONNECT. This plugin also hooks ClientAuthenticate: with this
+    ## rule every connection is explicitly allowed, unless an earlier auth
+    ## plugin already returned 'deny'.
+    ##
+    ## IMPORTANT: a connection that a custom auth plugin (rmqtt-auth-http,
+    ## rmqtt-auth-jwt, ...) decided to 'ignore' — for example the auth service
+    ## returned a non-2xx status (404/500/502) — is allowed by this rule too,
+    ## EVEN when allow_anonymous = false.
+    ##
+    ## If you enable a custom auth plugin, comment out ["allow", "all"] and
+    ## enable ["deny", "all"] instead (fail-closed): only clients explicitly
+    ## allowed by the auth plugin can connect, and publish/subscribe must be
+    ## authorized by the auth plugin's ACL data or the allow rules above.
+    ## See docs/en_US/acl.md for details.
     ["allow", "all"]
     #["deny", "all"]
 ]

--- a/rmqtt-plugins/rmqtt-acl/README-CN.md
+++ b/rmqtt-plugins/rmqtt-acl/README-CN.md
@@ -4,11 +4,13 @@
 
 [![crates.io](https://img.shields.io/crates/v/rmqtt-acl.svg)](https://crates.io/crates/rmqtt-acl)
 
-基于文件的访问控制列表（ACL）插件。通过 allow/deny 规则控制客户端发布和订阅权限，支持按用户名、IP 地址、客户端 ID 和主题过滤。
+基于文件的访问控制列表（ACL）插件。通过 allow/deny 规则控制客户端的连接、发布和订阅权限，支持按用户名、IP 地址、客户端 ID 和主题过滤。
 
 ## 概述
 
 `rmqtt-acl` 实现了一个基于规则的 ACL 引擎。规则按顺序评估，第一条匹配的规则决定结果。如果没有规则匹配，默认拒绝访问。插件注册了 5 个 Hook 回调，覆盖认证、ACL 检查和客户端生命周期事件。
+
+**注意**：本插件同时挂载了 `ClientAuthenticate`（连接认证阶段）。默认规则集以 `["allow", "all"]` 结尾，其省略的动作列表示**包含 CONNECT 在内的所有操作**——启用自定义认证插件前，请先阅读[与认证插件的交互](#与认证插件的交互)。
 
 ## 使用方法
 
@@ -78,8 +80,25 @@ rules = [
 | `"subscribe"` | 仅订阅 |
 | `"publish"` | 仅发布 |
 | `"pubsub"` | 订阅和发布 |
+| `"connect"` | 仅连接（认证阶段） |
+| `"all"` —— 或**省略该列** | 所有操作，**包括 CONNECT** |
 
 **`<主题列表>`**：主题过滤器列表。支持 `{ eq = "exact/topic" }` 进行精确匹配。
+
+### 与认证插件的交互
+
+本插件同时挂载了 `ClientAuthenticate`。连接阶段的规则评估逻辑：
+
+- 命中 `allow` 规则 → 连接被**显式放行**（认证 hook 链终止）。
+- 命中 `deny` 规则 → 连接被拒绝。
+- 无规则命中 → 连接被拒绝（`NotAuthorized`）。
+
+默认规则末条 `["allow", "all"]` 省略了动作列，表示**包含 CONNECT 在内的所有操作**。由此带来以下行为：
+
+- 除非更早执行的认证插件返回 `deny`，所有连接都会被本插件放行。
+- 被自定义认证插件（rmqtt-auth-http、rmqtt-auth-jwt 等）判定为 **`ignore`** 的连接——例如认证服务返回非 2xx 状态码（404/500/502）——同样会被该规则放行，**即使 `allow_anonymous = false`**。
+
+> **加固建议**：启用自定义认证插件时，请将 `rmqtt-acl.toml` 中的 `["allow", "all"]` 注释掉并启用 `["deny", "all"]`。此时本插件成为兜底的 deny-all（fail-closed）：只有被认证插件显式放行的客户端才能连接，发布/订阅必须由认证插件返回的 ACL 数据或上方的显式 allow 规则授权。
 
 ### 配置选项
 
@@ -102,7 +121,7 @@ rules = [
 |-----------|------|
 | `ClientConnected` | 客户端连接后预计算主题占位符（`%c`=client_id, `%u`=username）和 ACL 规则 |
 | `ClientDisconnected` | 清理客户端缓存的 topic filter |
-| `ClientAuthenticate` | 根据 ACL 规则验证用户名/密码 |
+| `ClientAuthenticate` | 对连接评估 ACL 规则：命中 `allow` 规则则放行，命中 `deny` 规则则拒绝，无规则命中则拒绝（`NotAuthorized`）。在更高优先级的认证插件之后执行（如 rmqtt-auth-http 默认 priority=100，本插件默认 10） |
 | `ClientSubscribeCheckAcl` | 订阅时检查 ACL，返回 `SubscribeAclResult` |
 | `MessagePublishCheckAcl` | 发布时检查 ACL，返回 `PublishAclResult` |
 

--- a/rmqtt-plugins/rmqtt-acl/README.md
+++ b/rmqtt-plugins/rmqtt-acl/README.md
@@ -4,11 +4,13 @@
 
 [![crates.io](https://img.shields.io/crates/v/rmqtt-acl.svg)](https://crates.io/crates/rmqtt-acl)
 
-File-based Access Control List plugin. Evaluates allow/deny rules to control client publish and subscribe access by user, IP address, client ID, and topic filter patterns.
+File-based Access Control List plugin. Evaluates allow/deny rules to control client connect, publish, and subscribe access by user, IP address, client ID, and topic filter patterns.
 
 ## Overview
 
 Rules are evaluated in order — the first matching rule determines the result. If no rule matches, access is denied by default. The plugin registers 5 hook callbacks covering authentication, ACL checks, and client lifecycle events.
+
+**Note**: this plugin also hooks `ClientAuthenticate` (connection phase). The default rule set ends with `["allow", "all"]`, whose omitted action column resolves to ALL operations **including connect** — see [Interaction with Authentication Plugins](#interaction-with-authentication-plugins) before enabling a custom auth plugin.
 
 ## Usage
 
@@ -98,7 +100,7 @@ The plugin loads config via `scx.plugins.load_config_default::<PluginConfig>("rm
 |-----------|---------|
 | `ClientConnected` | Pre-compute topic placeholders (`%c`, `%u`) and ACL rules per client |
 | `ClientDisconnected` | Clean up per-client cached topic filters |
-| `ClientAuthenticate` | Verify username/password against ACL rules |
+| `ClientAuthenticate` | Evaluate ACL rules for the connection: a matching `allow` rule allows it, a matching `deny` rule rejects it, and no matching rule denies it (`NotAuthorized`). Runs after auth plugins with higher hook priority (e.g. rmqtt-auth-http default priority = 100 vs this plugin's default 10) |
 | `ClientSubscribeCheckAcl` | Check subscribe ACL, return `SubscribeAclResult` |
 | `MessagePublishCheckAcl` | Check publish ACL, return `PublishAclResult` |
 

--- a/rmqtt-plugins/rmqtt-acl/src/config.rs
+++ b/rmqtt-plugins/rmqtt-acl/src/config.rs
@@ -65,7 +65,17 @@ impl PluginConfig {
                 ["allow", { user = "dashboard" }, "subscribe", ["$SYS/#"]],
                 ["allow", { ipaddr = "127.0.0.1" }, "pubsub", ["$SYS/#", "#"]],
                 ["deny", "all", "subscribe", ["$SYS/#", { eq = "#" }]],
+                # The rule below OMITS the action column, which resolves to ALL
+                # operations, INCLUDING CONNECT. This plugin also hooks
+                # ClientAuthenticate: with this rule every connection is
+                # explicitly allowed, unless an earlier auth plugin already
+                # returned 'deny'. A connection that a custom auth plugin
+                # (rmqtt-auth-http, rmqtt-auth-jwt, ...) decided to 'ignore' is
+                # allowed here too, EVEN when allow_anonymous = false. If you
+                # enable a custom auth plugin, comment out ["allow", "all"] and
+                # enable ["deny", "all"] for fail-closed behavior.
                 ["allow", "all"]
+                #["deny", "all"]
         ]"###;
 
         let josn_rules = match toml::from_str::<serde_json::Value>(rules) {

--- a/rmqtt-plugins/rmqtt-auth-http.toml
+++ b/rmqtt-plugins/rmqtt-auth-http.toml
@@ -22,7 +22,20 @@ disconnect_if_pub_rejected = true
 ## Default: false
 disconnect_if_expiry = false
 
-## Return 'Deny' if http request error otherwise 'Ignore'
+## Return 'Deny' if the HTTP request itself fails (transport-layer errors such
+## as connection refused, timeout, DNS or TLS failure), otherwise 'Ignore'.
+##
+## NOTE: This only covers request-level failures. If the auth service responds
+## with a non-2xx status code (404/500/502, ...), the request succeeded but no
+## auth decision was returned; the result is always 'Ignore' and the auth chain
+## continues, regardless of this option.
+##
+## WARNING: An 'Ignore' result leaves the decision to the remaining plugins.
+## The built-in rmqtt-acl plugin ships a default ["allow", "all"] rule whose
+## omitted action column resolves to ALL operations including CONNECT, so such
+## connections are explicitly allowed (even with allow_anonymous = false).
+## If you enable a custom auth plugin, comment out ["allow", "all"] and enable
+## ["deny", "all"] in rmqtt-acl.toml for fail-closed behavior.
 ##
 ## Value: true | false
 ## Default: true

--- a/rmqtt-plugins/rmqtt-auth-http/README-CN.md
+++ b/rmqtt-plugins/rmqtt-auth-http/README-CN.md
@@ -10,7 +10,7 @@ RMQTT 的 HTTP 认证/授权插件。将客户端认证和 ACL 检查委托给�
 
 向可配置的 HTTP 端点发送请求（POST/GET/PUT），携带客户端凭证。HTTP 响应决定客户端是否允许连接、发布或订阅。支持在请求参数中使用变量替换。
 
-- **认证**：客户端连接时，插件向 `http_auth_req.url` 发送 HTTP 请求，携带客户端凭证。2xx 响应允许连接，其他响应拒绝连接。
+- **认证**：客户端连接时，插件向 `http_auth_req.url` 发送 HTTP 请求，携带客户端凭证。**2xx 响应体**决定结果：`allow`、`deny` 或 `ignore`（纯文本），或含 `result` 字段的 JSON 文档。**非 2xx** 状态码（404/500/502 等）判定为 `ignore`——继续执行认证链。若 HTTP 请求本身失败（连接拒绝、超时、DNS/TLS 错误），`deny_if_error = true` 将其转为 `deny`。
 - **ACL 检查**：客户端发布或订阅时，插件向 `http_acl_req.url` 发送 HTTP 请求，携带访问详情。响应决定操作是否允许。
 
 ## 使用
@@ -40,7 +40,7 @@ rmqtt_auth_http::register(&scx, true, false).await?;
 | `http_headers.Connection` | String | `"keep-alive"` | Connection 请求头 |
 | `disconnect_if_pub_rejected` | Boolean | `true` | 发布被拒绝时是否断开客户端 |
 | `disconnect_if_expiry` | Boolean | `false` | 过期后是否断开客户端 |
-| `deny_if_error` | Boolean | `true` | HTTP 错误时返回"拒绝"；设为 `false` 则返回"忽略" |
+| `deny_if_error` | Boolean | `true` | 仅当 HTTP 请求本身失败（传输层错误：连接拒绝、超时、DNS/TLS 失败）时返回"拒绝"；非 2xx 状态码响应（404/500/502 等）始终判定为"忽略"。设为 `false` 时传输层错误也返回"忽略" |
 | `http_auth_req.url` | String | `"http://127.0.0.1:9090/mqtt/auth"` | 认证请求 URL |
 | `http_auth_req.method` | String | `"post"` | HTTP 方法：`post`、`get` 或 `put` |
 | `http_auth_req.headers` | Table | `{ content-type = "application/x-www-form-urlencoded" }` | 请求头（支持 `application/json`） |
@@ -76,16 +76,20 @@ rmqtt_auth_http::register(&scx, true, false).await?;
 
 1. 客户端携带凭证连接
 2. 插件向 `http_auth_req.url` 发送 HTTP 请求，携带 `http_auth_req.params` 和 `http_auth_req.headers`
-3. HTTP 响应为 2xx → 认证成功；否则 → 认证失败
-4. 认证失败：拒绝客户端连接
-5. 请求出错时，若 `deny_if_error = true`：拒绝客户端连接；若 `deny_if_error = false`：忽略认证结果（客户端使用默认认证规则）
+3. **2xx 响应**：由响应体决定——`allow`（允许连接）、`deny`（拒绝连接）或 `ignore`（继续执行认证链）。JSON 响应由 `result` 字段决定
+4. **非 2xx 响应**（404/500/502 等）：判定为 `ignore`，继续执行认证链，**与 `deny_if_error` 无关**
+5. **请求级失败**（连接拒绝、超时、DNS/TLS 错误）：`deny_if_error = true` 拒绝连接；`deny_if_error = false` 判定为 `ignore`（继续执行认证链）
+
+> **警告**：判定为 `ignore` 时，最终结果由认证链中其余插件决定。内置 rmqtt-acl 插件默认规则以 `["allow", "all"]` 结尾，其省略的动作列表示**包含 CONNECT 在内的所有操作**，因此这类连接会被该规则显式放行——即使 `allow_anonymous = false`。启用自定义认证插件时，请将 `rmqtt-acl.toml` 中的 `["allow", "all"]` 注释掉并启用 `["deny", "all"]`，以获得 fail-closed（失败即拒绝）行为（参见 rmqtt-acl README）。
 
 ### ACL 流程
 
 1. 客户端尝试发布或订阅
 2. 插件向 `http_acl_req.url` 发送 HTTP 请求，携带 `http_acl_req.params`
-3. HTTP 响应为 2xx → 操作允许；否则 → 操作拒绝
-4. 若 `disconnect_if_pub_rejected = true`，被拒绝的发布操作将导致客户端断开
+3. **2xx 响应**：由响应体决定——`allow`、`deny` 或 `ignore`（继续执行 ACL 链）。JSON 响应由 `result` 字段决定
+4. **非 2xx 响应**：判定为 `ignore`，继续执行 ACL 链，与 `deny_if_error` 无关
+5. **请求级失败**：`deny_if_error = true` 拒绝操作；`deny_if_error = false` 判定为 `ignore`
+6. 若 `disconnect_if_pub_rejected = true`，被拒绝的发布操作将导致客户端断开
 
 ## 配置示例
 

--- a/rmqtt-plugins/rmqtt-auth-http/README.md
+++ b/rmqtt-plugins/rmqtt-auth-http/README.md
@@ -10,7 +10,7 @@ HTTP authentication plugin for RMQTT. Delegates client authentication and ACL ch
 
 Sends HTTP requests (POST/GET/PUT) to configurable endpoints with client credentials. The HTTP response determines whether the client is allowed to connect, publish, or subscribe. Supports variable substitution in request parameters.
 
-- **Authentication**: When a client connects, the plugin sends an HTTP request to `http_auth_req.url` with the client's credentials. A successful response (2xx) allows the connection; any other response denies it.
+- **Authentication**: When a client connects, the plugin sends an HTTP request to `http_auth_req.url` with the client's credentials. The **2xx response body** decides the result: `allow`, `deny`, or `ignore` (plain text), or a JSON document with a `result` field. A **non-2xx** status code (404/500/502, ...) is treated as `ignore` — the auth chain continues. If the request itself fails (connection refused, timeout, DNS/TLS error), `deny_if_error = true` turns it into a `deny`.
 - **ACL check**: When a client publishes or subscribes, the plugin sends an HTTP request to `http_acl_req.url` with the access details. The response determines whether the operation is allowed.
 
 ## Usage
@@ -40,7 +40,7 @@ File: `rmqtt-auth-http.toml`
 | `http_headers.Connection` | String | `"keep-alive"` | Connection header |
 | `disconnect_if_pub_rejected` | Boolean | `true` | Disconnect client if publish is rejected |
 | `disconnect_if_expiry` | Boolean | `false` | Disconnect client after expiry |
-| `deny_if_error` | Boolean | `true` | Return 'Deny' on HTTP error; if false, return 'Ignore' |
+| `deny_if_error` | Boolean | `true` | Return 'Deny' when the HTTP request itself fails (transport-layer errors: connection refused, timeout, DNS/TLS failure). Non-2xx status responses (404/500/502, ...) always yield 'Ignore'. If `false`, transport errors also yield 'Ignore' |
 | `http_auth_req.url` | String | `"http://127.0.0.1:9090/mqtt/auth"` | Authentication request URL |
 | `http_auth_req.method` | String | `"post"` | HTTP method: `post`, `get`, or `put` |
 | `http_auth_req.headers` | Table | `{ content-type = "application/x-www-form-urlencoded" }` | Request headers (supports `application/json`) |
@@ -76,16 +76,20 @@ For `http_acl_req.params`:
 
 1. Client connects with credentials
 2. Plugin sends HTTP request to `http_auth_req.url` with `http_auth_req.params` and `http_auth_req.headers`
-3. If HTTP response is 2xx → authentication success; otherwise → authentication failure
-4. On failure: client is denied connection
-5. On error with `deny_if_error = true`: client is denied connection; with `deny_if_error = false`: the auth result is ignored (client proceeds with default auth rules)
+3. **2xx response**: the body decides — `allow` (connection accepted), `deny` (connection rejected), or `ignore` (the auth chain continues). For JSON responses the `result` field decides
+4. **Non-2xx response** (404/500/502, ...): treated as `ignore`; the auth chain continues, **regardless of `deny_if_error`**
+5. **Request-level failure** (connection refused, timeout, DNS/TLS error): `deny_if_error = true` denies the connection; `deny_if_error = false` yields `ignore` (the auth chain continues)
+
+> **Warning**: an `ignore` result leaves the final decision to the remaining plugins in the auth chain. The built-in rmqtt-acl plugin ships a default `["allow", "all"]` rule whose omitted action column resolves to **all operations including CONNECT**, so such connections are explicitly allowed by that rule — even with `allow_anonymous = false`. When enabling a custom auth plugin, comment out `["allow", "all"]` and enable `["deny", "all"]` in `rmqtt-acl.toml` for fail-closed behavior (see the rmqtt-acl README).
 
 ### ACL Flow
 
 1. Client attempts to publish or subscribe
 2. Plugin sends HTTP request to `http_acl_req.url` with `http_acl_req.params`
-3. If HTTP response is 2xx → operation allowed; otherwise → operation denied
-4. If `disconnect_if_pub_rejected = true`, a denied publish causes client disconnection
+3. **2xx response**: the body decides — `allow`, `deny`, or `ignore` (the ACL chain continues). For JSON responses the `result` field decides
+4. **Non-2xx response**: treated as `ignore`; the ACL chain continues, regardless of `deny_if_error`
+5. **Request-level failure**: `deny_if_error = true` denies the operation; `deny_if_error = false` yields `ignore`
+6. If `disconnect_if_pub_rejected = true`, a denied publish causes client disconnection
 
 ## Example Configuration
 

--- a/rmqtt-plugins/rmqtt-auth-http/src/config.rs
+++ b/rmqtt-plugins/rmqtt-auth-http/src/config.rs
@@ -33,7 +33,14 @@ pub struct PluginConfig {
     #[serde(default = "PluginConfig::priority_default")]
     pub priority: Priority,
 
-    ///#Return 'Deny' if http request error otherwise 'Ignore'
+    /// Return 'Deny' if the HTTP request itself fails (transport-layer errors:
+    /// connection refused, timeout, DNS/TLS failure), otherwise 'Ignore'.
+    ///
+    /// Non-2xx HTTP status responses (404/500/502, ...) are NOT treated as
+    /// request errors: they always yield 'Ignore' and the auth chain continues,
+    /// regardless of this option. Note that an 'Ignore' result may still end up
+    /// allowed by later plugins — the default rmqtt-acl rules end with
+    /// ["allow", "all"], whose omitted action column covers CONNECT.
     #[serde(default = "PluginConfig::deny_if_error_default")]
     pub deny_if_error: bool,
 

--- a/rmqtt-test/README-CN.md
+++ b/rmqtt-test/README-CN.md
@@ -104,6 +104,8 @@ configs/
   cluster-broadcast-sled-stress/  # 同上，独立 sled 路径（压测专用）
   cluster-raft-sled/        # 三节点 raft 集群（1888/1889/1890 MQTT、6008-6010 raft）
   cluster-raft-sled-stress/ # 同上，独立 sled 路径（压测专用）
+  auth-http-acl-fallthrough/ # issue #501：auth-http 404-ignore × rmqtt-acl 末条规则
+                             #（自管 broker 1896 allow-all / 1900 deny-all，mock 用临时端口）
 ```
 
 **按用例自动切换配置**：用例可通过 `TestCase::broker_config()` 声明所需配置
@@ -137,7 +139,7 @@ configs/
 
 > v3.1 客户端通过 `build_connect_bytes` 手工构造 MQIsdp CONNECT 报文（codec 将协议级别硬编码为 4，对 3.1.1/5.0 正确）。
 
-### functional_v311（108 个用例）— MQTT 3.1.1
+### functional_v311（110 个用例）— MQTT 3.1.1
 
 | 类别 | 用例 |
 |------|------|
@@ -154,6 +156,7 @@ configs/
 | 多主题 | `multi_topic_subscribe_v311` / `overlapping_subscriptions` / `message_ordering` |
 | 协议错误 | `invalid_protocol_version` / `protocol_error_v311_*`（订阅/取消订阅：QoS3、QoS0 固定头、空 payload/filter、packet id 0；发布：QoS3、pid0、空主题、QoS0 携带 packet id；剩余长度非法、声明长度不匹配、报文截断、保留 packet type、packet type 15、PUBREL/PUBREC/PUBCOMP 错误 flags、未请求的 PUBREL、CONNECT payload 顺序、非法 UTF-8 主题）/ `remaining_length_transition_v311` |
 | CONNACK 返回码（自管 broker） | `connack_return_codes_auth_http_v311`（auth-http + 用例内 mock，端口 1892）/ `connack_not_authorized_v311`（auth-jwt，端口 1893）——这两个用例自行拉起 broker，不使用 harness broker |
+| issue #501 认证 × ACL 穿透（自管 broker） | `auth_http_ignore_allow_all_acl_v311`（auth 服务返回 404 → 判定 'ignore'；acl `["allow", "all"]` 将其放行 → CONNACK 0x00 fail-open 复现，端口 1896）/ `auth_http_ignore_deny_all_acl_v311`（acl `["deny", "all"]` 兜底 → CONNACK 0x05 fail-closed，端口 1900） |
 
 ### functional_v5（99 个用例）— MQTT 5.0
 
@@ -294,6 +297,9 @@ rmqtt-test/
     cluster-broadcast-sled-stress/ # 同上，独立 sled 路径（压测专用）
     cluster-raft-sled/           #   三节点 raft 集群（1888/1889/1890 MQTT、5368-5370 gRPC、6008-6010 raft）
     cluster-raft-sled-stress/    #   同上，独立 sled 路径（压测专用）
+    auth-http-acl-fallthrough/   #   issue #501 复现：auth-http（临时端口 mock，恒回 404）+
+                                 #   rmqtt-acl；自管 broker 1896/5376（allow-all）与
+                                 #   1900/5377（deny-all）
 ```
 
 > **测试隔离说明**：所有发布保留消息的测试结束后会自行删除（空 payload + RETAIN=1）；

--- a/rmqtt-test/README.md
+++ b/rmqtt-test/README.md
@@ -109,6 +109,8 @@ configs/
   cluster-broadcast-sled-stress/  # same, isolated sled path (stress test only)
   cluster-raft-sled/        # three-node raft cluster (1888/1889/1890 MQTT, 6008-6010 raft)
   cluster-raft-sled-stress/ # same, isolated sled path (stress test only)
+  auth-http-acl-fallthrough/ # issue #501: auth-http 404-ignore × rmqtt-acl final rule
+                             # (self-managed 1896 allow-all / 1900 deny-all, ephemeral mock)
 ```
 
 **Per-test config switching**: a test case can declare its required config via
@@ -146,7 +148,7 @@ and boundary scenarios:
 > The v3.1 client hand-builds the MQIsdp CONNECT bytes (`build_connect_bytes`)
 > because the codec hard-codes protocol level 4 (correct for 3.1.1/5.0).
 
-### `functional_v311` (108 cases) — MQTT 3.1.1
+### `functional_v311` (110 cases) — MQTT 3.1.1
 
 | Category | Cases |
 |----------|-------|
@@ -163,6 +165,7 @@ and boundary scenarios:
 | Multi-topic | `multi_topic_subscribe_v311` / `overlapping_subscriptions` / `message_ordering` |
 | Protocol errors | `invalid_protocol_version` / `protocol_error_v311_*` (subscribe/unsubscribe: qos3, qos0 fixed header, empty payload/filter, packet id 0; publish: qos3, pid0, empty topic, packet id on QoS0; bad remaining length, declared length mismatch, truncated packet, reserved packet type, packet type 15, pubrel/pubrec/pubcomp wrong flags, unsolicited pubrel, connect payload order, invalid UTF-8 topic) / `remaining_length_transition_v311` |
 | CONNACK return codes (self-managed brokers) | `connack_return_codes_auth_http_v311` (auth-http + in-test mock, port 1892) / `connack_not_authorized_v311` (auth-jwt, port 1893) — these cases spawn their own brokers and don't use the harness broker |
+| Issue #501 auth × ACL fallthrough (self-managed brokers) | `auth_http_ignore_allow_all_acl_v311` (auth service replies 404 → auth 'ignore'; acl `["allow", "all"]` promotes it → CONNACK 0x00 fail-open reproduction, port 1896) / `auth_http_ignore_deny_all_acl_v311` (acl `["deny", "all"]` backstop → CONNACK 0x05 fail-closed, port 1900) |
 
 ### `functional_v5` (99 cases) — MQTT 5.0
 
@@ -311,6 +314,9 @@ rmqtt-test/
     cluster-broadcast-sled-stress/ #  same, isolated sled path for the stress test
     cluster-raft-sled/           #   3-node raft cluster (1888/1889/1890 MQTT, 5368-5370 gRPC, 6008-6010 raft)
     cluster-raft-sled-stress/    #   same, isolated sled path for the stress test
+    auth-http-acl-fallthrough/   #   issue #501 repro: auth-http (ephemeral mock, always 404) +
+                                 #   rmqtt-acl; self-managed brokers on 1896/5376 (allow-all)
+                                 #   and 1900/5377 (deny-all)
 ```
 
 > **Test isolation note**: all tests that publish retained messages delete them

--- a/rmqtt-test/src/main.rs
+++ b/rmqtt-test/src/main.rs
@@ -376,6 +376,7 @@ fn build_functional_v3_suite() -> TestSuite {
 }
 
 fn build_functional_v311_suite() -> TestSuite {
+    use tests::functional::auth_http_acl_fallthrough_v311::*;
     use tests::functional::auth_v311::*;
     use tests::functional::boundary::*;
     use tests::functional::connack_return_codes_v311::*;
@@ -516,6 +517,12 @@ fn build_functional_v311_suite() -> TestSuite {
     // sub-suites by broker_config())
     suite.add(ConnackReturnCodesAuthHttpV311Test);
     suite.add(ConnackNotAuthorizedV311Test);
+    // Issue #501: the fate of connections a custom auth plugin leaves as
+    // 'ignore' (non-2xx auth response) is decided by the rmqtt-acl FINAL
+    // rule — self-managed brokers on 1896 (allow-all → CONNACK 0x00
+    // fail-open reproduction) / 1900 (deny-all → CONNACK 0x05 fail-closed).
+    suite.add(AuthHttpIgnoreAllowAllAclV311Test);
+    suite.add(AuthHttpIgnoreDenyAllAclV311Test);
     // G14 concurrent session takeover
     suite.add(SessionV311TakeoverTest);
     // G15 empty topic levels

--- a/rmqtt-test/src/tests/functional/connack_return_codes_v311.rs
+++ b/rmqtt-test/src/tests/functional/connack_return_codes_v311.rs
@@ -38,7 +38,7 @@ const AUTH_NODE_START_TIMEOUT: Duration = Duration::from_secs(20);
 /// built-in defaults — http-api on 6060, gRPC on 5363, MQTT on 1883 — which
 /// then collides with the harness broker (WSAEADDRINUSE 10048) and the
 /// intended auth config never takes effect.
-fn spawn_auth_broker_with_config(
+pub(crate) fn spawn_auth_broker_with_config(
     config: PathBuf,
     label: &str,
     addr: &str,
@@ -80,7 +80,7 @@ fn spawn_auth_broker_with_config(
 }
 
 /// Recursively copy a directory tree.
-fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+pub(crate) fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
@@ -151,7 +151,7 @@ fn prepare_jwt_config() -> anyhow::Result<PathBuf> {
 /// Build a raw v3.1.1 CONNECT with optional username / password.
 /// Connect flags: clean session (0x02) | user name flag (0x80) |
 /// password flag (0x40), as passed by the caller.
-fn build_connect(
+pub(crate) fn build_connect(
     connect_flags: u8,
     client_id: &str,
     username: Option<&str>,
@@ -196,7 +196,7 @@ fn build_connect(
 
 /// Send a raw CONNECT and return the CONNACK return code, or `None` when the
 /// broker closed the connection without a CONNACK.
-fn connect_return_code(broker_addr: &str, packet: &[u8]) -> anyhow::Result<Option<u8>> {
+pub(crate) fn connect_return_code(broker_addr: &str, packet: &[u8]) -> anyhow::Result<Option<u8>> {
     let mut stream = TcpStream::connect(broker_addr)?;
     stream.set_read_timeout(Some(Duration::from_secs(5)))?;
     stream.write_all(packet)?;

--- a/rmqtt-test/src/tests/functional/mod.rs
+++ b/rmqtt-test/src/tests/functional/mod.rs
@@ -1,6 +1,7 @@
 //! Functional tests module
 
 pub mod assigned_clientid_v5;
+pub mod auth_http_acl_fallthrough_v311;
 pub mod auth_v311;
 pub mod boundary;
 pub mod boundary_v3;

--- a/rmqtt.toml
+++ b/rmqtt.toml
@@ -67,6 +67,14 @@ log.file = "rmqtt.log"
 #Plug in configuration file directory
 plugins.dir = "rmqtt-plugins/"
 #Plug in started by default, when the mqtt server is started
+#NOTE: rmqtt-acl (built-in, always enabled unless listed in
+#plugins.disabled_default_startups) ships a default ["allow", "all"] rule whose
+#omitted action column resolves to ALL operations including CONNECT. Connections
+#that custom auth plugins (rmqtt-auth-http, rmqtt-auth-jwt, ...) decided to
+#'ignore' are explicitly allowed by that rule, even with allow_anonymous = false.
+#When enabling a custom auth plugin, adjust the rmqtt-acl rules: comment out
+#["allow", "all"] and enable ["deny", "all"] for fail-closed behavior.
+#See rmqtt-plugins/rmqtt-acl.toml and docs/en_US/acl.md.
 plugins.default_startups = [
     #"rmqtt-plugin-template",
     "rmqtt-retainer",


### PR DESCRIPTION
Issue #501 reported a fail-open when the HTTP auth service replies with a non-2xx status. The behavior is by design and documented, but the config comments were ambiguous and the plugin READMEs described it backwards, so make the semantics explicit everywhere:

- rmqtt-auth-http: deny_if_error covers transport-layer failures only (connection refused, timeout, DNS/TLS). Non-2xx auth responses (404/500/502, ...) are NOT request errors: the plugin always yields 'ignore' and the auth chain continues. Fix the reversed auth/ACL flow descriptions in both READMEs, extend the deny_if_error comment in rmqtt-auth-http.toml and config.rs, and add a warning about the rmqtt-acl interaction (docs/en_US + docs/zh_CN auth-http.md included).

- rmqtt-acl: the final default rule ["allow", "all"] omits the action column, which resolves to ALL operations INCLUDING CONNECT, and the plugin also hooks ClientAuthenticate — so a connection an auth plugin leaves as 'ignore' is explicitly allowed even with allow_anonymous = false. Spell out the fail-closed hardening (comment out ["allow", "all"], enable ["deny", "all"]) in rmqtt-acl.toml, the embedded default rules, and a new "Interaction with authentication plugins" section in both READMEs.

- rmqtt.toml: note the same interaction next to plugins.default_startups.

No behavior change.